### PR TITLE
fix: make VPResponse.VPToken spec-compliant (map[string][]string)

### DIFF
--- a/internal/apigw/apiv1/handlers_verifier.go
+++ b/internal/apigw/apiv1/handlers_verifier.go
@@ -211,11 +211,12 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 	}
 
 	// Extract VP Token from the map using the credential query ID
-	vpToken, ok := vpResponse.VPToken[credQueryID]
-	if !ok {
+	vpTokens, ok := vpResponse.VPToken[credQueryID]
+	if !ok || len(vpTokens) == 0 {
 		c.log.Error(nil, "VP Token not found for credential query", "query_id", credQueryID, "available_keys", vpResponse.VPToken)
 		return nil, fmt.Errorf("VP Token not found for credential query: %s", credQueryID)
 	}
+	vpToken := vpTokens[0]
 
 	// Prepare response parameters
 	responseParams := &openid4vp.ResponseParameters{

--- a/internal/verifier/apiv1/handlers_verification.go
+++ b/internal/verifier/apiv1/handlers_verification.go
@@ -139,11 +139,12 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 	credentialCaches := make([]sdjwtvc.CredentialCache, 0, len(authCtx.Scopes))
 
 	for _, scope := range authCtx.Scopes {
-		vpToken, ok := vpResponse.VPToken[scope]
-		if !ok {
+		vpTokens, ok := vpResponse.VPToken[scope]
+		if !ok || len(vpTokens) == 0 {
 			c.log.Error(nil, "VP token not found for scope", "scope", scope)
 			return nil, fmt.Errorf("VP token not found for scope: %s", scope)
 		}
+		vpToken := vpTokens[0]
 
 		responseParams := &openid4vp.ResponseParameters{}
 		responseParams.State = vpResponse.State

--- a/pkg/openid4vp/response_parameters.go
+++ b/pkg/openid4vp/response_parameters.go
@@ -8,8 +8,8 @@ import (
 )
 
 type VPResponse struct {
-	VPToken map[string]string `json:"vp_token,omitempty" bson:"vp_token" validate:"required"`
-	State   string            `json:"state,omitempty" bson:"state" validate:"required"`
+	VPToken map[string][]string `json:"vp_token,omitempty" bson:"vp_token" validate:"required"`
+	State   string              `json:"state,omitempty" bson:"state" validate:"required"`
 }
 
 type ResponseParameters struct {

--- a/pkg/openid4vp/response_parameters_additional_test.go
+++ b/pkg/openid4vp/response_parameters_additional_test.go
@@ -224,9 +224,9 @@ func TestResponseParameters_RoundTrip(t *testing.T) {
 func TestVPResponse(t *testing.T) {
 	t.Run("create and marshal", func(t *testing.T) {
 		vpResp := VPResponse{
-			VPToken: map[string]string{
-				"credential_1": "token1",
-				"credential_2": "token2",
+			VPToken: map[string][]string{
+				"credential_1": {"token1"},
+				"credential_2": {"token2"},
 			},
 			State: "test-state",
 		}


### PR DESCRIPTION
## Summary

`VPResponse.VPToken` was typed as `map[string]string`, but the [OID4VP 1.0 spec (§8.1)](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-8.1) requires each `vp_token` value to be an **array** of presentations.

When a spec-compliant wallet sends `{"vp_token": {"pid_1_5": ["eyJ..."]}}`, `json.Unmarshal` silently drops the entry because it cannot coerce `[]string` into `string`, leaving the map empty and causing downstream **"VP Token not found"** errors.

## Changes

1. **`response_parameters.go`** — Changed `VPToken` from `map[string]string` to `map[string][]string`
2. **`handlers_verifier.go`** — Updated map lookup to unwrap `vpTokens[0]` after length check
3. **`handlers_verification.go`** — Same unwrap logic for the verifier handler
4. **`response_parameters_additional_test.go`** — Updated test to use new array type

Fixes #365