### PR TITLE
fix: VPResponse.VPToken as map[string][]string per OID4VP DCQL spec

### DIFF
--- a/internal/apigw/apiv1/handlers_verifier.go
+++ b/internal/apigw/apiv1/handlers_verifier.go
@@ -209,8 +209,8 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 		return nil, errors.New("DCQL query has no credential queries")
 	}
 	for _, cq := range authCtx.DCQLQuery.Credentials {
-		if token, ok := vpResponse.VPToken[cq.ID]; ok {
-			vpToken = token
+		if tokens, ok := vpResponse.VPToken[cq.ID]; ok && len(tokens) > 0 {
+			vpToken = tokens[0]
 			break
 		}
 	}

--- a/internal/apigw/apiv1/handlers_verifier.go
+++ b/internal/apigw/apiv1/handlers_verifier.go
@@ -210,6 +210,9 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 	}
 	for _, cq := range authCtx.DCQLQuery.Credentials {
 		if tokens, ok := vpResponse.VPToken[cq.ID]; ok && len(tokens) > 0 {
+			if len(tokens) > 1 {
+				c.log.Info("multiple VP tokens received for credential query, using first", "credential_query_id", cq.ID, "count", len(tokens))
+			}
 			vpToken = tokens[0]
 			break
 		}

--- a/internal/verifier/apiv1/handlers_verification.go
+++ b/internal/verifier/apiv1/handlers_verification.go
@@ -146,6 +146,9 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 			c.log.Error(nil, "VP token not found for scope", "scope", scope)
 			return nil, fmt.Errorf("VP token not found for scope: %s", scope)
 		}
+		if len(vpTokens) > 1 {
+			c.log.Info("multiple VP tokens received for scope, using first", "scope", scope, "count", len(vpTokens))
+		}
 		vpToken := vpTokens[0]
 
 		responseParams := &openid4vp.ResponseParameters{}

--- a/internal/verifier/apiv1/handlers_verification.go
+++ b/internal/verifier/apiv1/handlers_verification.go
@@ -141,11 +141,12 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 	credentialCaches := make([]sdjwtvc.CredentialCache, 0, len(authCtx.Scopes))
 
 	for _, scope := range authCtx.Scopes {
-		vpToken, ok := vpResponse.VPToken[scope]
-		if !ok {
+		vpTokens, ok := vpResponse.VPToken[scope]
+		if !ok || len(vpTokens) == 0 {
 			c.log.Error(nil, "VP token not found for scope", "scope", scope)
 			return nil, fmt.Errorf("VP token not found for scope: %s", scope)
 		}
+		vpToken := vpTokens[0]
 
 		responseParams := &openid4vp.ResponseParameters{}
 		responseParams.State = vpResponse.State

--- a/pkg/openid4vp/response_parameters.go
+++ b/pkg/openid4vp/response_parameters.go
@@ -8,8 +8,8 @@ import (
 )
 
 type VPResponse struct {
-	VPToken map[string]string `json:"vp_token,omitempty" bson:"vp_token" validate:"required"`
-	State   string            `json:"state,omitempty" bson:"state" validate:"required"`
+	VPToken map[string][]string `json:"vp_token,omitempty" bson:"vp_token" validate:"required"`
+	State   string              `json:"state,omitempty" bson:"state" validate:"required"`
 }
 
 type ResponseParameters struct {

--- a/pkg/openid4vp/response_parameters_additional_test.go
+++ b/pkg/openid4vp/response_parameters_additional_test.go
@@ -224,9 +224,9 @@ func TestResponseParameters_RoundTrip(t *testing.T) {
 func TestVPResponse(t *testing.T) {
 	t.Run("create and marshal", func(t *testing.T) {
 		vpResp := VPResponse{
-			VPToken: map[string]string{
-				"credential_1": "token1",
-				"credential_2": "token2",
+			VPToken: map[string][]string{
+				"credential_1": {"token1"},
+				"credential_2": {"token2"},
 			},
 			State: "test-state",
 		}


### PR DESCRIPTION
## Summary

Per OID4VP §6.3 with DCQL, `vp_token` values are arrays of Verifiable Presentations keyed by credential query ID. The previous `map[string]string` type caused `json.Unmarshal` to fail when a spec-compliant wallet sends array values, resulting in errors like `failed to unmarshal decrypted JWE`.

## Changes

- Change `VPToken` from `map[string]string` to `map[string][]string` in `VPResponse`
- Unwrap first token from array in apigw DCQL credential query loop (`handlers_verifier.go`)
- Unwrap first token from array in verifier scope-based lookup (`handlers_verification.go`)
- Update tests to use new type

## Notes

This is the forward-port of sirosfoundation/vc@5caa7704 (already deployed in `release/sirosid/v0.5.0`) to the `main`-branch DCQL handler structure, which uses a `for _, cq := range authCtx.DCQLQuery.Credentials` loop instead of a single key lookup.

Fixes #365