### PR TITLE
fix: rename dc4eu swagger tags to vc-platform

### DIFF
--- a/docs/apigw/docs.go
+++ b/docs/apigw/docs.go
@@ -25,7 +25,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "AddConsent",
                 "operationId": "add-consent",
@@ -63,7 +63,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "GetConsent",
                 "operationId": "get-consent",
@@ -104,7 +104,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "OIDCCredential",
                 "operationId": "create-credential",
@@ -145,7 +145,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "JWKS",
                 "operationId": "issuer-JWKS",
@@ -175,7 +175,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "GetDocument",
                 "operationId": "get-document",
@@ -214,7 +214,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "DeleteDocument",
                 "operationId": "delete-document",
@@ -252,7 +252,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "GetDocumentByCollectID",
                 "operationId": "get-document-collect-id",
@@ -293,7 +293,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "AddDocumentIdentity",
                 "operationId": "add-document-identity",
@@ -329,7 +329,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "DeleteDocumentIdentity",
                 "operationId": "delete-document-identity",
@@ -367,7 +367,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "DocumentList",
                 "operationId": "document-list",
@@ -408,7 +408,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "RevokeDocument",
                 "operationId": "revoke-document",
@@ -446,7 +446,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "IdentityMapping",
                 "operationId": "identity-mapping",
@@ -487,7 +487,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "Notification",
                 "operationId": "generic-notification",
@@ -528,7 +528,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "Revoke",
                 "operationId": "generic-revoke",
@@ -569,7 +569,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "Upload",
                 "operationId": "generic-upload",

--- a/docs/apigw/swagger.json
+++ b/docs/apigw/swagger.json
@@ -17,7 +17,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "AddConsent",
                 "operationId": "add-consent",
@@ -55,7 +55,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "GetConsent",
                 "operationId": "get-consent",
@@ -96,7 +96,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "OIDCCredential",
                 "operationId": "create-credential",
@@ -137,7 +137,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "JWKS",
                 "operationId": "issuer-JWKS",
@@ -167,7 +167,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "GetDocument",
                 "operationId": "get-document",
@@ -206,7 +206,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "DeleteDocument",
                 "operationId": "delete-document",
@@ -244,7 +244,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "GetDocumentByCollectID",
                 "operationId": "get-document-collect-id",
@@ -285,7 +285,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "AddDocumentIdentity",
                 "operationId": "add-document-identity",
@@ -321,7 +321,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "DeleteDocumentIdentity",
                 "operationId": "delete-document-identity",
@@ -359,7 +359,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "DocumentList",
                 "operationId": "document-list",
@@ -400,7 +400,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "RevokeDocument",
                 "operationId": "revoke-document",
@@ -438,7 +438,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "IdentityMapping",
                 "operationId": "identity-mapping",
@@ -479,7 +479,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "Notification",
                 "operationId": "generic-notification",
@@ -520,7 +520,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "Revoke",
                 "operationId": "generic-revoke",
@@ -561,7 +561,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "Upload",
                 "operationId": "generic-upload",

--- a/docs/apigw/swagger.yaml
+++ b/docs/apigw/swagger.yaml
@@ -824,7 +824,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: AddConsent
       tags:
-      - dc4eu
+      - vc-platform
   /consent/get:
     post:
       consumes:
@@ -851,7 +851,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: GetConsent
       tags:
-      - dc4eu
+      - vc-platform
   /credential:
     post:
       consumes:
@@ -878,7 +878,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: OIDCCredential
       tags:
-      - dc4eu
+      - vc-platform
   /credential/.well-known/jwks:
     get:
       consumes:
@@ -898,7 +898,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: JWKS
       tags:
-      - dc4eu
+      - vc-platform
   /document:
     delete:
       consumes:
@@ -923,7 +923,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: DeleteDocument
       tags:
-      - dc4eu
+      - vc-platform
     post:
       consumes:
       - application/json
@@ -949,7 +949,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: GetDocument
       tags:
-      - dc4eu
+      - vc-platform
   /document/collect_id:
     post:
       consumes:
@@ -976,7 +976,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: GetDocumentByCollectID
       tags:
-      - dc4eu
+      - vc-platform
   /document/identity:
     delete:
       consumes:
@@ -1001,7 +1001,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: DeleteDocumentIdentity
       tags:
-      - dc4eu
+      - vc-platform
     put:
       consumes:
       - application/json
@@ -1025,7 +1025,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: AddDocumentIdentity
       tags:
-      - dc4eu
+      - vc-platform
   /document/list:
     post:
       consumes:
@@ -1052,7 +1052,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: DocumentList
       tags:
-      - dc4eu
+      - vc-platform
   /document/revoke:
     post:
       consumes:
@@ -1077,7 +1077,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: RevokeDocument
       tags:
-      - dc4eu
+      - vc-platform
   /identity/mapping:
     post:
       consumes:
