### PR TITLE
fix: move apigw static file registration after Default() for branding support

### DIFF
--- a/internal/apigw/httpserver/branding_order_test.go
+++ b/internal/apigw/httpserver/branding_order_test.go
@@ -1,0 +1,92 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SUNET/vc/internal/apigw/staticembed"
+	"github.com/SUNET/vc/pkg/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestBrandingMiddleware returns a gin.HandlerFunc that intercepts
+// /static/logo.png and /static/favicon.png when custom paths are configured,
+// mirroring the CustomBranding middleware from httphelpers.
+// This is intentionally duplicated here to test the registration ORDER
+// (middleware before StaticFS) without pulling in the full httphelpers.Client.
+func newTestBrandingMiddleware(branding model.Branding) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		switch c.Request.URL.Path {
+		case "/static/logo.png":
+			if branding.LogoPath != "" {
+				c.File(branding.LogoPath)
+				c.Abort()
+				return
+			}
+		case "/static/favicon.png":
+			if branding.FaviconPath != "" {
+				c.File(branding.FaviconPath)
+				c.Abort()
+				return
+			}
+		}
+		c.Next()
+	}
+}
+
+// TestBrandingMiddlewareOrder_CorrectOrder verifies that when CustomBranding
+// middleware is registered BEFORE StaticFS, custom files take priority over
+// embedded defaults. This is a regression test for #361.
+func TestBrandingMiddlewareOrder_CorrectOrder(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dir := t.TempDir()
+	logoPath := filepath.Join(dir, "logo.png")
+	require.NoError(t, os.WriteFile(logoPath, []byte("custom-logo"), 0644)) //#nosec G306
+
+	branding := model.Branding{LogoPath: logoPath}
+
+	// Correct order: middleware first, then static files (matches the fix)
+	engine := gin.New()
+	engine.Use(newTestBrandingMiddleware(branding))
+	engine.StaticFS("/static", http.FS(staticembed.FS))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/static/logo.png", nil)
+	engine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "custom-logo", w.Body.String(), "custom logo should override embedded default")
+}
+
+// TestBrandingMiddlewareOrder_WrongOrder demonstrates the bug from #361:
+// when StaticFS is registered BEFORE the branding middleware, the middleware
+// is not in the handler chain and the embedded default is served instead.
+func TestBrandingMiddlewareOrder_WrongOrder(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dir := t.TempDir()
+	logoPath := filepath.Join(dir, "logo.png")
+	require.NoError(t, os.WriteFile(logoPath, []byte("custom-logo"), 0644)) //#nosec G306
+
+	branding := model.Branding{LogoPath: logoPath}
+
+	// Wrong order: static files first, then middleware (the pre-fix bug)
+	engine := gin.New()
+	engine.StaticFS("/static", http.FS(staticembed.FS))
+	engine.Use(newTestBrandingMiddleware(branding))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/static/logo.png", nil)
+	engine.ServeHTTP(w, req)
+
+	// With wrong order, the embedded default is served — NOT the custom logo.
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NotEqual(t, "custom-logo", w.Body.String(), "wrong order should serve embedded default, not custom logo")
+}

--- a/internal/apigw/httpserver/service.go
+++ b/internal/apigw/httpserver/service.go
@@ -92,28 +92,6 @@ func New(ctx context.Context, cfg *model.Cfg, apiv1 *apiv1.Client, tracer *trace
 		return nil, err
 	}
 
-	// Used in development to avoid bundling static files in the executable.
-	// When used, comment the four lines below these ones.
-	// s.gin.Static("/static", "./staticembed")
-	// s.gin.LoadHTMLGlob("./staticembed/*.html")
-
-	s.gin.StaticFS("/static", http.FS(staticembed.FS))
-
-	// Create a new template with custom functions before parsing
-	t := template.New("").Funcs(template.FuncMap{
-		"json": func(v any) (any, error) {
-			jsonBytes, err := json.Marshal(v)
-			if err != nil {
-				return "", err
-			}
-			return template.JS(string(jsonBytes)), nil //#nosec G203 -- json.Marshal output is safe
-		},
-	})
-
-	f := template.Must(t.ParseFS(staticembed.FS, "*.html"))
-
-	s.gin.SetHTMLTemplate(f)
-
 	// Configure CORS at the engine level (before route registration) so that
 	// OPTIONS preflight requests are handled correctly. Placing CORS on a
 	// router group causes preflight requests to hit Gin's NoRoute handler
