### PR TITLE
fix: swap allowed_client_dns map direction to name->DN

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -255,10 +255,10 @@ registry:
     #   client_ca_path: "/pki/client_ca.crt"  # For mutual TLS
     #   # Pin specific certs by fingerprint
     #   allowed_client_fingerprints:
-    #     "sha256:aa:bb:cc:...": "apigw-prod"
-    #   # Allow certs by Subject DN
+    #     "sha256:aa:bb:cc:...":  "apigw-prod"
+    #   # Allow certs by Subject DN (key is friendly name, value is Subject DN)
     #   allowed_client_dns:
-    #     "CN=apigw.example.com,O=MyOrg": "apigw-acme"
+    #     apigw-acme: "CN=apigw.example.com,O=MyOrg"
   # Token Status Lists configuration per draft-ietf-oauth-status-list
   token_status_lists:
     key_config:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -515,7 +515,7 @@ Configuration for the Issuer service that signs and issues verifiable credential
 | `key_file_path`               | `string` | Server private key                          | -                              | `/pki/grpc_server.key` | Yes (if enabled) |
 | `client_ca_path`              | `string` | CA to verify client certificates (for mTLS) | -                              | `/pki/client_ca.crt`   | Yes (if enabled) |
 | `allowed_client_fingerprints` | `object` | SHA256 fingerprint -> friendly name         | `a1b2c3...: issuer-prod`       | -                      | No               |
-| `allowed_client_dns`          | `object` | Certificate Subject DN -> friendly name     | `CN=apigw,O=SUNET: apigw-prod` | -                      | No               |
+| `allowed_client_dns`          | `object` | Friendly name -> Certificate Subject DN     | `apigw-prod: CN=apigw,O=SUNET` | -                      | No               |
 
 ### `jwt_attribute`
 

