### PR TITLE
feat: add TS11 schema-meta for eduID and disable auto-publish workflow

### DIFF
--- a/.github/workflows/vctm.yml
+++ b/.github/workflows/vctm.yml
@@ -1,10 +1,8 @@
 name: Update VCTM
 
+# Disabled: registry-cli now handles credential discovery centrally.
+# The vctm branch is maintained directly. To regenerate, run manually.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'credentials/**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/credentials/eduid.schema-meta.yaml
+++ b/credentials/eduid.schema-meta.yaml
@@ -1,0 +1,6 @@
+attestation_los: iso_18045_high
+binding_type: key
+trusted_authorities:
+  - framework_type: eidas
+    value: "https://eidas.ec.europa.eu"
+    is_lote: false


### PR DESCRIPTION
## Summary

Upgrades the eduID credential to ETSI TS11 compliance by adding a `schema-meta.yaml` file and disables the per-repo VCTM auto-publish workflow.

## Changes

### TS11 Schema Metadata (`credentials/eduid.schema-meta.yaml`)

Adds TS11-required metadata for the eduID credential:
- **attestation_los**: `iso_18045_high` — high assurance identity credential
- **binding_type**: `key` — cryptographic key binding
- **trusted_authorities**: eIDAS trust framework reference

This enables `registry-cli` to classify the eduID credential as TS11-compliant in the [SIROS Credential Registry](https://registry.siros.org).

### Workflow changes (`.github/workflows/vctm.yml`)

The automatic push-on-change trigger has been replaced with `workflow_dispatch` only. This is because:
- The centralized [registry-cli](https://github.com/sirosfoundation/registry-cli) now handles credential discovery and registry generation
- Per-repo VCTM branch publishing is no longer the primary discovery mechanism
- The workflow remains available for manual invocation if the vctm branch needs updating

## Background

The SIROS Credential Registry has migrated to a centralized build pipeline using `registry-cli`, which discovers credentials from source repositories via `sources.yaml`. TS11 compliance requires each credential to have a `schema-meta.yaml` file declaring attestation level of security, binding type, and trust framework references (per ETSI TS 119 612 §4.3).

See: https://registry.siros.org/docs/ts11.html