### PR TITLE
fix: ClaimsExtractor DCQL response type to map[string][]string

### DIFF
--- a/pkg/openid4vp/claims_extractor.go
+++ b/pkg/openid4vp/claims_extractor.go
@@ -61,7 +61,7 @@ func (ce *ClaimsExtractor) ExtractClaimsFromVPToken(ctx context.Context, vpToken
 // is a JSON object mapping credential query IDs to their individual VP tokens.
 // Claims from all credentials are merged into a single map.
 func (ce *ClaimsExtractor) extractClaimsFromDCQLResponse(ctx context.Context, vpToken string) (map[string]any, error) {
-	var dcqlResponse map[string]string
+	var dcqlResponse map[string][]string
 	if err := json.Unmarshal([]byte(vpToken), &dcqlResponse); err != nil {
 		return nil, fmt.Errorf("failed to parse DCQL vp_token as JSON object: %w", err)
 	}
@@ -71,12 +71,17 @@ func (ce *ClaimsExtractor) extractClaimsFromDCQLResponse(ctx context.Context, vp
 	}
 
 	merged := make(map[string]any)
-	for credID, token := range dcqlResponse {
-		claims, err := ce.extractClaimsFromSingleToken(token)
-		if err != nil {
-			return nil, fmt.Errorf("failed to extract claims from credential %q: %w", credID, err)
+	for credID, tokens := range dcqlResponse {
+		if len(tokens) == 0 {
+			return nil, fmt.Errorf("DCQL vp_token contains empty array for credential %q", credID)
 		}
-		maps.Copy(merged, claims)
+		for _, token := range tokens {
+			claims, err := ce.extractClaimsFromSingleToken(token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to extract claims from credential %q: %w", credID, err)
+			}
+			maps.Copy(merged, claims)
+		}
 	}
 
 	return merged, nil

--- a/pkg/openid4vp/claims_extractor.go
+++ b/pkg/openid4vp/claims_extractor.go
@@ -58,12 +58,13 @@ func (ce *ClaimsExtractor) ExtractClaimsFromVPToken(ctx context.Context, vpToken
 }
 
 // extractClaimsFromDCQLResponse parses a DCQL vp_token response where the value
-// is a JSON object mapping credential query IDs to their individual VP tokens.
-// Claims from all credentials are merged into a single map.
+// is a JSON object mapping credential query IDs to arrays of VP token strings
+// (per OID4VP §6.3). Claims from all credentials are merged into a single map;
+// credential query IDs are processed in sorted order for deterministic output.
 func (ce *ClaimsExtractor) extractClaimsFromDCQLResponse(ctx context.Context, vpToken string) (map[string]any, error) {
 	var dcqlResponse map[string][]string
 	if err := json.Unmarshal([]byte(vpToken), &dcqlResponse); err != nil {
-		return nil, fmt.Errorf("failed to parse DCQL vp_token as JSON object: %w", err)
+		return nil, fmt.Errorf("failed to parse DCQL vp_token as map[string][]string: %w", err)
 	}
 
 	if len(dcqlResponse) == 0 {
@@ -71,7 +72,13 @@ func (ce *ClaimsExtractor) extractClaimsFromDCQLResponse(ctx context.Context, vp
 	}
 
 	merged := make(map[string]any)
-	for credID, tokens := range dcqlResponse {
+	credIDs := make([]string, 0, len(dcqlResponse))
+	for credID := range dcqlResponse {
+		credIDs = append(credIDs, credID)
+	}
+	slices.Sort(credIDs)
+	for _, credID := range credIDs {
+		tokens := dcqlResponse[credID]
 		if len(tokens) == 0 {
 			return nil, fmt.Errorf("DCQL vp_token contains empty array for credential %q", credID)
 		}

--- a/pkg/openid4vp/claims_extractor_test.go
+++ b/pkg/openid4vp/claims_extractor_test.go
@@ -788,3 +788,42 @@ func TestClaimsExtractor_ExtractClaimsFromVPToken_MDocFormat(t *testing.T) {
 	// Placeholder: in a full integration test we'd verify with actual mdoc tokens
 	_ = deviceResponse
 }
+
+func TestClaimsExtractor_ExtractClaimsFromVPToken_DCQLArray(t *testing.T) {
+	ce := NewClaimsExtractor()
+	ctx := t.Context()
+
+	t.Run("rejects_map_string_string_json", func(t *testing.T) {
+		// Old format: map[string]string — should fail because DCQL values must be arrays
+		vpToken := `{"cred1": "not-an-array"}`
+		_, err := ce.ExtractClaimsFromVPToken(ctx, vpToken)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse DCQL vp_token")
+	})
+
+	t.Run("accepts_map_string_array_json", func(t *testing.T) {
+		// New format: map[string][]string — this is what spec-compliant wallets send
+		// The individual tokens will fail to parse (not real SD-JWTs), but the
+		// JSON unmarshal into map[string][]string must succeed
+		vpToken := `{"cred1": ["fake-token"]}`
+		_, err := ce.ExtractClaimsFromVPToken(ctx, vpToken)
+		require.Error(t, err)
+		// Error should be about parsing the token, NOT about JSON unmarshalling
+		assert.Contains(t, err.Error(), "failed to extract claims from credential")
+		assert.NotContains(t, err.Error(), "failed to parse DCQL vp_token")
+	})
+
+	t.Run("empty_array_rejected", func(t *testing.T) {
+		vpToken := `{"cred1": []}`
+		_, err := ce.ExtractClaimsFromVPToken(ctx, vpToken)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty array")
+	})
+
+	t.Run("empty_object_rejected", func(t *testing.T) {
+		vpToken := `{}`
+		_, err := ce.ExtractClaimsFromVPToken(ctx, vpToken)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no credentials")
+	})
+}


### PR DESCRIPTION
## Summary

`ClaimsExtractor.extractClaimsFromDCQLResponse` uses `map[string]string` to unmarshal the DCQL `vp_token` JSON, but OID4VP §6.3 requires values to be arrays of presentations (`map[string][]string`). When a spec-compliant wallet sends array values, `json.Unmarshal` fails with:

```
json: cannot unmarshal array into Go value of type string
```

## Changes

- Change `dcqlResponse` from `map[string]string` to `map[string][]string`
- Iterate over all tokens per credential query ID
- Add empty-array guard
- Add tests for DCQL array format acceptance/rejection

## Affected code paths

The OIDC handler (`handler_oidc.go`) and OpenID4VP direct-post handler (`handler_openid4vp.go`) both pass raw DCQL JSON to `extractAndMapClaims` → `ExtractClaimsFromVPToken` → `extractClaimsFromDCQLResponse`, hitting this bug.

Companion to sirosfoundation/vc#6 (targeting `release/sirosid/v0.5.0`).