--- a/pkg/grpchelpers/grpchelpers_test.go
+++ b/pkg/grpchelpers/grpchelpers_test.go
@@ -257,7 +257,7 @@ func TestNewServerOptions_InvalidCert(t *testing.T) {
 	cfg := model.GRPCServer{
 		Addr: "localhost:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: "/nonexistent/cert.pem",
 			KeyFilePath:  "/nonexistent/key.pem",
 		},
@@ -281,7 +281,7 @@ func TestNewServerOptions_InvalidClientCA(t *testing.T) {
 	cfg := model.GRPCServer{
 		Addr: "localhost:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: "/nonexistent/ca.pem",
@@ -311,7 +311,7 @@ func TestNewServerOptions_InvalidClientCAPEM(t *testing.T) {
 	cfg := model.GRPCServer{
 		Addr: "localhost:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caPath,
@@ -336,7 +336,7 @@ func TestNewServerOptions_ValidTLS(t *testing.T) {
 	cfg := model.GRPCServer{
 		Addr: "localhost:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 		},
@@ -364,7 +364,7 @@ func TestNewServerOptions_ValidMTLS(t *testing.T) {
 	cfg := model.GRPCServer{
 		Addr: "localhost:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caCertPath,
@@ -393,7 +393,7 @@ func TestNewServerOptions_WithFingerprints(t *testing.T) {
 	cfg := model.GRPCServer{
 		Addr: "localhost:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caCertPath,
@@ -717,6 +717,36 @@ func TestCanonicalizeDN_MatchesCertCanonicalDN(t *testing.T) {
 	}
 }
 
+// TestBuildClientAllowlists_DN validates both the name->DN config format
+// (issue #349 regression) and fail-fast on invalid DN values.
+func TestBuildClientAllowlists_DN(t *testing.T) {
+	t.Run("valid DN matches cert", func(t *testing.T) {
+		// Exact scenario from issue #349
+		tlsCfg := model.GRPCTLS{
+			AllowedClientDNs: map[string]string{
+				"issuer-apigw": "CN=issuer-apigw-client,OU=clients,O=siros",
+			},
+		}
+		_, allowedDNs, err := buildClientAllowlists(tlsCfg)
+		require.NoError(t, err)
+		name, ok := allowedDNs[canonicalizeDN("CN=issuer-apigw-client,OU=clients,O=siros")]
+		require.True(t, ok, "canonical DN should be in allowlist, got keys: %v", allowedDNs)
+		assert.Equal(t, "issuer-apigw", name)
+	})
+
+	t.Run("invalid DN fails fast", func(t *testing.T) {
+		tlsCfg := model.GRPCTLS{
+			AllowedClientDNs: map[string]string{
+				"apigw-prod": "not-a-valid-dn",
+			},
+		}
+		_, _, err := buildClientAllowlists(tlsCfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "apigw-prod")
+		assert.Contains(t, err.Error(), "canonicalizes to empty")
+	})
+}
+
 // TestVerifyClientIdentity_DNOrderIndependent tests that DN allowlist matching works
 // regardless of the attribute order in the config DN string.
 func TestVerifyClientIdentity_DNOrderIndependent(t *testing.T) {
@@ -881,41 +911,8 @@ func TestVerifyClientIdentity_NeitherMatches(t *testing.T) {
 	assert.Contains(t, st.Message(), "not in allowlist")
 }
 
-// TestNewServerOptions_WithDNs tests server options with DN allowlist
-func TestNewServerOptions_WithDNs(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Generate CA
-	caCert, _ := generateTestCA(t)
-	caCertPath := writeCertToFile(t, tmpDir, "ca.pem", caCert)
-
-	// Generate server cert
-	serverCert, serverKey := generateTestCertAndKey(t, "server")
-	serverCertPath := writeCertToFile(t, tmpDir, "server.pem", serverCert)
-	serverKeyPath := writeKeyToFile(t, tmpDir, "server-key.pem", serverKey)
-
-	cfg := model.GRPCServer{
-		Addr: "localhost:0",
-		TLS: model.GRPCTLS{
-			Enable:      true,
-			CertFilePath: serverCertPath,
-			KeyFilePath:  serverKeyPath,
-			ClientCAPath: caCertPath,
-			AllowedClientDNs: map[string]string{
-				"CN=apigw,O=SUNET": "apigw-prod",
-			},
-		},
-	}
-
-	opts, err := NewServerOptions(cfg)
-	require.NoError(t, err)
-	require.NotNil(t, opts)
-	// TLS credentials + unary interceptor + stream interceptor
-	assert.Len(t, opts, 3)
-}
-
-// TestNewServerOptions_WithBothFingerprintsAndDNs tests server options with both allowlists
-func TestNewServerOptions_WithBothFingerprintsAndDNs(t *testing.T) {
+// TestNewServerOptions_WithAllowlists tests server options with DN and/or fingerprint allowlists
+func TestNewServerOptions_WithAllowlists(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	caCert, _ := generateTestCA(t)
@@ -925,26 +922,33 @@ func TestNewServerOptions_WithBothFingerprintsAndDNs(t *testing.T) {
 	serverCertPath := writeCertToFile(t, tmpDir, "server.pem", serverCert)
 	serverKeyPath := writeKeyToFile(t, tmpDir, "server-key.pem", serverKey)
 
-	cfg := model.GRPCServer{
-		Addr: "localhost:0",
-		TLS: model.GRPCTLS{
-			Enable:      true,
-			CertFilePath: serverCertPath,
-			KeyFilePath:  serverKeyPath,
-			ClientCAPath: caCertPath,
-			AllowedClientFingerprints: map[string]string{
-				"SHA256:a1:b2:c3:d4": "pinned-client",
-			},
-			AllowedClientDNs: map[string]string{
-				"CN=apigw,O=SUNET": "apigw-acme",
-			},
-		},
+	baseTLS := model.GRPCTLS{
+		Enable:       true,
+		CertFilePath: serverCertPath,
+		KeyFilePath:  serverKeyPath,
+		ClientCAPath: caCertPath,
 	}
 
-	opts, err := NewServerOptions(cfg)
-	require.NoError(t, err)
-	require.NotNil(t, opts)
-	assert.Len(t, opts, 3)
+	t.Run("DNs only", func(t *testing.T) {
+		tls := baseTLS
+		tls.AllowedClientDNs = map[string]string{"apigw-prod": "CN=apigw,O=SUNET"}
+		cfg := model.GRPCServer{Addr: "localhost:0", TLS: tls}
+		opts, err := NewServerOptions(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, opts)
+		assert.Len(t, opts, 3)
+	})
+
+	t.Run("both fingerprints and DNs", func(t *testing.T) {
+		tls := baseTLS
+		tls.AllowedClientFingerprints = map[string]string{"SHA256:a1:b2:c3:d4": "pinned-client"}
+		tls.AllowedClientDNs = map[string]string{"apigw-acme": "CN=apigw,O=SUNET"}
+		cfg := model.GRPCServer{Addr: "localhost:0", TLS: tls}
+		opts, err := NewServerOptions(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, opts)
+		assert.Len(t, opts, 3)
+	})
 }
 
 // TestVerifyClientIdentity_BothFingerprintAndDNMatch tests that when both fingerprint and DN
@@ -1007,7 +1011,7 @@ func TestIntegration_mTLS_BothFingerprintAndDNMatch(t *testing.T) {
 	serverCfg := model.GRPCServer{
 		Addr: "127.0.0.1:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caCertPath,
@@ -1015,7 +1019,7 @@ func TestIntegration_mTLS_BothFingerprintAndDNMatch(t *testing.T) {
 				clientFingerprint: "client-pinned",
 			},
 			AllowedClientDNs: map[string]string{
-				clientDN: "client-dn",
+				"client-dn": clientDN,
 			},
 		},
 	}
@@ -1097,12 +1101,12 @@ func TestIntegration_mTLS_DNInAllowlist(t *testing.T) {
 	serverCfg := model.GRPCServer{
 		Addr: "127.0.0.1:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caCertPath,
 			AllowedClientDNs: map[string]string{
-				clientDN: "allowed-by-dn",
+				"allowed-by-dn": clientDN,
 			},
 		},
 	}
@@ -1170,12 +1174,12 @@ func TestIntegration_mTLS_DNNotInAllowlist(t *testing.T) {
 	serverCfg := model.GRPCServer{
 		Addr: "127.0.0.1:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caCertPath,
 			AllowedClientDNs: map[string]string{
-				"cn=some-other-client,o=other-org": "not-our-client",
+				"not-our-client": "cn=some-other-client,o=other-org",
 			},
 		},
 	}
@@ -1245,7 +1249,7 @@ func TestIntegration_mTLS_DNAllowedFingerprintNot(t *testing.T) {
 	serverCfg := model.GRPCServer{
 		Addr: "127.0.0.1:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caCertPath,
@@ -1253,7 +1257,7 @@ func TestIntegration_mTLS_DNAllowedFingerprintNot(t *testing.T) {
 				"0000000000000000000000000000000000000000000000000000000000000000": "wrong-fingerprint",
 			},
 			AllowedClientDNs: map[string]string{
-				clientDN: "allowed-by-dn",
+				"allowed-by-dn": clientDN,
 			},
 		},
 	}
@@ -1557,7 +1561,7 @@ func TestIntegration_mTLS_FingerprintNotInAllowlist(t *testing.T) {
 	serverCfg := model.GRPCServer{
 		Addr: "127.0.0.1:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caCertPath,
@@ -1646,7 +1650,7 @@ func TestIntegration_mTLS_FingerprintInAllowlist(t *testing.T) {
 	serverCfg := model.GRPCServer{
 		Addr: "127.0.0.1:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caCertPath,
@@ -1742,7 +1746,7 @@ func TestIntegration_mTLS_InvalidClientCert(t *testing.T) {
 	serverCfg := model.GRPCServer{
 		Addr: "127.0.0.1:0",
 		TLS: model.GRPCTLS{
-			Enable:      true,
+			Enable:       true,
 			CertFilePath: serverCertPath,
 			KeyFilePath:  serverKeyPath,
 			ClientCAPath: caCertPath, // Only trusts the first CA

--- a/pkg/grpchelpers/server.go
+++ b/pkg/grpchelpers/server.go
@@ -61,7 +61,10 @@ func NewServerOptions(cfg model.GRPCServer) ([]grpc.ServerOption, error) {
 	opts := []grpc.ServerOption{grpc.Creds(creds)}
 
 	// Add client identity verification interceptor if any allowlist is configured
-	allowedFingerprints, allowedDNs := buildClientAllowlists(cfg.TLS)
+	allowedFingerprints, allowedDNs, err := buildClientAllowlists(cfg.TLS)
+	if err != nil {
+		return nil, fmt.Errorf("invalid client allowlist config: %w", err)
+	}
 	if allowedFingerprints != nil || allowedDNs != nil {
 		interceptor := clientAuthUnaryInterceptor(allowedFingerprints, allowedDNs)
 		streamInterceptor := clientAuthStreamInterceptor(allowedFingerprints, allowedDNs)
@@ -76,7 +79,8 @@ func NewServerOptions(cfg model.GRPCServer) ([]grpc.ServerOption, error) {
 
 // buildClientAllowlists normalizes the fingerprint and DN allowlists from the TLS config.
 // Returns nil maps when the respective allowlist is not configured.
-func buildClientAllowlists(tlsCfg model.GRPCTLS) (allowedFingerprints, allowedDNs map[string]string) {
+// Returns an error if any DN value cannot be canonicalized (likely a misconfigured entry).
+func buildClientAllowlists(tlsCfg model.GRPCTLS) (allowedFingerprints, allowedDNs map[string]string, err error) {
 	if len(tlsCfg.AllowedClientFingerprints) > 0 {
 		allowedFingerprints = make(map[string]string, len(tlsCfg.AllowedClientFingerprints))
 		for fp, name := range tlsCfg.AllowedClientFingerprints {
@@ -86,12 +90,16 @@ func buildClientAllowlists(tlsCfg model.GRPCTLS) (allowedFingerprints, allowedDN
 
 	if len(tlsCfg.AllowedClientDNs) > 0 {
 		allowedDNs = make(map[string]string, len(tlsCfg.AllowedClientDNs))
-		for dn, name := range tlsCfg.AllowedClientDNs {
-			allowedDNs[canonicalizeDN(dn)] = name
+		for name, dn := range tlsCfg.AllowedClientDNs {
+			canonical := canonicalizeDN(dn)
+			if canonical == "" {
+				return nil, nil, fmt.Errorf("allowed_client_dns entry %q has invalid DN value %q (canonicalizes to empty string)", name, dn)
+			}
+			allowedDNs[canonical] = name
 		}
 	}
 
-	return allowedFingerprints, allowedDNs
+	return allowedFingerprints, allowedDNs, nil
 }
 
 // normalizeFingerprint normalizes a fingerprint string for comparison.

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sync"
 	"time"
+
 	"github.com/SUNET/vc/pkg/oauth2"
 	"github.com/SUNET/vc/pkg/openid4vci"
 	"github.com/SUNET/vc/pkg/openid4vp"
@@ -171,7 +172,7 @@ type GRPCTLS struct {
 	KeyFilePath               string            `yaml:"key_file_path" validate:"required_if=Enable true" default:"/pki/grpc_server.key"`  // Server private key
 	ClientCAPath              string            `yaml:"client_ca_path" validate:"required_if=Enable true" default:"/pki/client_ca.crt"`   // CA to verify client certificates (for mTLS)
 	AllowedClientFingerprints map[string]string `yaml:"allowed_client_fingerprints" doc_example:"a1b2c3...: issuer-prod"`                 // SHA256 fingerprint -> friendly name
-	AllowedClientDNs          map[string]string `yaml:"allowed_client_dns" doc_example:"CN=apigw,O=SUNET: apigw-prod"`                    // Certificate Subject DN -> friendly name
+	AllowedClientDNs          map[string]string `yaml:"allowed_client_dns" doc_example:"apigw-prod: CN=apigw,O=SUNET"`                    // Friendly name -> Certificate Subject DN
 }
 
 // JWTAttribute holds the jwt attribute configuration.


### PR DESCRIPTION
## Problem

The `allowed_client_dns` config map expected the Distinguished Name as the YAML key and a friendly name as the value:

```yaml
allowed_client_dns:
  "CN=apigw,O=SUNET": apigw-prod
```

This was counter-intuitive and caused real deployment failures because operators naturally write it as `name: DN`:

```yaml
allowed_client_dns:
  issuer-apigw: CN=issuer-apigw-client,OU=clients,O=siros
```

When configured this way, the code canonicalized the YAML key (the friendly name `issuer-apigw`) as if it were a DN, producing an empty/wrong canonical form that never matched any certificate — causing `PermissionDenied` errors.

## Fix

Swap the map semantics so the key is the friendly name and the value is the DN, matching natural YAML conventions. This is consistent with how operators expect to write YAML config (`identifier: value`).

### Config format change

**Before (broken/counter-intuitive):**
```yaml
allowed_client_dns:
  "CN=apigw,O=SUNET": apigw-prod
```

**After (natural):**
```yaml
allowed_client_dns:
  apigw-prod: "CN=apigw,O=SUNET"
```

### Changes
- `pkg/grpchelpers/server.go`: Swap loop variables in `buildClientAllowlists`
- `pkg/model/config.go`: Update doc_example and comment
- `config.yaml`: Update example comments
- `docs/CONFIGURATION.md`: Update documentation table
- `pkg/grpchelpers/grpchelpers_test.go`: Update all tests + add regression test for exact issue #349 scenario

All 80 tests in the grpchelpers package pass.

Fixes #349