### PR TITLE
fix: use dedicated struct for identity mapping request

### DIFF
--- a/docs/apigw/docs.go
+++ b/docs/apigw/docs.go
@@ -106,7 +106,7 @@ const docTemplate = `{
                 "tags": [
                     "vc-platform"
                 ],
-                "summary": "OIDCCredential",
+                "summary": "VCICredential",
                 "operationId": "create-credential",
                 "parameters": [
                     {
@@ -124,36 +124,6 @@ const docTemplate = `{
                         "description": "Success",
                         "schema": {
                             "$ref": "#/definitions/apiv1_issuer.MakeSDJWTReply"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/credential/.well-known/jwks": {
-            "get": {
-                "description": "JWKS endpoint",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "vc-platform"
-                ],
-                "summary": "JWKS",
-                "operationId": "issuer-JWKS",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/apiv1_issuer.JwksReply"
                         }
                     },
                     "400": {
@@ -498,7 +468,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/apiv1.NotificationRequest"
+                            "$ref": "#/definitions/vcclient.NotificationRequest"
                         }
                     }
                 ],
@@ -506,48 +476,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Success",
                         "schema": {
-                            "$ref": "#/definitions/apiv1.NotificationReply"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/revoke": {
-            "post": {
-                "description": "Revoke endpoint",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "vc-platform"
-                ],
-                "summary": "Revoke",
-                "operationId": "generic-revoke",
-                "parameters": [
-                    {
-                        "description": " ",
-                        "name": "req",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.RevokeRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.RevokeReply"
+                            "$ref": "#/definitions/vcclient.NotificationReply"
                         }
                     },
                     "400": {
@@ -603,20 +532,26 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "authentic_source",
-                "authentic_source_person_id"
+                "authentic_source_person_id",
+                "consent_to",
+                "session_id"
             ],
             "properties": {
                 "authentic_source": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "authentic_source_person_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "consent_to": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "session_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -740,10 +675,12 @@ const docTemplate = `{
             ],
             "properties": {
                 "authentic_source": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "authentic_source_person_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -805,6 +742,86 @@ const docTemplate = `{
                 }
             }
         },
+        "apiv1.IdentityMappingIdentity": {
+            "type": "object",
+            "required": [
+                "birth_date",
+                "family_name",
+                "given_name",
+                "schema"
+            ],
+            "properties": {
+                "birth_date": {
+                    "type": "string"
+                },
+                "birth_family_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "birth_given_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "birth_place": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 2
+                },
+                "email_address": {
+                    "type": "string"
+                },
+                "family_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "given_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "issuing_authority": {
+                    "type": "string"
+                },
+                "issuing_country": {
+                    "type": "string"
+                },
+                "mobile_phone_number": {
+                    "type": "string"
+                },
+                "nationality": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "personal_administrative_number": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 4
+                },
+                "schema": {
+                    "$ref": "#/definitions/model.IdentitySchema"
+                },
+                "sex": {
+                    "type": "string",
+                    "enum": [
+                        "0",
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                        "5",
+                        "6",
+                        "7",
+                        "8",
+                        "9"
+                    ]
+                }
+            }
+        },
         "apiv1.IdentityMappingReply": {
             "type": "object",
             "properties": {
@@ -822,37 +839,11 @@ const docTemplate = `{
             "properties": {
                 "authentic_source": {
                     "description": "required: true\nexample: SUNET",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "identity": {
-                    "$ref": "#/definitions/model.Identity"
-                }
-            }
-        },
-        "apiv1.NotificationReply": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/openid4vci.QR"
-                }
-            }
-        },
-        "apiv1.NotificationRequest": {
-            "type": "object",
-            "required": [
-                "authentic_source",
-                "document_id",
-                "vct"
-            ],
-            "properties": {
-                "authentic_source": {
-                    "type": "string"
-                },
-                "document_id": {
-                    "type": "string"
-                },
-                "vct": {
-                    "type": "string"
+                    "$ref": "#/definitions/apiv1.IdentityMappingIdentity"
                 }
             }
         },
@@ -875,95 +866,11 @@ const docTemplate = `{
                 }
             }
         },
-        "apiv1.RevokeReply": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "boolean"
-                        }
-                    }
-                }
-            }
-        },
-        "apiv1.RevokeRequest": {
-            "type": "object",
-            "properties": {
-                "authentic_source": {
-                    "type": "string"
-                },
-                "document_id": {
-                    "type": "string"
-                },
-                "revocation_id": {
-                    "type": "string"
-                },
-                "vct": {
-                    "type": "string"
-                }
-            }
-        },
         "apiv1_issuer.Credential": {
             "type": "object",
             "properties": {
                 "credential": {
                     "type": "string"
-                }
-            }
-        },
-        "apiv1_issuer.Jwk": {
-            "type": "object",
-            "properties": {
-                "crv": {
-                    "type": "string"
-                },
-                "d": {
-                    "type": "string"
-                },
-                "ext": {
-                    "type": "boolean"
-                },
-                "key_ops": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "kid": {
-                    "type": "string"
-                },
-                "kty": {
-                    "type": "string"
-                },
-                "x": {
-                    "type": "string"
-                },
-                "y": {
-                    "type": "string"
-                }
-            }
-        },
-        "apiv1_issuer.JwksReply": {
-            "type": "object",
-            "properties": {
-                "issuer": {
-                    "type": "string"
-                },
-                "jwks": {
-                    "$ref": "#/definitions/apiv1_issuer.Keys"
-                }
-            }
-        },
-        "apiv1_issuer.Keys": {
-            "type": "object",
-            "properties": {
-                "keys": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/apiv1_issuer.Jwk"
-                    }
                 }
             }
         },
@@ -975,6 +882,14 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/apiv1_issuer.Credential"
                     }
+                },
+                "token_status_list_index": {
+                    "description": "Token Status List index",
+                    "type": "integer"
+                },
+                "token_status_list_section": {
+                    "description": "Token Status List section",
+                    "type": "integer"
                 }
             }
         },