@@ -1104,7 +1104,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: IdentityMapping
       tags:
-      - dc4eu
+      - vc-platform
   /notification:
     post:
       consumes:
@@ -1131,7 +1131,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: Notification
       tags:
-      - dc4eu
+      - vc-platform
   /revoke:
     post:
       consumes:
@@ -1158,7 +1158,7 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: Revoke
       tags:
-      - dc4eu
+      - vc-platform
   /upload:
     post:
       consumes:
@@ -1183,5 +1183,5 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: Upload
       tags:
-      - dc4eu
+      - vc-platform
 swagger: "2.0"

--- a/docs/issuer/docs.go
+++ b/docs/issuer/docs.go
@@ -25,7 +25,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "Revoke",
                 "operationId": "generic-revoke",

--- a/docs/issuer/swagger.json
+++ b/docs/issuer/swagger.json
@@ -17,7 +17,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "dc4eu"
+                    "vc-platform"
                 ],
                 "summary": "Revoke",
                 "operationId": "generic-revoke",

--- a/docs/issuer/swagger.yaml
+++ b/docs/issuer/swagger.yaml
@@ -61,5 +61,5 @@ paths:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: Revoke
       tags:
-      - dc4eu
+      - vc-platform
 swagger: "2.0"

--- a/internal/apigw/apiv1/handlers_consent.go
+++ b/internal/apigw/apiv1/handlers_consent.go
@@ -20,7 +20,7 @@ type AddConsentRequest struct {
 //	@Summary		AddConsent
 //	@ID				add-consent
 //	@Description	Add consent endpoint
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	"Success"
@@ -55,7 +55,7 @@ type GetConsentRequest struct {
 //	@Summary		GetConsent
 //	@ID				get-consent
 //	@Description	Get consent endpoint
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	{object}	model.Consent			"Success"

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -18,7 +18,7 @@ import (
 //	@Summary		Upload
 //	@ID				generic-upload
 //	@Description	Upload endpoint
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	"Success"
@@ -146,7 +146,7 @@ func (c *Client) Upload(ctx context.Context, req *vcclient.UploadRequest) error 
 //	@Summary		Notification
 //	@ID				generic-notification
 //	@Description	notification endpoint
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	{object}	vcclient.NotificationReply		"Success"
@@ -187,7 +187,7 @@ type IdentityMappingReply struct {
 //	@Summary		IdentityMapping
 //	@ID				identity-mapping
 //	@Description	Identity mapping endpoint
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	{object}	IdentityMappingReply	"Success"
@@ -234,7 +234,7 @@ type AddDocumentIdentityRequest struct {
 //	@Summary		AddDocumentIdentity
 //	@ID				add-document-identity
 //	@Description	Adding array of identities to one document
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200
@@ -279,7 +279,7 @@ type DeleteDocumentIdentityRequest struct {
 //	@Summary		DeleteDocumentIdentity
 //	@ID				delete-document-identity
 //	@Description	Delete identity to document endpoint
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200
@@ -320,7 +320,7 @@ type DeleteDocumentRequest struct {
 //	@Summary		DeleteDocument
 //	@ID				delete-document
 //	@Description	delete one document endpoint
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	"Success"
@@ -357,7 +357,7 @@ type GetDocumentReply struct {
 //	@Summary		GetDocument
 //	@ID				get-document
 //	@Description	Get document endpoint
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	{object}	GetDocumentReply		"Success"
@@ -402,7 +402,7 @@ type DocumentListReply struct {
 //	@Summary		DocumentList
 //	@ID				document-list
 //	@Description	List documents for an identity
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	{object}	DocumentListReply		"Success"
@@ -444,7 +444,7 @@ type GetDocumentCollectIDReply struct {
 //	@Summary		GetDocumentByCollectID
 //	@ID				get-document-collect-id
 //	@Description	Get one document with collect id
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	{object}	GetDocumentCollectIDReply	"Success"
@@ -487,7 +487,7 @@ type RevokeDocumentRequest struct {
 //	@Summary		RevokeDocument
 //	@ID				revoke-document
 //	@Description	Revoke one document
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	"Success"

--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -60,7 +60,7 @@ func (c *Client) VCINonce(ctx context.Context) (*openid4vci.NonceResponse, error
 //	@Summary		VCICredential
 //	@ID				create-credential
 //	@Description	Create credential endpoint
-//	@Tags			dc4eu
+//	@Tags			vc-platform
 //	@Accept			json
 //	@Produce		json
 //	@Success		200	{object}	apiv1_issuer.MakeSDJWTReply		"Success"


### PR DESCRIPTION
Replace legacy `dc4eu` tag references in swagger annotations with `vc-platform` across all API Gateway handlers (datastore, issuer, consent) and regenerated swagger documentation.

The `dc4eu` tag is a leftover from when the project was under the dc4eu organization. This rename brings the swagger tags in line with the current project identity.