### PR TITLE
Handle wallet redirect server side

### DIFF
--- a/internal/apigw/httpserver/endpoints.go
+++ b/internal/apigw/httpserver/endpoints.go
@@ -90,6 +90,11 @@ func (s *Service) endpointLoginPIDUser(ctx context.Context, c *gin.Context) (any
 		return nil, err
 	}
 
+	session.Set("redirect_uri", reply.RedirectURL)
+	if err := session.Save(); err != nil {
+		return nil, err
+	}
+
 	return reply, nil
 }
 

--- a/internal/apigw/httpserver/endpoints_oauth.go
+++ b/internal/apigw/httpserver/endpoints_oauth.go
@@ -143,7 +143,7 @@ func (s *Service) endpointOAuthAuthorizationConsent(ctx context.Context, c *gin.
 func (s *Service) endpointOAuthWalletRedirect(ctx context.Context, c *gin.Context) (any, error) {
 	s.log.Debug("endpointWalletRedirect", "c.Request.URL", c.Request.URL.String(), "headers", c.Request.Header)
 
-	_, span := s.tracer.Start(ctx, "httpserver:endpointAuthorizationConsent")
+	_, span := s.tracer.Start(ctx, "httpserver:endpointWalletRedirect")
 	defer span.End()
 	session := sessions.Default(c)
 

--- a/internal/apigw/httpserver/endpoints_oauth.go
+++ b/internal/apigw/httpserver/endpoints_oauth.go
@@ -139,3 +139,24 @@ func (s *Service) endpointOAuthAuthorizationConsent(ctx context.Context, c *gin.
 
 	return nil, nil
 }
+
+func (s *Service) endpointOAuthWalletRedirect(ctx context.Context, c *gin.Context) (any, error) {
+	s.log.Debug("endpointWalletRedirect", "c.Request.URL", c.Request.URL.String(), "headers", c.Request.Header)
+
+	_, span := s.tracer.Start(ctx, "httpserver:endpointAuthorizationConsent")
+	defer span.End()
+	session := sessions.Default(c)
+
+	redirectURI, ok := session.Get("redirect_uri").(string)
+	if !ok {
+		err := errors.New("redirect_uri not found in session")
+		span.SetStatus(codes.Error, err.Error())
+		s.log.Error(err, "endpointWalletRedirect: redirect_uri not found in session")
+		return nil, err
+	}
+
+	c.Request.Method = "GET"
+	c.Redirect(http.StatusSeeOther, redirectURI)
+
+	return nil, nil
+}

--- a/internal/apigw/httpserver/endpoints_oauth.go
+++ b/internal/apigw/httpserver/endpoints_oauth.go
@@ -141,9 +141,9 @@ func (s *Service) endpointOAuthAuthorizationConsent(ctx context.Context, c *gin.
 }
 
 func (s *Service) endpointOAuthWalletRedirect(ctx context.Context, c *gin.Context) (any, error) {
-	s.log.Debug("endpointWalletRedirect", "c.Request.URL", c.Request.URL.String(), "headers", c.Request.Header)
+	s.log.Debug("endpointOAuthWalletRedirect", "c.Request.URL", c.Request.URL.String(), "headers", c.Request.Header)
 
-	_, span := s.tracer.Start(ctx, "httpserver:endpointWalletRedirect")
+	_, span := s.tracer.Start(ctx, "httpserver:endpointOAuthWalletRedirect")
 	defer span.End()
 	session := sessions.Default(c)
 
@@ -151,7 +151,7 @@ func (s *Service) endpointOAuthWalletRedirect(ctx context.Context, c *gin.Contex
 	if !ok {
 		err := errors.New("redirect_uri not found in session")
 		span.SetStatus(codes.Error, err.Error())
-		s.log.Error(err, "endpointWalletRedirect: redirect_uri not found in session")
+		s.log.Error(err, "endpointOAuthWalletRedirect: redirect_uri not found in session")
 		return nil, err
 	}
 

--- a/internal/apigw/httpserver/endpoints_oauth.go
+++ b/internal/apigw/httpserver/endpoints_oauth.go
@@ -155,7 +155,6 @@ func (s *Service) endpointOAuthWalletRedirect(ctx context.Context, c *gin.Contex
 		return nil, err
 	}
 
-	c.Request.Method = "GET"
 	c.Redirect(http.StatusSeeOther, redirectURI)
 
 	return nil, nil

--- a/internal/apigw/httpserver/service.go
+++ b/internal/apigw/httpserver/service.go
@@ -110,6 +110,7 @@ func New(ctx context.Context, cfg *model.Cfg, apiv1 *apiv1.Client, tracer *trace
 	s.httpHelpers.Server.RegEndpoint(ctx, rgOAuthSession, http.MethodPost, "op/par", http.StatusCreated, s.endpointOAuthPar)
 	s.httpHelpers.Server.RegEndpoint(ctx, rgOAuthSession, http.MethodGet, "authorize", http.StatusPermanentRedirect, s.endpointOAuthAuthorize)
 	s.httpHelpers.Server.RegEndpoint(ctx, rgOAuthSession, http.MethodGet, "authorization/consent", http.StatusNotModified, s.endpointOAuthAuthorizationConsent)
+	s.httpHelpers.Server.RegEndpoint(ctx, rgOAuthSession, http.MethodPost, "authorization/consent", http.StatusSeeOther, s.endpointOAuthWalletRedirect)
 	s.httpHelpers.Server.RegEndpoint(ctx, rgOAuthSession, http.MethodPost, "token", http.StatusOK, s.endpointOAuthToken)
 
 	s.httpHelpers.Server.RegEndpoint(ctx, rgRoot, http.MethodGet, "health", 200, s.endpointHealth)

--- a/internal/apigw/staticembed/consent.js
+++ b/internal/apigw/staticembed/consent.js
@@ -127,11 +127,6 @@ Alpine.data("app", () => ({
         }
     },
 
-    /** @param {SubmitEvent} event */
-    handleCredentialSelection(event) {
-        window.location.replace(this.grantResponse.redirect_url);
-    },
-
     /** @param {Event} event */
     handleLogout(event) {
         this.loggedIn = false;

--- a/internal/apigw/staticembed/index.html
+++ b/internal/apigw/staticembed/index.html
@@ -45,7 +45,7 @@
                     <div class="block">
                         <p>Select the credential you wish to retrieve by clicking on it:</p>
                     </div>
-                    <form x-ref="credentialSelectionForm" @submit.prevent="handleCredentialSelection">
+                    <form x-ref="credentialSelectionForm" method="POST">
                         <div class="field">
                             <template x-for="(credential, index) in credentials">
                                 <div class="block control is-flex is-align-items-flex-start is-gap-1 is-justify-content-space-between">


### PR DESCRIPTION
Handle the redirect back to the wallet on the server side instead of the client.