### PR TITLE
security: pin Go version and add apt-get upgrade in Dockerfiles

### DIFF
--- a/dockerfiles/wallet
+++ b/dockerfiles/wallet
@@ -1,5 +1,5 @@
 # Wallet test tool - lightweight build without swagger/proto
-FROM golang:latest AS builder
+FROM golang:1.26.3 AS builder
 
 ARG SERVICE_NAME=wallet
 
@@ -27,7 +27,7 @@ FROM debian:13-slim
 
 WORKDIR /
 
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/app/bin/vc_wallet /vc_wallet
 

--- a/dockerfiles/web_worker
+++ b/dockerfiles/web_worker
@@ -38,8 +38,8 @@ ARG SERVICE_NAME
 
 WORKDIR /
 
-RUN apt-get update && apt-get install -y curl procps iputils-ping less
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl procps iputils-ping less \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/app/bin/vc_${SERVICE_NAME} /vc_service
 COPY --from=builder /go/src/app/internal/${SERVICE_NAME}/static /static/

--- a/dockerfiles/worker
+++ b/dockerfiles/worker
@@ -38,8 +38,8 @@ ARG SERVICE_NAME
 
 WORKDIR /
 
-RUN apt-get update && apt-get install -y curl procps iputils-ping less netcat-openbsd
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl procps iputils-ping less netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/app/bin/vc_${SERVICE_NAME} /vc_service
 COPY --from=builder /go/src/app/docs /docs


### PR DESCRIPTION
## Security Scan Remediation

Addresses findings from the external security scan performed on 2026-05-20 against the vc-apigw, vc-issuer, vc-registry, and vc-verifier Docker images.

### Changes

1. **`dockerfiles/wallet`**: Pin `golang:latest` → `golang:1.26.3` (unpinned base is a security risk)
2. **`dockerfiles/web_worker`**: Add `apt-get upgrade -y` before package install to pick up available Debian security fixes
3. **`dockerfiles/worker`**: Same `apt-get upgrade -y` addition
4. Merge two separate `RUN` layers for apt-get into one (reduces image layers)

### Debian Fixes Applied via apt-get upgrade

| CVE | Component | Fix Version | Description |
|---|---|---|---|
| CVE-2026-4046 | glibc (iconv) | 2.41-12+deb13u3 | iconv crash on certain inputs |
| CVE-2026-4437 | glibc (gethostbyaddr) | 2.41-12+deb13u3 | gethostbyaddr buffer issue |
| CVE-2026-27135 | nghttp2 | 1.64.0-1.1+deb13u1 | HTTP/2 memory leak |
| CVE-2026-4878 | libcap2 | 1:2.75-10+deb13u1 | TOCTOU privilege escalation |

### Findings Not Fixable Yet (no upstream Debian fix)

These are monitored. Most are not applicable to our deployment:
- libgnutls DTLS CVEs — DTLS not used
- curl SMB CVEs — SMB not used  
- linux-pam CVE — containers don't use PAM
- ncurses CVE — CLI dev tool, not invoked at runtime

### Go Runtime CVEs

The go.mod and gobuild Dockerfile are already at Go 1.26.3 on main, which addresses all Go runtime CVEs from the scan (CVE-2026-27143 critical, plus 11 High). The scanned images (dev-824d199) were built with Go 1.26.2. Rebuilding resolves these.

Ref: External security scan SIROS_komponenter_SECURITY_CVES, 2026-05-20