@@ -1000,7 +915,8 @@ const docTemplate = `{
             "properties": {
                 "id": {
                     "description": "required: false\nexample: 98fe67fc-c03f-11ee-bbee-4345224d414f",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "valid_until": {
                     "description": "required: false\nexample: 509567558\nformat: int64",
@@ -1018,7 +934,8 @@ const docTemplate = `{
             "properties": {
                 "consent_to": {
                     "description": "required: true\nexample: \"Using my data for research\"",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "created_at": {
                     "description": "required: true\nexample: 509567558\nformat: int64",
@@ -1026,7 +943,8 @@ const docTemplate = `{
                 },
                 "session_id": {
                     "description": "required: true\nexample: \"sess-123\"",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -1088,13 +1006,15 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "authentic_source_person_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
         "model.Identity": {
             "type": "object",
             "required": [
+                "authentic_source_person_id",
                 "birth_date",
                 "family_name",
                 "given_name",
@@ -1124,7 +1044,8 @@ const docTemplate = `{
                 },
                 "authentic_source_person_id": {
                     "description": "required: true\nexample: 65636cbc-c03f-11ee-8dc4-67135cc9bd8a",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "birth_date": {
                     "description": "required: true\nexample: 1970-01-01 TODO: Day, month, and year?",
@@ -1148,7 +1069,8 @@ const docTemplate = `{
                 },
                 "document_number": {
                     "description": "required: false\nexample:",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "email_address": {
                     "description": "required: false\nexample: \u003cemail-address\u003e",
@@ -1183,7 +1105,8 @@ const docTemplate = `{
                 },
                 "issuing_jurisdiction": {
                     "description": "required: false\nexample:",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "mobile_phone_number": {
                     "description": "required: false\nexample: \u003c+mobile-phone-number\u003e",
@@ -1256,7 +1179,8 @@ const docTemplate = `{
                     ]
                 },
                 "trust_anchor": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -1268,7 +1192,8 @@ const docTemplate = `{
             "properties": {
                 "name": {
                     "description": "required: true\nexample: \"SE\"",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "version": {
                     "description": "required: false\nexample: \"1.0.0\"",
@@ -1282,12 +1207,14 @@ const docTemplate = `{
                 "authentic_source",
                 "document_id",
                 "document_version",
+                "scope",
                 "vct"
             ],
             "properties": {
                 "authentic_source": {
                     "description": "required: true\nexample: SUNET",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "collect": {
                     "$ref": "#/definitions/model.Collect"
@@ -1302,11 +1229,13 @@ const docTemplate = `{
                 },
                 "document_data_validation": {
                     "description": "required: false\nexample: file://path/to/schema.json or http://example.com/schema.json\nformat: string",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "document_id": {
                     "description": "required: true\nexample: 5e7a981c-c03f-11ee-b116-9b12c59362b9",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "document_version": {
                     "description": "required: true\nexample: \"1.0.0\"",
@@ -1324,9 +1253,15 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "scope": {
+                    "description": "Scope is the credential configuration ID scope\nrequired: false\nexample: \"ehic\", \"pda1\"",
+                    "type": "string",
+                    "maxLength": 128
+                },
                 "vct": {
                     "description": "VCT is the Verifiable Credential Type\nrequired: true\nexample: \"urn:eudi:pid:1\"",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -1335,11 +1270,13 @@ const docTemplate = `{
             "properties": {
                 "id": {
                     "description": "ID is the ID of the revocation\nrequired: false\nexample: 8dbd2680-c03f-11ee-a21b-034aafe41222",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "reason": {
                     "description": "Reason is the reason for revocation\nrequired: false\nexample: lost or stolen",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "reference": {
                     "$ref": "#/definitions/model.RevocationReference"
@@ -1358,49 +1295,20 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "authentic_source": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "document_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "vct": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
         "openid4vci.CredentialRequest": {
-            "type": "object",
-            "properties": {
-                "credential_identifier": {
-                    "description": "REQUIRED when credential_identifiers parameter was returned from the Token Response. It MUST NOT be used otherwise. It is a String that identifies a Credential that is being requested to be issued. When this parameter is used, the format parameter and any other Credential format specific parameters such as those defined in Appendix A MUST NOT be present.",
-                    "type": "string"
-                },
-                "credential_response_encryption": {
-                    "description": "CredentialIdentifier REQUIRED when credential_identifiers parameter was returned from the Token Response. It MUST NOT be used otherwise. It is a String that identifies a Credential that is being requested to be issued. When this parameter is used, the format parameter and any other Credential format specific parameters such as those defined in Appendix A MUST NOT be present.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/openid4vci.CredentialResponseEncryption"
-                        }
-                    ]
-                },
-                "format": {
-                    "description": "Format REQUIRED when the credential_identifiers parameter was not returned from the Token Response. It MUST NOT be used otherwise. It is a String that determines the format of the Credential to be issued, which may determine the type and any other information related to the Credential to be issued. Credential Format Profiles consist of the Credential format specific parameters that are defined in Appendix A. When this parameter is used, the credential_identifier Credential Request parameter MUST NOT be present.",
-                    "type": "string"
-                },
-                "headers": {
-                    "$ref": "#/definitions/openid4vci.CredentialRequestHeader"
-                },
-                "proof": {
-                    "description": "Proof OPTIONAL. Object containing the proof of possession of the cryptographic key material the issued Credential would be bound to. The proof object is REQUIRED if the proof_types_supported parameter is non-empty and present in the credential_configurations_supported parameter of the Issuer metadata for the requested Credential. The proof object MUST contain the following:",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/openid4vci.Proof"
-                        }
-                    ]
-                }
-            }
-        },
-        "openid4vci.CredentialRequestHeader": {
             "type": "object",
             "required": [
                 "authorization",
@@ -1410,27 +1318,118 @@ const docTemplate = `{
                 "authorization": {
                     "type": "string"
                 },
-                "dpoP": {
+                "credential_configuration_id": {
+                    "description": "CredentialConfigurationID REQUIRED if a credential_identifiers parameter was not returned from\nthe Token Response as part of the authorization_details parameter. It MUST NOT be used otherwise.\nString that uniquely identifies one of the keys in the name/value pairs stored in the\ncredential_configurations_supported Credential Issuer metadata. When this parameter is used,\nthe credential_identifier MUST NOT be present.",
                     "type": "string"
+                },
+                "credential_identifier": {
+                    "description": "CredentialIdentifier REQUIRED when an Authorization Details of type openid_credential was returned\nfrom the Token Response. It MUST NOT be used otherwise. A string that identifies a Credential Dataset\nthat is requested for issuance. When this parameter is used, the credential_configuration_id MUST NOT be present.",
+                    "type": "string"
+                },
+                "credential_response_encryption": {
+                    "description": "CredentialResponseEncryption OPTIONAL. Object containing information for encrypting the Credential Response.\nIf this request element is not present, the corresponding credential response returned is not encrypted.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.CredentialResponseEncryption"
+                        }
+                    ]
+                },
+                "dpoP": {
+                    "description": "Header fields",
+                    "type": "string"
+                },
+                "proof": {
+                    "description": "Proof OPTIONAL. Single proof object for non-batch requests.\nDeprecated: Use Proofs instead. This field is kept for backward compatibility with older wallets.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.Proof"
+                        }
+                    ]
+                },
+                "proofs": {
+                    "description": "Proofs OPTIONAL. Object providing one or more proof of possessions of the cryptographic key material\nto which the issued Credential instances will be bound to. The proofs parameter contains exactly one\nparameter named as the proof type in Appendix F, the value set for this parameter is a non-empty array\ncontaining parameters as defined by the corresponding proof type.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.Proofs"
+                        }
+                    ]
                 }
             }
         },
         "openid4vci.CredentialResponseEncryption": {
             "type": "object",
             "required": [
-                "alg",
                 "enc",
                 "jwk"
             ],
             "properties": {
-                "alg": {
-                    "type": "string"
-                },
                 "enc": {
+                    "description": "Enc REQUIRED. JWE enc algorithm for encrypting Credential Responses.",
                     "type": "string"
                 },
                 "jwk": {
-                    "$ref": "#/definitions/openid4vci.JWK"
+                    "description": "JWK REQUIRED. Object containing a single public key as a JWK used for encrypting the Credential Response.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.JWK"
+                        }
+                    ]
+                },
+                "zip": {
+                    "description": "Zip OPTIONAL. JWE zip algorithm for compressing Credential Responses prior to encryption.\nIf absent then compression MUST not be used.",
+                    "type": "string"
+                }
+            }
+        },
+        "openid4vci.DIVPProof": {
+            "type": "object",
+            "required": [
+                "cryptosuite",
+                "domain",
+                "proofPurpose",
+                "proofValue",
+                "type",
+                "verificationMethod"
+            ],
+            "properties": {
+                "challenge": {
+                    "description": "Challenge MUST be the c_nonce value provided by the Credential Issuer (when provided)",
+                    "type": "string"
+                },
+                "created": {
+                    "description": "Created is the creation time of the proof",
+                    "type": "string"
+                },
+                "cryptosuite": {
+                    "description": "Cryptosuite identifies the cryptographic suite used\nSupported: eddsa-rdfc-2022, ecdsa-rdfc-2019, ecdsa-sd-2023, eddsa-jcs-2022, ecdsa-jcs-2019",
+                    "type": "string",
+                    "enum": [
+                        "eddsa-rdfc-2022",
+                        "ecdsa-rdfc-2019",
+                        "ecdsa-sd-2023",
+                        "eddsa-jcs-2022",
+                        "ecdsa-jcs-2019"
+                    ]
+                },
+                "domain": {
+                    "description": "Domain MUST be the Credential Issuer Identifier",
+                    "type": "string"
+                },
+                "proofPurpose": {
+                    "description": "ProofPurpose MUST be \"authentication\" for OpenID4VCI",
+                    "type": "string"
+                },
+                "proofValue": {
+                    "description": "ProofValue is the actual proof signature value",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type is the proof type, e.g., \"DataIntegrityProof\"",
+                    "type": "string"
+                },
+                "verificationMethod": {
+                    "description": "VerificationMethod is a URL that identifies the public key to use for verification",
+                    "type": "string"
                 }
             }
         },
@@ -1438,7 +1437,6 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "crv",
-                "d",
                 "kid",
                 "kty",
                 "x",
@@ -1446,9 +1444,6 @@ const docTemplate = `{
             ],
             "properties": {
                 "crv": {
-                    "type": "string"
-                },
-                "d": {
                     "type": "string"
                 },
                 "kid": {
@@ -1471,23 +1466,96 @@ const docTemplate = `{
                 "proof_type"
             ],
             "properties": {
-                "attestation": {
+                "cwt": {
+                    "description": "CWT The CWT proof, when proof_type is \"cwt\"",
                     "type": "string"
                 },
                 "jwt": {
+                    "description": "JWT The JWT proof, when proof_type is \"jwt\"",
                     "type": "string"
                 },
                 "ldp_vp": {
-                    "type": "string"
+                    "description": "LDPVp The Linked Data Proof VP, when proof_type is \"ldp_vp\""
                 },
                 "proof_type": {
-                    "description": "ProofType REQUIRED. String denoting the key proof type. The value of this parameter determines other parameters in the key proof object and its respective processing rules. Key proof types defined in this specification can be found in Section 7.2.1.",
-                    "type": "string",
-                    "enum": [
-                        "jwt",
-                        "ldp_vp",
-                        "cwt"
+                    "description": "ProofType REQUIRED. String denoting the key proof type.",
+                    "type": "string"
+                }
+            }
+        },
+        "openid4vci.ProofDIVP": {
+            "type": "object",
+            "required": [
+                "@context",
+                "type"
+            ],
+            "properties": {
+                "@context": {
+                    "description": "Context is the JSON-LD context, REQUIRED per W3C VC Data Model",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "holder": {
+                    "description": "Holder is the DID of the holder",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID is an optional identifier for the presentation",
+                    "type": "string"
+                },
+                "proof": {
+                    "description": "Proof contains the Data Integrity Proof(s), one of Proof or Proofs REQUIRED",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.DIVPProof"
+                        }
                     ]
+                },
+                "proofs": {
+                    "description": "Proofs contains multiple Data Integrity Proofs if more than one is present",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openid4vci.DIVPProof"
+                    }
+                },
+                "type": {
+                    "description": "Type is the type of the presentation, REQUIRED, must include \"VerifiablePresentation\"",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "verifiableCredential": {
+                    "description": "VerifiableCredential contains the credentials being presented",
+                    "type": "array",
+                    "items": {}
+                }
+            }
+        },
+        "openid4vci.Proofs": {
+            "type": "object",
+            "properties": {
+                "attestation": {
+                    "description": "Attestation contains a single JWT representing a key attestation\nas defined in Appendix D.1",
+                    "type": "string"
+                },
+                "di_vp": {
+                    "description": "DIVP contains an array of W3C Verifiable Presentations\nsigned using Data Integrity Proof as defined in Appendix F.2",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openid4vci.ProofDIVP"
+                    }
+                },
+                "jwt": {
+                    "description": "JWT contains an array of JWTs as defined in Appendix F.1",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -1498,6 +1566,33 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "qr_base64": {
+                    "type": "string"
+                }
+            }
+        },
+        "vcclient.NotificationReply": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/openid4vci.QR"
+                }
+            }
+        },
+        "vcclient.NotificationRequest": {
+            "type": "object",
+            "required": [
+                "authentic_source",
+                "document_id",
+                "vct"
+            ],
+            "properties": {
+                "authentic_source": {
+                    "type": "string"
+                },
+                "document_id": {
+                    "type": "string"
+                },
+                "vct": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.json
+++ b/docs/apigw/swagger.json
@@ -98,7 +98,7 @@
                 "tags": [
                     "vc-platform"
                 ],
-                "summary": "OIDCCredential",
+                "summary": "VCICredential",
                 "operationId": "create-credential",
                 "parameters": [
                     {
@@ -116,36 +116,6 @@
                         "description": "Success",
                         "schema": {
                             "$ref": "#/definitions/apiv1_issuer.MakeSDJWTReply"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/credential/.well-known/jwks": {
-            "get": {
-                "description": "JWKS endpoint",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "vc-platform"
-                ],
-                "summary": "JWKS",
-                "operationId": "issuer-JWKS",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/apiv1_issuer.JwksReply"
                         }
                     },
                     "400": {
@@ -490,7 +460,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/apiv1.NotificationRequest"
+                            "$ref": "#/definitions/vcclient.NotificationRequest"
                         }
                     }
                 ],
@@ -498,48 +468,7 @@
                     "200": {
                         "description": "Success",
                         "schema": {
-                            "$ref": "#/definitions/apiv1.NotificationReply"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/revoke": {
-            "post": {
-                "description": "Revoke endpoint",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "vc-platform"
-                ],
-                "summary": "Revoke",
-                "operationId": "generic-revoke",
-                "parameters": [
-                    {
-                        "description": " ",
-                        "name": "req",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.RevokeRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.RevokeReply"
+                            "$ref": "#/definitions/vcclient.NotificationReply"
                         }
                     },
                     "400": {
@@ -595,20 +524,26 @@
             "type": "object",
             "required": [
                 "authentic_source",
-                "authentic_source_person_id"
+                "authentic_source_person_id",
+                "consent_to",
+                "session_id"
             ],
             "properties": {
                 "authentic_source": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "authentic_source_person_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "consent_to": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "session_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -732,10 +667,12 @@
             ],
             "properties": {
                 "authentic_source": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "authentic_source_person_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -797,6 +734,86 @@
                 }
             }
         },
+        "apiv1.IdentityMappingIdentity": {
+            "type": "object",
+            "required": [
+                "birth_date",
+                "family_name",
+                "given_name",
+                "schema"
+            ],
+            "properties": {
+                "birth_date": {
+                    "type": "string"
+                },
+                "birth_family_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "birth_given_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "birth_place": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 2
+                },
+                "email_address": {
+                    "type": "string"
+                },
+                "family_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "given_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "issuing_authority": {
+                    "type": "string"
+                },
+                "issuing_country": {
+                    "type": "string"
+                },
+                "mobile_phone_number": {
+                    "type": "string"
+                },
+                "nationality": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "personal_administrative_number": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 4
+                },
+                "schema": {
+                    "$ref": "#/definitions/model.IdentitySchema"
+                },
+                "sex": {
+                    "type": "string",
+                    "enum": [
+                        "0",
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                        "5",
+                        "6",
+                        "7",
+                        "8",
+                        "9"
+                    ]
+                }
+            }
+        },
         "apiv1.IdentityMappingReply": {
             "type": "object",
             "properties": {
@@ -814,37 +831,11 @@
             "properties": {
                 "authentic_source": {
                     "description": "required: true\nexample: SUNET",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "identity": {
-                    "$ref": "#/definitions/model.Identity"
-                }
-            }
-        },
-        "apiv1.NotificationReply": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/openid4vci.QR"
-                }
-            }
-        },
-        "apiv1.NotificationRequest": {
-            "type": "object",
-            "required": [
-                "authentic_source",
-                "document_id",
-                "vct"
-            ],
-            "properties": {
-                "authentic_source": {
-                    "type": "string"
-                },
-                "document_id": {
-                    "type": "string"
-                },
-                "vct": {
-                    "type": "string"
+                    "$ref": "#/definitions/apiv1.IdentityMappingIdentity"
                 }
             }
         },
@@ -867,95 +858,11 @@
                 }
             }
         },
-        "apiv1.RevokeReply": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "boolean"
-                        }
-                    }
-                }
-            }
-        },
-        "apiv1.RevokeRequest": {
-            "type": "object",
-            "properties": {
-                "authentic_source": {
-                    "type": "string"
-                },
-                "document_id": {
-                    "type": "string"
-                },
-                "revocation_id": {
-                    "type": "string"
-                },
-                "vct": {
-                    "type": "string"
-                }
-            }
-        },
         "apiv1_issuer.Credential": {
             "type": "object",
             "properties": {
                 "credential": {
                     "type": "string"
-                }
-            }
-        },
-        "apiv1_issuer.Jwk": {
-            "type": "object",
-            "properties": {
-                "crv": {
-                    "type": "string"
-                },
-                "d": {
-                    "type": "string"
-                },
-                "ext": {
-                    "type": "boolean"
-                },
-                "key_ops": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "kid": {
-                    "type": "string"
-                },
-                "kty": {
-                    "type": "string"
-                },
-                "x": {
-                    "type": "string"
-                },
-                "y": {
-                    "type": "string"
-                }
-            }
-        },
-        "apiv1_issuer.JwksReply": {
-            "type": "object",
-            "properties": {
-                "issuer": {
-                    "type": "string"
-                },
-                "jwks": {
-                    "$ref": "#/definitions/apiv1_issuer.Keys"
-                }
-            }
-        },
-        "apiv1_issuer.Keys": {
-            "type": "object",
-            "properties": {
-                "keys": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/apiv1_issuer.Jwk"
-                    }
                 }
             }
         },