@@ -146,6 +124,33 @@ func New(ctx context.Context, cfg *model.Cfg, apiv1 *apiv1.Client, tracer *trace
 	if err != nil {
 		return nil, err
 	}
+
+	// Static files and templates are registered AFTER Default() so that the
+	// CustomBranding middleware (registered by Default) is part of the handler
+	// chain for /static/* routes. Otherwise branding overrides are ignored
+	// because Gin snapshots the middleware chain at route-registration time.
+	// See https://github.com/SUNET/vc/issues/361
+	//
+	// In development, comment the four lines below and uncomment the two after:
+	// s.gin.Static("/static", "./staticembed")
+	// s.gin.LoadHTMLGlob("./staticembed/*.html")
+
+	s.gin.StaticFS("/static", http.FS(staticembed.FS))
+
+	// Create a new template with custom functions before parsing
+	t := template.New("").Funcs(template.FuncMap{
+		"json": func(v any) (any, error) {
+			jsonBytes, err := json.Marshal(v)
+			if err != nil {
+				return "", err
+			}
+			return template.JS(string(jsonBytes)), nil //#nosec G203 -- json.Marshal output is safe
+		},
+	})
+
+	f := template.Must(t.ParseFS(staticembed.FS, "*.html"))
+
+	s.gin.SetHTMLTemplate(f)
 
 	// Build SPOCP engine once — shared between API and session auth paths.
 	s.spocpEngine, err = httphelpers.BuildSPOCPEngine(s.cfg.APIGW.APIServer.APIAuth)

--- a/internal/apigw/httpserver/service.go
+++ b/internal/apigw/httpserver/service.go
@@ -131,14 +131,17 @@ func New(ctx context.Context, cfg *model.Cfg, apiv1 *apiv1.Client, tracer *trace
 	// because Gin snapshots the middleware chain at route-registration time.
 	// See https://github.com/SUNET/vc/issues/361
 	//
-	// In development, comment the four lines below and uncomment the two after:
-	// s.gin.Static("/static", "./staticembed")
-	// s.gin.LoadHTMLGlob("./staticembed/*.html")
+	// --- Development mode ---
+	// To serve static files from disk instead of the embedded FS (useful for
+	// live-editing HTML/CSS/JS without recompiling), replace the StaticFS call
+	// and the ParseFS+SetHTMLTemplate block below with:
+	//
+	//   s.gin.Static("/static", "./staticembed")
+	//   s.gin.LoadHTMLGlob("./staticembed/*.html")
 
 	s.gin.StaticFS("/static", http.FS(staticembed.FS))
 
-	// Create a new template with custom functions before parsing
-	t := template.New("").Funcs(template.FuncMap{
+	tmpl := template.New("").Funcs(template.FuncMap{
 		"json": func(v any) (any, error) {
 			jsonBytes, err := json.Marshal(v)
 			if err != nil {
@@ -147,10 +150,7 @@ func New(ctx context.Context, cfg *model.Cfg, apiv1 *apiv1.Client, tracer *trace
 			return template.JS(string(jsonBytes)), nil //#nosec G203 -- json.Marshal output is safe
 		},
 	})
-
-	f := template.Must(t.ParseFS(staticembed.FS, "*.html"))
-
-	s.gin.SetHTMLTemplate(f)
+	s.gin.SetHTMLTemplate(template.Must(tmpl.ParseFS(staticembed.FS, "*.html")))
 
 	// Build SPOCP engine once — shared between API and session auth paths.
 	s.spocpEngine, err = httphelpers.BuildSPOCPEngine(s.cfg.APIGW.APIServer.APIAuth)


### PR DESCRIPTION
## Summary

Fixes #361 — branding configuration (custom favicon and logotype) was ignored by the apigw component.

## Root Cause

Gin snapshots the middleware chain at route registration time. In the apigw constructor, `StaticFS("/static", ...)` was registered **before** `httpHelpers.Server.Default()` was called. Since `Default()` is where the `CustomBranding` middleware is added, the `/static/*` route handler chain never included it — requests for `/static/logo.png` and `/static/favicon.png` went straight to the embedded FS, bypassing branding overrides.

The verifier works correctly because it calls `Default()` first, then registers `Static("/static", ...)`.

## Fix

Move `StaticFS` and template registration to after the `Default()` call, matching the verifier's approach. No change to the embedded FS mechanism — the `CustomBranding` middleware handles overrides at the HTTP layer regardless of the backing storage.