@@ -967,6 +874,14 @@
                     "items": {
                         "$ref": "#/definitions/apiv1_issuer.Credential"
                     }
+                },
+                "token_status_list_index": {
+                    "description": "Token Status List index",
+                    "type": "integer"
+                },
+                "token_status_list_section": {
+                    "description": "Token Status List section",
+                    "type": "integer"
                 }
             }
         },
@@ -992,7 +907,8 @@
             "properties": {
                 "id": {
                     "description": "required: false\nexample: 98fe67fc-c03f-11ee-bbee-4345224d414f",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "valid_until": {
                     "description": "required: false\nexample: 509567558\nformat: int64",
@@ -1010,7 +926,8 @@
             "properties": {
                 "consent_to": {
                     "description": "required: true\nexample: \"Using my data for research\"",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "created_at": {
                     "description": "required: true\nexample: 509567558\nformat: int64",
@@ -1018,7 +935,8 @@
                 },
                 "session_id": {
                     "description": "required: true\nexample: \"sess-123\"",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -1080,13 +998,15 @@
             "type": "object",
             "properties": {
                 "authentic_source_person_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
         "model.Identity": {
             "type": "object",
             "required": [
+                "authentic_source_person_id",
                 "birth_date",
                 "family_name",
                 "given_name",
@@ -1116,7 +1036,8 @@
                 },
                 "authentic_source_person_id": {
                     "description": "required: true\nexample: 65636cbc-c03f-11ee-8dc4-67135cc9bd8a",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "birth_date": {
                     "description": "required: true\nexample: 1970-01-01 TODO: Day, month, and year?",
@@ -1140,7 +1061,8 @@
                 },
                 "document_number": {
                     "description": "required: false\nexample:",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "email_address": {
                     "description": "required: false\nexample: \u003cemail-address\u003e",
@@ -1175,7 +1097,8 @@
                 },
                 "issuing_jurisdiction": {
                     "description": "required: false\nexample:",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "mobile_phone_number": {
                     "description": "required: false\nexample: \u003c+mobile-phone-number\u003e",
@@ -1248,7 +1171,8 @@
                     ]
                 },
                 "trust_anchor": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -1260,7 +1184,8 @@
             "properties": {
                 "name": {
                     "description": "required: true\nexample: \"SE\"",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "version": {
                     "description": "required: false\nexample: \"1.0.0\"",
@@ -1274,12 +1199,14 @@
                 "authentic_source",
                 "document_id",
                 "document_version",
+                "scope",
                 "vct"
             ],
             "properties": {
                 "authentic_source": {
                     "description": "required: true\nexample: SUNET",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "collect": {
                     "$ref": "#/definitions/model.Collect"
@@ -1294,11 +1221,13 @@
                 },
                 "document_data_validation": {
                     "description": "required: false\nexample: file://path/to/schema.json or http://example.com/schema.json\nformat: string",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "document_id": {
                     "description": "required: true\nexample: 5e7a981c-c03f-11ee-b116-9b12c59362b9",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "document_version": {
                     "description": "required: true\nexample: \"1.0.0\"",
@@ -1316,9 +1245,15 @@
                         }
                     ]
                 },
+                "scope": {
+                    "description": "Scope is the credential configuration ID scope\nrequired: false\nexample: \"ehic\", \"pda1\"",
+                    "type": "string",
+                    "maxLength": 128
+                },
                 "vct": {
                     "description": "VCT is the Verifiable Credential Type\nrequired: true\nexample: \"urn:eudi:pid:1\"",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -1327,11 +1262,13 @@
             "properties": {
                 "id": {
                     "description": "ID is the ID of the revocation\nrequired: false\nexample: 8dbd2680-c03f-11ee-a21b-034aafe41222",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "reason": {
                     "description": "Reason is the reason for revocation\nrequired: false\nexample: lost or stolen",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "reference": {
                     "$ref": "#/definitions/model.RevocationReference"
@@ -1350,49 +1287,20 @@
             "type": "object",
             "properties": {
                 "authentic_source": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "document_id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 },
                 "vct": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
         "openid4vci.CredentialRequest": {
-            "type": "object",
-            "properties": {
-                "credential_identifier": {
-                    "description": "REQUIRED when credential_identifiers parameter was returned from the Token Response. It MUST NOT be used otherwise. It is a String that identifies a Credential that is being requested to be issued. When this parameter is used, the format parameter and any other Credential format specific parameters such as those defined in Appendix A MUST NOT be present.",
-                    "type": "string"
-                },
-                "credential_response_encryption": {
-                    "description": "CredentialIdentifier REQUIRED when credential_identifiers parameter was returned from the Token Response. It MUST NOT be used otherwise. It is a String that identifies a Credential that is being requested to be issued. When this parameter is used, the format parameter and any other Credential format specific parameters such as those defined in Appendix A MUST NOT be present.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/openid4vci.CredentialResponseEncryption"
-                        }
-                    ]
-                },
-                "format": {
-                    "description": "Format REQUIRED when the credential_identifiers parameter was not returned from the Token Response. It MUST NOT be used otherwise. It is a String that determines the format of the Credential to be issued, which may determine the type and any other information related to the Credential to be issued. Credential Format Profiles consist of the Credential format specific parameters that are defined in Appendix A. When this parameter is used, the credential_identifier Credential Request parameter MUST NOT be present.",
-                    "type": "string"
-                },
-                "headers": {
-                    "$ref": "#/definitions/openid4vci.CredentialRequestHeader"
-                },
-                "proof": {
-                    "description": "Proof OPTIONAL. Object containing the proof of possession of the cryptographic key material the issued Credential would be bound to. The proof object is REQUIRED if the proof_types_supported parameter is non-empty and present in the credential_configurations_supported parameter of the Issuer metadata for the requested Credential. The proof object MUST contain the following:",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/openid4vci.Proof"
-                        }
-                    ]
-                }
-            }
-        },
-        "openid4vci.CredentialRequestHeader": {
             "type": "object",
             "required": [
                 "authorization",
@@ -1402,27 +1310,118 @@
                 "authorization": {
                     "type": "string"
                 },
-                "dpoP": {
+                "credential_configuration_id": {
+                    "description": "CredentialConfigurationID REQUIRED if a credential_identifiers parameter was not returned from\nthe Token Response as part of the authorization_details parameter. It MUST NOT be used otherwise.\nString that uniquely identifies one of the keys in the name/value pairs stored in the\ncredential_configurations_supported Credential Issuer metadata. When this parameter is used,\nthe credential_identifier MUST NOT be present.",
                     "type": "string"
+                },
+                "credential_identifier": {
+                    "description": "CredentialIdentifier REQUIRED when an Authorization Details of type openid_credential was returned\nfrom the Token Response. It MUST NOT be used otherwise. A string that identifies a Credential Dataset\nthat is requested for issuance. When this parameter is used, the credential_configuration_id MUST NOT be present.",
+                    "type": "string"
+                },
+                "credential_response_encryption": {
+                    "description": "CredentialResponseEncryption OPTIONAL. Object containing information for encrypting the Credential Response.\nIf this request element is not present, the corresponding credential response returned is not encrypted.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.CredentialResponseEncryption"
+                        }
+                    ]
+                },
+                "dpoP": {
+                    "description": "Header fields",
+                    "type": "string"
+                },
+                "proof": {
+                    "description": "Proof OPTIONAL. Single proof object for non-batch requests.\nDeprecated: Use Proofs instead. This field is kept for backward compatibility with older wallets.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.Proof"
+                        }
+                    ]
+                },
+                "proofs": {
+                    "description": "Proofs OPTIONAL. Object providing one or more proof of possessions of the cryptographic key material\nto which the issued Credential instances will be bound to. The proofs parameter contains exactly one\nparameter named as the proof type in Appendix F, the value set for this parameter is a non-empty array\ncontaining parameters as defined by the corresponding proof type.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.Proofs"
+                        }
+                    ]
                 }
             }
         },
         "openid4vci.CredentialResponseEncryption": {
             "type": "object",
             "required": [
-                "alg",
                 "enc",
                 "jwk"
             ],
             "properties": {
-                "alg": {
-                    "type": "string"
-                },
                 "enc": {
+                    "description": "Enc REQUIRED. JWE enc algorithm for encrypting Credential Responses.",
                     "type": "string"
                 },
                 "jwk": {
-                    "$ref": "#/definitions/openid4vci.JWK"
+                    "description": "JWK REQUIRED. Object containing a single public key as a JWK used for encrypting the Credential Response.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.JWK"
+                        }
+                    ]
+                },
+                "zip": {
+                    "description": "Zip OPTIONAL. JWE zip algorithm for compressing Credential Responses prior to encryption.\nIf absent then compression MUST not be used.",
+                    "type": "string"
+                }
+            }
+        },
+        "openid4vci.DIVPProof": {
+            "type": "object",
+            "required": [
+                "cryptosuite",
+                "domain",
+                "proofPurpose",
+                "proofValue",
+                "type",
+                "verificationMethod"
+            ],
+            "properties": {
+                "challenge": {
+                    "description": "Challenge MUST be the c_nonce value provided by the Credential Issuer (when provided)",
+                    "type": "string"
+                },
+                "created": {
+                    "description": "Created is the creation time of the proof",
+                    "type": "string"
+                },
+                "cryptosuite": {
+                    "description": "Cryptosuite identifies the cryptographic suite used\nSupported: eddsa-rdfc-2022, ecdsa-rdfc-2019, ecdsa-sd-2023, eddsa-jcs-2022, ecdsa-jcs-2019",
+                    "type": "string",
+                    "enum": [
+                        "eddsa-rdfc-2022",
+                        "ecdsa-rdfc-2019",
+                        "ecdsa-sd-2023",
+                        "eddsa-jcs-2022",
+                        "ecdsa-jcs-2019"
+                    ]
+                },
+                "domain": {
+                    "description": "Domain MUST be the Credential Issuer Identifier",
+                    "type": "string"
+                },
+                "proofPurpose": {
+                    "description": "ProofPurpose MUST be \"authentication\" for OpenID4VCI",
+                    "type": "string"
+                },
+                "proofValue": {
+                    "description": "ProofValue is the actual proof signature value",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type is the proof type, e.g., \"DataIntegrityProof\"",
+                    "type": "string"
+                },
+                "verificationMethod": {
+                    "description": "VerificationMethod is a URL that identifies the public key to use for verification",
+                    "type": "string"
                 }
             }
         },
@@ -1430,7 +1429,6 @@
             "type": "object",
             "required": [
                 "crv",
-                "d",
                 "kid",
                 "kty",
                 "x",
@@ -1438,9 +1436,6 @@
             ],
             "properties": {
                 "crv": {
-                    "type": "string"
-                },
-                "d": {
                     "type": "string"
                 },
                 "kid": {
@@ -1463,23 +1458,96 @@
                 "proof_type"
             ],
             "properties": {
-                "attestation": {
+                "cwt": {
+                    "description": "CWT The CWT proof, when proof_type is \"cwt\"",
                     "type": "string"
                 },
                 "jwt": {
+                    "description": "JWT The JWT proof, when proof_type is \"jwt\"",
                     "type": "string"
                 },
                 "ldp_vp": {
-                    "type": "string"
+                    "description": "LDPVp The Linked Data Proof VP, when proof_type is \"ldp_vp\""
                 },
                 "proof_type": {
-                    "description": "ProofType REQUIRED. String denoting the key proof type. The value of this parameter determines other parameters in the key proof object and its respective processing rules. Key proof types defined in this specification can be found in Section 7.2.1.",
-                    "type": "string",
-                    "enum": [
-                        "jwt",
-                        "ldp_vp",
-                        "cwt"
+                    "description": "ProofType REQUIRED. String denoting the key proof type.",
+                    "type": "string"
+                }
+            }
+        },
+        "openid4vci.ProofDIVP": {
+            "type": "object",
+            "required": [
+                "@context",
+                "type"
+            ],
+            "properties": {
+                "@context": {
+                    "description": "Context is the JSON-LD context, REQUIRED per W3C VC Data Model",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "holder": {
+                    "description": "Holder is the DID of the holder",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID is an optional identifier for the presentation",
+                    "type": "string"
+                },
+                "proof": {
+                    "description": "Proof contains the Data Integrity Proof(s), one of Proof or Proofs REQUIRED",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/openid4vci.DIVPProof"
+                        }
                     ]
+                },
+                "proofs": {
+                    "description": "Proofs contains multiple Data Integrity Proofs if more than one is present",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openid4vci.DIVPProof"
+                    }
+                },
+                "type": {
+                    "description": "Type is the type of the presentation, REQUIRED, must include \"VerifiablePresentation\"",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "verifiableCredential": {
+                    "description": "VerifiableCredential contains the credentials being presented",
+                    "type": "array",
+                    "items": {}
+                }
+            }
+        },
+        "openid4vci.Proofs": {
+            "type": "object",
+            "properties": {
+                "attestation": {
+                    "description": "Attestation contains a single JWT representing a key attestation\nas defined in Appendix D.1",
+                    "type": "string"
+                },
+                "di_vp": {
+                    "description": "DIVP contains an array of W3C Verifiable Presentations\nsigned using Data Integrity Proof as defined in Appendix F.2",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openid4vci.ProofDIVP"
+                    }
+                },
+                "jwt": {
+                    "description": "JWT contains an array of JWTs as defined in Appendix F.1",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -1490,6 +1558,33 @@
                     "type": "string"
                 },
                 "qr_base64": {
+                    "type": "string"
+                }
+            }
+        },
+        "vcclient.NotificationReply": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/openid4vci.QR"
+                }
+            }
+        },
+        "vcclient.NotificationRequest": {
+            "type": "object",
+            "required": [
+                "authentic_source",
+                "document_id",
+                "vct"
+            ],
+            "properties": {
+                "authentic_source": {
+                    "type": "string"
+                },
+                "document_id": {
+                    "type": "string"
+                },
+                "vct": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.yaml
+++ b/docs/apigw/swagger.yaml
@@ -3,16 +3,22 @@ definitions:
   apiv1.AddConsentRequest:
     properties:
       authentic_source:
+        maxLength: 128
         type: string
       authentic_source_person_id:
+        maxLength: 128
         type: string
       consent_to:
+        maxLength: 128
         type: string
       session_id:
+        maxLength: 128
         type: string
     required:
     - authentic_source
     - authentic_source_person_id
+    - consent_to
+    - session_id
     type: object
   apiv1.AddDocumentIdentityRequest:
     properties:
@@ -116,8 +122,10 @@ definitions:
   apiv1.GetConsentRequest:
     properties:
       authentic_source:
+        maxLength: 128
         type: string
       authentic_source_person_id:
+        maxLength: 128
         type: string
     required:
     - authentic_source
@@ -162,6 +170,67 @@ definitions:
     - document_id
     - vct
     type: object
+  apiv1.IdentityMappingIdentity:
+    properties:
+      birth_date:
+        type: string
+      birth_family_name:
+        maxLength: 100
+        minLength: 1
+        type: string
+      birth_given_name:
+        maxLength: 100
+        minLength: 1
+        type: string
+      birth_place:
+        maxLength: 100
+        minLength: 2
+        type: string
+      email_address:
+        type: string
+      family_name:
+        maxLength: 100
+        minLength: 1
+        type: string
+      given_name:
+        maxLength: 100
+        minLength: 1
+        type: string
+      issuing_authority:
+        type: string
+      issuing_country:
+        type: string
+      mobile_phone_number:
+        type: string
+      nationality:
+        items:
+          type: string
+        type: array
+      personal_administrative_number:
+        maxLength: 50
+        minLength: 4
+        type: string
+      schema:
+        $ref: '#/definitions/model.IdentitySchema'
+      sex:
+        enum:
+        - "0"
+        - "1"
+        - "2"
+        - "3"
+        - "4"
+        - "5"
+        - "6"
+        - "7"
+        - "8"
+        - "9"
+        type: string
+    required:
+    - birth_date
+    - family_name
+    - given_name
+    - schema
+    type: object
   apiv1.IdentityMappingReply:
     properties:
       data:
@@ -173,30 +242,13 @@ definitions:
         description: |-
           required: true
           example: SUNET
+        maxLength: 128
         type: string
       identity:
-        $ref: '#/definitions/model.Identity'
+        $ref: '#/definitions/apiv1.IdentityMappingIdentity'
     required:
     - authentic_source
     - identity
-    type: object
-  apiv1.NotificationReply:
-    properties:
-      data:
-        $ref: '#/definitions/openid4vci.QR'
-    type: object
-  apiv1.NotificationRequest:
-    properties:
-      authentic_source:
-        type: string
-      document_id:
-        type: string
-      vct:
-        type: string
-    required:
-    - authentic_source
-    - document_id
-    - vct
     type: object
   apiv1.RevokeDocumentRequest:
     properties:
@@ -211,64 +263,10 @@ definitions:
     - revocation
     - vct
     type: object
-  apiv1.RevokeReply:
-    properties:
-      data:
-        properties:
-          status:
-            type: boolean
-        type: object
-    type: object
-  apiv1.RevokeRequest:
-    properties:
-      authentic_source:
-        type: string
-      document_id:
-        type: string
-      revocation_id:
-        type: string
-      vct:
-        type: string
-    type: object
   apiv1_issuer.Credential:
     properties:
       credential:
         type: string
-    type: object
-  apiv1_issuer.Jwk:
-    properties:
-      crv:
-        type: string
-      d:
-        type: string
-      ext:
-        type: boolean
-      key_ops:
-        items:
-          type: string
-        type: array
-      kid:
-        type: string
-      kty:
-        type: string
-      x:
-        type: string
-      "y":
-        type: string
-    type: object
-  apiv1_issuer.JwksReply:
-    properties:
-      issuer:
-        type: string
-      jwks:
-        $ref: '#/definitions/apiv1_issuer.Keys'
-    type: object
-  apiv1_issuer.Keys:
-    properties:
-      keys:
-        items:
-          $ref: '#/definitions/apiv1_issuer.Jwk'
-        type: array
     type: object
   apiv1_issuer.MakeSDJWTReply:
     properties:
@@ -276,6 +274,12 @@ definitions:
         items:
           $ref: '#/definitions/apiv1_issuer.Credential'
         type: array
+      token_status_list_index:
+        description: Token Status List index
+        type: integer
+      token_status_list_section:
+        description: Token Status List section
+        type: integer
     type: object
   helpers.Error:
     properties:
@@ -294,6 +298,7 @@ definitions:
         description: |-
           required: false
           example: 98fe67fc-c03f-11ee-bbee-4345224d414f
+        maxLength: 128
         type: string
       valid_until:
         description: |-
@@ -308,6 +313,7 @@ definitions:
         description: |-
           required: true
           example: "Using my data for research"
+        maxLength: 128
         type: string
       created_at:
         description: |-
@@ -319,6 +325,7 @@ definitions:
         description: |-
           required: true
           example: "sess-123"
+        maxLength: 128
         type: string
     required:
     - consent_to
@@ -373,6 +380,7 @@ definitions:
   model.IDMapping:
     properties:
       authentic_source_person_id:
+        maxLength: 128
         type: string
     type: object
   model.Identity:
@@ -395,6 +403,7 @@ definitions:
         description: |-
           required: true
           example: 65636cbc-c03f-11ee-8dc4-67135cc9bd8a
+        maxLength: 128
         type: string
       birth_date:
         description: |-
@@ -420,6 +429,7 @@ definitions:
         description: |-
           required: false
           example:
+        maxLength: 128
         type: string
       email_address:
         description: |-
@@ -461,6 +471,7 @@ definitions:
         description: |-
           required: false
           example:
+        maxLength: 128
         type: string
       mobile_phone_number:
         description: |-
@@ -542,8 +553,10 @@ definitions:
         - "9"
         type: string
       trust_anchor:
+        maxLength: 128
         type: string
     required:
+    - authentic_source_person_id
     - birth_date
     - family_name
     - given_name
@@ -555,6 +568,7 @@ definitions:
         description: |-
           required: true
           example: "SE"
+        maxLength: 128
         type: string
       version:
         description: |-
@@ -570,6 +584,7 @@ definitions:
         description: |-
           required: true
           example: SUNET
+        maxLength: 128
         type: string
       collect:
         $ref: '#/definitions/model.Collect'
@@ -590,11 +605,13 @@ definitions:
           required: false
           example: file://path/to/schema.json or http://example.com/schema.json
           format: string
+        maxLength: 128
         type: string
       document_id:
         description: |-
           required: true
           example: 5e7a981c-c03f-11ee-b116-9b12c59362b9
+        maxLength: 128
         type: string
       document_version:
         description: |-
@@ -611,16 +628,25 @@ definitions:
         allOf:
         - $ref: '#/definitions/model.Revocation'
         description: Revocation is a collection of fields representing a revocation
+      scope:
+        description: |-
+          Scope is the credential configuration ID scope
+          required: false
+          example: "ehic", "pda1"
+        maxLength: 128
+        type: string
       vct:
         description: |-
           VCT is the Verifiable Credential Type
           required: true
           example: "urn:eudi:pid:1"
+        maxLength: 128
         type: string
     required:
     - authentic_source
     - document_id
     - document_version
+    - scope
     - vct
     type: object
   model.Revocation:
@@ -630,12 +656,14 @@ definitions:
           ID is the ID of the revocation
           required: false
           example: 8dbd2680-c03f-11ee-a21b-034aafe41222
+        maxLength: 128
         type: string
       reason:
         description: |-
           Reason is the reason for revocation
           required: false
           example: lost or stolen
+        maxLength: 128
         type: string
       reference:
         $ref: '#/definitions/model.RevocationReference'
@@ -656,80 +684,126 @@ definitions:
   model.RevocationReference:
     properties:
       authentic_source:
+        maxLength: 128
         type: string
       document_id:
+        maxLength: 128
         type: string
       vct:
+        maxLength: 128
         type: string
     type: object
   openid4vci.CredentialRequest:
     properties:
+      authorization:
+        type: string
+      credential_configuration_id:
+        description: |-
+          CredentialConfigurationID REQUIRED if a credential_identifiers parameter was not returned from
+          the Token Response as part of the authorization_details parameter. It MUST NOT be used otherwise.
+          String that uniquely identifies one of the keys in the name/value pairs stored in the
+          credential_configurations_supported Credential Issuer metadata. When this parameter is used,
+          the credential_identifier MUST NOT be present.
+        type: string
       credential_identifier:
-        description: REQUIRED when credential_identifiers parameter was returned from
-          the Token Response. It MUST NOT be used otherwise. It is a String that identifies
-          a Credential that is being requested to be issued. When this parameter is
-          used, the format parameter and any other Credential format specific parameters
-          such as those defined in Appendix A MUST NOT be present.
+        description: |-
+          CredentialIdentifier REQUIRED when an Authorization Details of type openid_credential was returned
+          from the Token Response. It MUST NOT be used otherwise. A string that identifies a Credential Dataset
+          that is requested for issuance. When this parameter is used, the credential_configuration_id MUST NOT be present.
         type: string
       credential_response_encryption:
         allOf:
         - $ref: '#/definitions/openid4vci.CredentialResponseEncryption'
-        description: CredentialIdentifier REQUIRED when credential_identifiers parameter
-          was returned from the Token Response. It MUST NOT be used otherwise. It
-          is a String that identifies a Credential that is being requested to be issued.
-          When this parameter is used, the format parameter and any other Credential
-          format specific parameters such as those defined in Appendix A MUST NOT
-          be present.
-      format:
-        description: Format REQUIRED when the credential_identifiers parameter was
-          not returned from the Token Response. It MUST NOT be used otherwise. It
-          is a String that determines the format of the Credential to be issued, which
-          may determine the type and any other information related to the Credential
-          to be issued. Credential Format Profiles consist of the Credential format
-          specific parameters that are defined in Appendix A. When this parameter
-          is used, the credential_identifier Credential Request parameter MUST NOT
-          be present.
+        description: |-
+          CredentialResponseEncryption OPTIONAL. Object containing information for encrypting the Credential Response.
+          If this request element is not present, the corresponding credential response returned is not encrypted.
+      dpoP:
+        description: Header fields
         type: string
-      headers:
-        $ref: '#/definitions/openid4vci.CredentialRequestHeader'
       proof:
         allOf:
         - $ref: '#/definitions/openid4vci.Proof'
-        description: 'Proof OPTIONAL. Object containing the proof of possession of
-          the cryptographic key material the issued Credential would be bound to.
-          The proof object is REQUIRED if the proof_types_supported parameter is non-empty
-          and present in the credential_configurations_supported parameter of the
-          Issuer metadata for the requested Credential. The proof object MUST contain
-          the following:'
-    type: object
-  openid4vci.CredentialRequestHeader:
-    properties:
-      authorization:
-        type: string
-      dpoP:
-        type: string
+        description: |-
+          Proof OPTIONAL. Single proof object for non-batch requests.
+          Deprecated: Use Proofs instead. This field is kept for backward compatibility with older wallets.
+      proofs:
+        allOf:
+        - $ref: '#/definitions/openid4vci.Proofs'
+        description: |-
+          Proofs OPTIONAL. Object providing one or more proof of possessions of the cryptographic key material
+          to which the issued Credential instances will be bound to. The proofs parameter contains exactly one
+          parameter named as the proof type in Appendix F, the value set for this parameter is a non-empty array
+          containing parameters as defined by the corresponding proof type.
     required:
     - authorization
     - dpoP
     type: object
   openid4vci.CredentialResponseEncryption:
     properties:
-      alg:
-        type: string
       enc:
+        description: Enc REQUIRED. JWE enc algorithm for encrypting Credential Responses.
         type: string
       jwk:
-        $ref: '#/definitions/openid4vci.JWK'
+        allOf:
+        - $ref: '#/definitions/openid4vci.JWK'
+        description: JWK REQUIRED. Object containing a single public key as a JWK
+          used for encrypting the Credential Response.
+      zip:
+        description: |-
+          Zip OPTIONAL. JWE zip algorithm for compressing Credential Responses prior to encryption.
+          If absent then compression MUST not be used.
+        type: string
     required:
-    - alg
     - enc
     - jwk
+    type: object
+  openid4vci.DIVPProof:
+    properties:
+      challenge:
+        description: Challenge MUST be the c_nonce value provided by the Credential
+          Issuer (when provided)
+        type: string
+      created:
+        description: Created is the creation time of the proof
+        type: string
+      cryptosuite:
+        description: |-
+          Cryptosuite identifies the cryptographic suite used
+          Supported: eddsa-rdfc-2022, ecdsa-rdfc-2019, ecdsa-sd-2023, eddsa-jcs-2022, ecdsa-jcs-2019
+        enum:
+        - eddsa-rdfc-2022
+        - ecdsa-rdfc-2019
+        - ecdsa-sd-2023
+        - eddsa-jcs-2022
+        - ecdsa-jcs-2019
+        type: string
+      domain:
+        description: Domain MUST be the Credential Issuer Identifier
+        type: string
+      proofPurpose:
+        description: ProofPurpose MUST be "authentication" for OpenID4VCI
+        type: string
+      proofValue:
+        description: ProofValue is the actual proof signature value
+        type: string
+      type:
+        description: Type is the proof type, e.g., "DataIntegrityProof"
+        type: string
+      verificationMethod:
+        description: VerificationMethod is a URL that identifies the public key to
+          use for verification
+        type: string
+    required:
+    - cryptosuite
+    - domain
+    - proofPurpose
+    - proofValue
+    - type
+    - verificationMethod
     type: object
   openid4vci.JWK:
     properties:
       crv:
-        type: string
-      d:
         type: string
       kid:
         type: string
@@ -741,7 +815,6 @@ definitions:
         type: string
     required:
     - crv
-    - d
     - kid
     - kty
     - x
@@ -749,24 +822,79 @@ definitions:
     type: object
   openid4vci.Proof:
     properties:
-      attestation:
+      cwt:
+        description: CWT The CWT proof, when proof_type is "cwt"
         type: string
       jwt:
+        description: JWT The JWT proof, when proof_type is "jwt"
         type: string
       ldp_vp:
-        type: string
+        description: LDPVp The Linked Data Proof VP, when proof_type is "ldp_vp"
       proof_type:
-        description: ProofType REQUIRED. String denoting the key proof type. The value
-          of this parameter determines other parameters in the key proof object and
-          its respective processing rules. Key proof types defined in this specification
-          can be found in Section 7.2.1.
-        enum:
-        - jwt
-        - ldp_vp
-        - cwt
+        description: ProofType REQUIRED. String denoting the key proof type.
         type: string
     required:
     - proof_type
+    type: object
+  openid4vci.ProofDIVP:
+    properties:
+      '@context':
+        description: Context is the JSON-LD context, REQUIRED per W3C VC Data Model
+        items:
+          type: string
+        minItems: 1
+        type: array
+      holder:
+        description: Holder is the DID of the holder
+        type: string
+      id:
+        description: ID is an optional identifier for the presentation
+        type: string
+      proof:
+        allOf:
+        - $ref: '#/definitions/openid4vci.DIVPProof'
+        description: Proof contains the Data Integrity Proof(s), one of Proof or Proofs
+          REQUIRED
+      proofs:
+        description: Proofs contains multiple Data Integrity Proofs if more than one
+          is present
+        items:
+          $ref: '#/definitions/openid4vci.DIVPProof'
+        type: array
+      type:
+        description: Type is the type of the presentation, REQUIRED, must include
+          "VerifiablePresentation"
+        items:
+          type: string
+        minItems: 1
+        type: array
+      verifiableCredential:
+        description: VerifiableCredential contains the credentials being presented
+        items: {}
+        type: array
+    required:
+    - '@context'
+    - type
+    type: object
+  openid4vci.Proofs:
+    properties:
+      attestation:
+        description: |-
+          Attestation contains a single JWT representing a key attestation
+          as defined in Appendix D.1
+        type: string
+      di_vp:
+        description: |-
+          DIVP contains an array of W3C Verifiable Presentations
+          signed using Data Integrity Proof as defined in Appendix F.2
+        items:
+          $ref: '#/definitions/openid4vci.ProofDIVP'
+        type: array
+      jwt:
+        description: JWT contains an array of JWTs as defined in Appendix F.1
+        items:
+          type: string
+        type: array
     type: object
   openid4vci.QR:
     properties:
@@ -774,6 +902,24 @@ definitions:
         type: string
       qr_base64:
         type: string
+    type: object
+  vcclient.NotificationReply:
+    properties:
+      data:
+        $ref: '#/definitions/openid4vci.QR'
+    type: object
+  vcclient.NotificationRequest:
+    properties:
+      authentic_source:
+        type: string
+      document_id:
+        type: string
+      vct:
+        type: string
+    required:
+    - authentic_source
+    - document_id
+    - vct
     type: object
   vcclient.UploadRequest:
     properties:
@@ -876,27 +1022,7 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/helpers.ErrorResponse'
-      summary: OIDCCredential
-      tags:
-      - vc-platform
-  /credential/.well-known/jwks:
-    get:
-      consumes:
-      - application/json
-      description: JWKS endpoint
-      operationId: issuer-JWKS
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Success
-          schema:
-            $ref: '#/definitions/apiv1_issuer.JwksReply'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/helpers.ErrorResponse'
-      summary: JWKS
+      summary: VCICredential
       tags:
       - vc-platform
   /document:
@@ -1117,46 +1243,19 @@ paths:
         name: req
         required: true
         schema:
-          $ref: '#/definitions/apiv1.NotificationRequest'
+          $ref: '#/definitions/vcclient.NotificationRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Success
           schema:
-            $ref: '#/definitions/apiv1.NotificationReply'
+            $ref: '#/definitions/vcclient.NotificationReply'
         "400":
           description: Bad Request
           schema:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: Notification
-      tags:
-      - vc-platform
-  /revoke:
-    post:
-      consumes:
-      - application/json
-      description: Revoke endpoint
-      operationId: generic-revoke
-      parameters:
-      - description: ' '
-        in: body
-        name: req
-        required: true
-        schema:
-          $ref: '#/definitions/apiv1.RevokeRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Success
-          schema:
-            $ref: '#/definitions/apiv1.RevokeReply'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/helpers.ErrorResponse'
-      summary: Revoke
       tags:
       - vc-platform
   /upload:

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -180,16 +180,16 @@ type IdentityMappingIdentity struct {
 	GivenName  string `json:"given_name" validate:"required,min=1,max=100,printascii"`
 	BirthDate  string `json:"birth_date" validate:"required,datetime=2006-01-02,printascii"`
 
-	BirthPlace                  string   `json:"birth_place,omitempty" validate:"omitempty,min=2,max=100,printascii"`
-	Nationality                 []string `json:"nationality,omitempty" validate:"omitempty,dive,iso3166_1_alpha2"`
-	PersonalAdministrativeNumber string  `json:"personal_administrative_number,omitempty" validate:"omitempty,min=4,max=50,printascii"`
-	BirthFamilyName             string   `json:"birth_family_name,omitempty" validate:"omitempty,min=1,max=100,printascii"`
-	BirthGivenName              string   `json:"birth_given_name,omitempty" validate:"omitempty,min=1,max=100,printascii"`
-	Sex                         string   `json:"sex,omitempty" validate:"omitempty,oneof=0 1 2 3 4 5 6 7 8 9"`
-	EmailAddress                string   `json:"email_address,omitempty" validate:"omitempty,email"`
-	MobilePhoneNumber           string   `json:"mobile_phone_number,omitempty" validate:"omitempty,e164"`
-	IssuingAuthority            string   `json:"issuing_authority,omitempty" validate:"omitempty,printascii"`
-	IssuingCountry              string   `json:"issuing_country,omitempty" validate:"omitempty,iso3166_1_alpha2"`
+	BirthPlace                   string   `json:"birth_place,omitempty" validate:"omitempty,min=2,max=100,printascii"`
+	Nationality                  []string `json:"nationality,omitempty" validate:"omitempty,dive,iso3166_1_alpha2"`
+	PersonalAdministrativeNumber string   `json:"personal_administrative_number,omitempty" validate:"omitempty,min=4,max=50,printascii"`
+	BirthFamilyName              string   `json:"birth_family_name,omitempty" validate:"omitempty,min=1,max=100,printascii"`
+	BirthGivenName               string   `json:"birth_given_name,omitempty" validate:"omitempty,min=1,max=100,printascii"`
+	Sex                          string   `json:"sex,omitempty" validate:"omitempty,oneof=0 1 2 3 4 5 6 7 8 9"`
+	EmailAddress                 string   `json:"email_address,omitempty" validate:"omitempty,email"`
+	MobilePhoneNumber            string   `json:"mobile_phone_number,omitempty" validate:"omitempty,e164"`
+	IssuingAuthority             string   `json:"issuing_authority,omitempty" validate:"omitempty,printascii"`
+	IssuingCountry               string   `json:"issuing_country,omitempty" validate:"omitempty,iso3166_1_alpha2"`
 }
 
 // IdentityMappingRequest is the request for IDMapping

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"time"
+
 	"github.com/SUNET/vc/internal/apigw/db"
 	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/model"
@@ -169,12 +170,34 @@ func (c *Client) Notification(ctx context.Context, req *vcclient.NotificationReq
 	return reply, nil
 }
 
+// IdentityMappingIdentity is the identity input for the mapping endpoint.
+// Unlike model.Identity, authentic_source_person_id is not required here because
+// the purpose of identity mapping is to look it up from the other identity fields.
+type IdentityMappingIdentity struct {
+	Schema *model.IdentitySchema `json:"schema" validate:"required"`
+
+	FamilyName string `json:"family_name" validate:"required,min=1,max=100,printascii"`
+	GivenName  string `json:"given_name" validate:"required,min=1,max=100,printascii"`
+	BirthDate  string `json:"birth_date" validate:"required,datetime=2006-01-02,printascii"`
+
+	BirthPlace                  string   `json:"birth_place,omitempty" validate:"omitempty,min=2,max=100,printascii"`
+	Nationality                 []string `json:"nationality,omitempty" validate:"omitempty,dive,iso3166_1_alpha2"`
+	PersonalAdministrativeNumber string  `json:"personal_administrative_number,omitempty" validate:"omitempty,min=4,max=50,printascii"`
+	BirthFamilyName             string   `json:"birth_family_name,omitempty" validate:"omitempty,min=1,max=100,printascii"`
+	BirthGivenName              string   `json:"birth_given_name,omitempty" validate:"omitempty,min=1,max=100,printascii"`
+	Sex                         string   `json:"sex,omitempty" validate:"omitempty,oneof=0 1 2 3 4 5 6 7 8 9"`
+	EmailAddress                string   `json:"email_address,omitempty" validate:"omitempty,email"`
+	MobilePhoneNumber           string   `json:"mobile_phone_number,omitempty" validate:"omitempty,e164"`
+	IssuingAuthority            string   `json:"issuing_authority,omitempty" validate:"omitempty,printascii"`
+	IssuingCountry              string   `json:"issuing_country,omitempty" validate:"omitempty,iso3166_1_alpha2"`
+}
+
 // IdentityMappingRequest is the request for IDMapping
 type IdentityMappingRequest struct {
 	// required: true
 	// example: SUNET
-	AuthenticSource string          `json:"authentic_source" validate:"required,max=128,printascii"`
-	Identity        *model.Identity `json:"identity" validate:"required"`
+	AuthenticSource string                   `json:"authentic_source" validate:"required,max=128,printascii"`
+	Identity        *IdentityMappingIdentity `json:"identity" validate:"required"`
 }
 
 // IdentityMappingReply is the reply for a IDMapping
@@ -195,9 +218,25 @@ type IdentityMappingReply struct {
 //	@Param			req	body		IdentityMappingRequest	true	" "
 //	@Router			/identity/mapping [post]
 func (c *Client) IdentityMapping(ctx context.Context, reg *IdentityMappingRequest) (*IdentityMappingReply, error) {
+	identity := &model.Identity{
+		Schema:                       reg.Identity.Schema,
+		FamilyName:                   reg.Identity.FamilyName,
+		GivenName:                    reg.Identity.GivenName,
+		BirthDate:                    reg.Identity.BirthDate,
+		BirthPlace:                   reg.Identity.BirthPlace,
+		Nationality:                  reg.Identity.Nationality,
+		PersonalAdministrativeNumber: reg.Identity.PersonalAdministrativeNumber,
+		BirthFamilyName:              reg.Identity.BirthFamilyName,
+		BirthGivenName:               reg.Identity.BirthGivenName,
+		Sex:                          reg.Identity.Sex,
+		EmailAddress:                 reg.Identity.EmailAddress,
+		MobilePhoneNumber:            reg.Identity.MobilePhoneNumber,
+		IssuingAuthority:             reg.Identity.IssuingAuthority,
+		IssuingCountry:               reg.Identity.IssuingCountry,
+	}
 	authenticSourcePersonID, err := c.datastoreStore.IDMapping(ctx, &db.IDMappingQuery{
 		AuthenticSource: reg.AuthenticSource,
-		Identity:        reg.Identity,
+		Identity:        identity,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/apigw/db/methods_vc_datastore.go
+++ b/internal/apigw/db/methods_vc_datastore.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+
 	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
@@ -73,16 +74,54 @@ type IDMappingQuery struct {
 
 // IDMapping return authentic source person id if any
 func (c *VCDatastoreColl) IDMapping(ctx context.Context, query *IDMappingQuery) (string, error) {
+	// Build an $elemMatch filter so all identity predicates must match
+	// the same array element, preventing cross-element false positives.
+	identityMatch := bson.M{
+		"schema.version": bson.M{"$eq": query.Identity.Schema.Version},
+		"family_name":    bson.M{"$eq": query.Identity.FamilyName},
+		"given_name":     bson.M{"$eq": query.Identity.GivenName},
+		"birth_date":     bson.M{"$eq": query.Identity.BirthDate},
+	}
+
+	// Add optional identity fields to narrow the match when provided
+	if query.Identity.BirthPlace != "" {
+		identityMatch["birth_place"] = bson.M{"$eq": query.Identity.BirthPlace}
+	}
+	if len(query.Identity.Nationality) > 0 {
+		identityMatch["nationality"] = bson.M{"$all": query.Identity.Nationality}
+	}
+	if query.Identity.PersonalAdministrativeNumber != "" {
+		identityMatch["personal_administrative_number"] = bson.M{"$eq": query.Identity.PersonalAdministrativeNumber}
+	}
+	if query.Identity.BirthFamilyName != "" {
+		identityMatch["birth_family_name"] = bson.M{"$eq": query.Identity.BirthFamilyName}
+	}
+	if query.Identity.BirthGivenName != "" {
+		identityMatch["birth_given_name"] = bson.M{"$eq": query.Identity.BirthGivenName}
+	}
+	if query.Identity.Sex != "" {
+		identityMatch["sex"] = bson.M{"$eq": query.Identity.Sex}
+	}
+	if query.Identity.EmailAddress != "" {
+		identityMatch["email_address"] = bson.M{"$eq": query.Identity.EmailAddress}
+	}
+	if query.Identity.MobilePhoneNumber != "" {
+		identityMatch["mobile_phone_number"] = bson.M{"$eq": query.Identity.MobilePhoneNumber}
+	}
+	if query.Identity.IssuingAuthority != "" {
+		identityMatch["issuing_authority"] = bson.M{"$eq": query.Identity.IssuingAuthority}
+	}
+	if query.Identity.IssuingCountry != "" {
+		identityMatch["issuing_country"] = bson.M{"$eq": query.Identity.IssuingCountry}
+	}
+
 	filter := bson.M{
-		"meta.authentic_source":     bson.M{"$eq": query.AuthenticSource},
-		"identities.schema.version": bson.M{"$eq": query.Identity.Schema.Version},
-		"identities.family_name":    bson.M{"$eq": query.Identity.FamilyName},
-		"identities.given_name":     bson.M{"$eq": query.Identity.GivenName},
-		"identities.birth_date":     bson.M{"$eq": query.Identity.BirthDate},
+		"meta.authentic_source": bson.M{"$eq": query.AuthenticSource},
+		"identities":            bson.M{"$elemMatch": identityMatch},
 	}
 
 	opts := options.FindOne().SetProjection(bson.M{
-		"identities.authentic_source_person_id": 1,
+		"identities.$": 1,
 	})
 	res := &model.CompleteDocument{}
 	if err := c.Coll.FindOne(ctx, filter, opts).Decode(&res); err != nil {


### PR DESCRIPTION
The `POST /api/v1/identity/mapping` endpoint reused `model.Identity` which marks `authentic_source_person_id` and `schema` as required via validation tags. However, `authentic_source_person_id` is the **output** of this endpoint — requiring it in the request is contradictory.

This creates a dedicated `IdentityMappingIdentity` struct for the mapping request with:
- **Required fields**: `schema`, `family_name`, `given_name`, `birth_date`
- **Optional fields** (for narrowing matches): `birth_place`, `nationality`, `personal_administrative_number`, `birth_family_name`, `birth_given_name`, `sex`, `email_address`, `mobile_phone_number`, `issuing_authority`, `issuing_country`

The handler converts `IdentityMappingIdentity` → `model.Identity` internally before passing to the datastore.

The MongoDB query now uses `$elemMatch` to ensure all identity predicates match the same array element (preventing cross-element false positives), and uses `$all` for nationality matching. Optional fields are included in the filter only when provided.

Regenerated swagger docs to reflect the new request type.

Reported by SKV during integration testing — the documented example (without `authentic_source_person_id`) was returning a validation error.