### PR TITLE
Mongo cache layer saved payload as raw bson.Raw, interface like jwk.K…

### DIFF
--- a/internal/apigw/cache/service.go
+++ b/internal/apigw/cache/service.go
@@ -78,7 +78,7 @@ func New(ctx context.Context, cfg *model.Cfg, dbService *db.Service, tracer *tra
 		return nil, fmt.Errorf("cache: auth_context: %w", err)
 	}
 
-	if s.EphemeralEncryptionKey, err = pkgcache.NewGenericCache[jwk.Key](cs, ctx, "apigw_ephemeral_keys", 10*time.Minute); err != nil {
+	if s.EphemeralEncryptionKey, err = pkgcache.NewGenericCache[jwk.Key](cs, ctx, "apigw_ephemeral_keys", 10*time.Minute, pkgcache.WithDecoder(jwkKeyDecoder)); err != nil {
 		return nil, fmt.Errorf("cache: ephemeral_keys: %w", err)
 	}
 
@@ -119,4 +119,9 @@ func New(ctx context.Context, cfg *model.Cfg, dbService *db.Service, tracer *tra
 	s.SessionEncKey = sharedSecrets.SessionEncKey
 
 	return s, nil
+}
+
+// jwkKeyDecoder parses raw JSON bytes into a jwk.Key.
+func jwkKeyDecoder(data []byte) (jwk.Key, error) {
+	return jwk.ParseKey(data)
 }

--- a/internal/verifier/cache/service.go
+++ b/internal/verifier/cache/service.go
@@ -66,7 +66,7 @@ func New(ctx context.Context, cfg *model.Cfg, dbService *db.Service, tracer *tra
 		return nil, fmt.Errorf("cache: credentials: %w", err)
 	}
 
-	if s.EphemeralEncryptionKey, err = pkgcache.NewGenericCache[jwk.Key](cs, ctx, "verifier_ephemeral_keys", 10*time.Minute); err != nil {
+	if s.EphemeralEncryptionKey, err = pkgcache.NewGenericCache[jwk.Key](cs, ctx, "verifier_ephemeral_keys", 10*time.Minute, pkgcache.WithDecoder(jwkKeyDecoder)); err != nil {
 		return nil, fmt.Errorf("cache: ephemeral_keys: %w", err)
 	}
 
@@ -83,4 +83,9 @@ func New(ctx context.Context, cfg *model.Cfg, dbService *db.Service, tracer *tra
 	s.SessionEncKey = sharedSecrets.SessionEncKey
 
 	return s, nil
+}
+
+// jwkKeyDecoder parses raw JSON bytes into a jwk.Key.
+func jwkKeyDecoder(data []byte) (jwk.Key, error) {
+	return jwk.ParseKey(data)
 }

--- a/pkg/cache/factory.go
+++ b/pkg/cache/factory.go
@@ -37,9 +37,9 @@ func (s *Service) NewAuthContextCache(ctx context.Context, collection string, tt
 }
 
 // NewGenericCache creates a Cache[V] backed by the service's backend.
-func NewGenericCache[V any](s *Service, ctx context.Context, collection string, ttl time.Duration) (Cache[V], error) {
+func NewGenericCache[V any](s *Service, ctx context.Context, collection string, ttl time.Duration, opts ...MongoCacheOption[V]) (Cache[V], error) {
 	if !s.ha {
 		return NewMemoryCache[V](ttl), nil
 	}
-	return NewMongoCache[V](ctx, s.client, s.databaseName, collection, ttl, s.log)
+	return NewMongoCache[V](ctx, s.client, s.databaseName, collection, ttl, s.log, opts...)
 }

--- a/pkg/cache/generic_mongo.go
+++ b/pkg/cache/generic_mongo.go
@@ -7,35 +7,50 @@ import (
 	"fmt"
 	"time"
 
-	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // mongoCacheEntry is the document structure stored in MongoDB for generic cache entries.
-type mongoCacheEntry[V any] struct {
+// Values are stored as JSON bytes to support interface types (e.g. jwk.Key) that
+// have no BSON codec but implement json.Marshal/Unmarshal.
+type mongoCacheEntry struct {
 	Key       string    `bson:"_id"`
-	Value     V         `bson:"value"`
-	Raw       bson.Raw  `bson:"raw_value,omitempty"`
+	JSONValue []byte    `bson:"json_value"`
 	CreatedAt time.Time `bson:"created_at"`
 }
 
 // MongoCache is a generic cache backed by a MongoDB collection.
-// It stores values as BSON documents and uses a TTL index on `created_at`
-// for automatic expiration. Enables HA by sharing state across instances.
+// Values are JSON-encoded before storage, which allows interface types
+// (e.g. jwk.Key) to round-trip correctly. A TTL index on `created_at`
+// provides automatic expiration. Enables HA by sharing state across instances.
 //
-// V must be serializable to BSON. Primitive types (string, bool, int, []byte)
-// and structs with bson tags are supported out of the box.
+// V must be JSON-serializable (implement json.Marshal/Unmarshal).
+// For interface types that require custom parsing, supply a MongoCacheOption
+// via WithDecoder.
 type MongoCache[V any] struct {
 	coll       *mongo.Collection
 	log        Logger
 	collection string
+	decode     func([]byte) (V, error) // optional custom JSON decoder
+}
+
+// MongoCacheOption configures optional behaviour for MongoCache.
+type MongoCacheOption[V any] func(*MongoCache[V])
+
+// WithDecoder supplies a custom JSON decoder for V.
+// Use this for interface types (e.g. jwk.Key) where json.Unmarshal cannot
+// infer the concrete type.
+func WithDecoder[V any](fn func([]byte) (V, error)) MongoCacheOption[V] {
+	return func(m *MongoCache[V]) { m.decode = fn }
 }
 
 // NewMongoCache creates a new MongoDB-backed generic cache.
 // It creates the necessary indexes including a TTL index for automatic expiration.
 // If log is nil operational errors are silently discarded.
-func NewMongoCache[V any](ctx context.Context, client *mongo.Client, database, collection string, ttl time.Duration, log Logger) (*MongoCache[V], error) {
+func NewMongoCache[V any](ctx context.Context, client *mongo.Client, database, collection string, ttl time.Duration, log Logger, opts ...MongoCacheOption[V]) (*MongoCache[V], error) {
 	if client == nil {
 		return nil, fmt.Errorf("mongo client cannot be nil")
 	}
@@ -58,12 +73,22 @@ func NewMongoCache[V any](ctx context.Context, client *mongo.Client, database, c
 		return nil, fmt.Errorf("failed to create indexes for cache %q: %w", collection, err)
 	}
 
-	return &MongoCache[V]{coll: coll, log: log, collection: collection}, nil
+	mc := &MongoCache[V]{
+		coll:       coll,
+		log:        log,
+		collection: collection,
+	}
+
+	for _, opt := range opts {
+		opt(mc)
+	}
+
+	return mc, nil
 }
 
 // Get retrieves a value by key.
 func (m *MongoCache[V]) Get(ctx context.Context, key string) (V, bool) {
-	var entry mongoCacheEntry[V]
+	var entry mongoCacheEntry
 	err := m.coll.FindOne(ctx, bson.M{"_id": key}).Decode(&entry)
 	if err != nil {
 		if !errors.Is(err, mongo.ErrNoDocuments) {
@@ -75,14 +100,20 @@ func (m *MongoCache[V]) Get(ctx context.Context, key string) (V, bool) {
 		return zero, false
 	}
 
-	// For interface types (like jwk.Key), BSON decodes to bson.Raw.
-	// We detect this and use JSON round-trip as fallback.
-	val, ok := tryRecoverValue[V](entry)
-	if ok {
-		return val, true
+	var v V
+	if m.decode != nil {
+		v, err = m.decode(entry.JSONValue)
+	} else {
+		err = json.Unmarshal(entry.JSONValue, &v)
 	}
-
-	return entry.Value, true
+	if err != nil {
+		m.log.Error(err, "mongo cache get: failed to unmarshal JSON value",
+			"cache", m.collection, "key", key,
+		)
+		var zero V
+		return zero, false
+	}
+	return v, true
 }
 
 // Set stores a value with the default TTL (uses upsert).
@@ -94,12 +125,11 @@ func (m *MongoCache[V]) Set(ctx context.Context, key string, value V) {
 // Returns true if the value was inserted, false if the key already existed.
 // Returns a non-nil error on operational failures (e.g. connectivity issues).
 func (m *MongoCache[V]) SetNX(ctx context.Context, key string, value V) (bool, error) {
-	entry := mongoCacheEntry[V]{
-		Key:       key,
-		Value:     value,
-		CreatedAt: time.Now(),
+	entry, err := m.marshalEntry(key, value)
+	if err != nil {
+		return false, fmt.Errorf("mongo cache setnx marshal failed (cache=%s): %w", m.collection, err)
 	}
-	_, err := m.coll.InsertOne(ctx, entry)
+	_, err = m.coll.InsertOne(ctx, entry)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
 			return false, nil
@@ -139,10 +169,12 @@ func (m *MongoCache[V]) Len() int {
 }
 
 func (m *MongoCache[V]) upsert(ctx context.Context, key string, value V) {
-	entry := mongoCacheEntry[V]{
-		Key:       key,
-		Value:     value,
-		CreatedAt: time.Now(),
+	entry, err := m.marshalEntry(key, value)
+	if err != nil {
+		m.log.Error(err, "mongo cache upsert marshal failed",
+			"cache", m.collection, "key", key,
+		)
+		return
 	}
 
 	opts := options.Replace().SetUpsert(true)
@@ -153,21 +185,15 @@ func (m *MongoCache[V]) upsert(ctx context.Context, key string, value V) {
 	}
 }
 
-// tryRecoverValue handles the case where V is an interface type and BSON
-// decoded the value as bson.Raw instead of the concrete type.
-// Falls back to JSON round-trip for recovery if raw bytes are present.
-func tryRecoverValue[V any](entry mongoCacheEntry[V]) (V, bool) {
-	// Check if Raw field has data (set when BSON couldn't decode to V directly)
-	if len(entry.Raw) > 0 {
-		var v V
-		// Try JSON round-trip: Raw → JSON bytes → V
-		jsonBytes, err := bson.MarshalExtJSON(entry.Raw, true, false)
-		if err == nil {
-			if err := json.Unmarshal(jsonBytes, &v); err == nil {
-				return v, true
-			}
-		}
+// marshalEntry serializes value to JSON and wraps it in a mongoCacheEntry.
+func (m *MongoCache[V]) marshalEntry(key string, value V) (mongoCacheEntry, error) {
+	jsonBytes, err := json.Marshal(value)
+	if err != nil {
+		return mongoCacheEntry{}, fmt.Errorf("json marshal: %w", err)
 	}
-	var zero V
-	return zero, false
+	return mongoCacheEntry{
+		Key:       key,
+		JSONValue: jsonBytes,
+		CreatedAt: time.Now(),
+	}, nil
 }

--- a/pkg/cache/generic_mongo.go
+++ b/pkg/cache/generic_mongo.go
@@ -34,6 +34,7 @@ type MongoCache[V any] struct {
 	coll       *mongo.Collection
 	log        Logger
 	collection string
+	ttl        time.Duration            // collection-level TTL used by the TTL index
 	decode     func([]byte) (V, error) // optional custom JSON decoder
 }
 
@@ -77,6 +78,7 @@ func NewMongoCache[V any](ctx context.Context, client *mongo.Client, database, c
 		coll:       coll,
 		log:        log,
 		collection: collection,
+		ttl:        ttl,
 	}
 
 	for _, opt := range opts {
@@ -125,7 +127,7 @@ func (m *MongoCache[V]) Set(ctx context.Context, key string, value V) {
 // Returns true if the value was inserted, false if the key already existed.
 // Returns a non-nil error on operational failures (e.g. connectivity issues).
 func (m *MongoCache[V]) SetNX(ctx context.Context, key string, value V) (bool, error) {
-	entry, err := m.marshalEntry(key, value)
+	entry, err := m.marshalEntry(key, value, time.Now())
 	if err != nil {
 		return false, fmt.Errorf("mongo cache setnx marshal failed (cache=%s): %w", m.collection, err)
 	}
@@ -140,13 +142,17 @@ func (m *MongoCache[V]) SetNX(ctx context.Context, key string, value V) (bool, e
 }
 
 // SetWithTTL stores a value with a custom TTL.
-// Note: MongoDB TTL is per-collection, so custom TTL is approximated by
-// setting created_at in the past/future relative to the collection TTL.
-// For most use cases, use Set with the collection default.
-func (m *MongoCache[V]) SetWithTTL(ctx context.Context, key string, value V, _ time.Duration) {
-	// MongoDB TTL indexes are collection-wide; per-entry TTL isn't natively supported.
-	// We store with current time and rely on the collection TTL index.
-	m.upsert(ctx, key, value)
+// MongoDB TTL indexes are collection-wide, so per-entry TTL is approximated
+// by shifting created_at: the document expires when
+//
+//	now >= created_at + collection_ttl
+//
+// Setting created_at = now - (collection_ttl - custom_ttl) makes the
+// document expire ~custom_ttl from now.
+func (m *MongoCache[V]) SetWithTTL(ctx context.Context, key string, value V, ttl time.Duration) {
+	shift := m.ttl - ttl
+	createdAt := time.Now().Add(-shift)
+	m.upsertAt(ctx, key, value, createdAt)
 }
 
 // Delete removes a value by key.
@@ -169,7 +175,11 @@ func (m *MongoCache[V]) Len() int {
 }
 
 func (m *MongoCache[V]) upsert(ctx context.Context, key string, value V) {
-	entry, err := m.marshalEntry(key, value)
+	m.upsertAt(ctx, key, value, time.Now())
+}
+
+func (m *MongoCache[V]) upsertAt(ctx context.Context, key string, value V, createdAt time.Time) {
+	entry, err := m.marshalEntry(key, value, createdAt)
 	if err != nil {
 		m.log.Error(err, "mongo cache upsert marshal failed",
 			"cache", m.collection, "key", key,
@@ -186,7 +196,7 @@ func (m *MongoCache[V]) upsert(ctx context.Context, key string, value V) {
 }
 
 // marshalEntry serializes value to JSON and wraps it in a mongoCacheEntry.
-func (m *MongoCache[V]) marshalEntry(key string, value V) (mongoCacheEntry, error) {
+func (m *MongoCache[V]) marshalEntry(key string, value V, createdAt time.Time) (mongoCacheEntry, error) {
 	jsonBytes, err := json.Marshal(value)
 	if err != nil {
 		return mongoCacheEntry{}, fmt.Errorf("json marshal: %w", err)
@@ -194,6 +204,6 @@ func (m *MongoCache[V]) marshalEntry(key string, value V) (mongoCacheEntry, erro
 	return mongoCacheEntry{
 		Key:       key,
 		JSONValue: jsonBytes,
-		CreatedAt: time.Now(),
+		CreatedAt: createdAt,
 	}, nil
 }

--- a/pkg/cache/generic_mongo.go
+++ b/pkg/cache/generic_mongo.go
@@ -14,8 +14,8 @@ import (
 )
 
 // mongoCacheEntry is the document structure stored in MongoDB for generic cache entries.
-// Values are stored as JSON bytes to support interface types (e.g. jwk.Key) that
-// have no BSON codec but implement json.Marshal/Unmarshal.
+// Values are stored as JSON bytes to avoid BSON codec requirements for interface
+// types (e.g. jwk.Key) that have no registered BSON encoder/decoder.
 type mongoCacheEntry struct {
 	Key       string    `bson:"_id"`
 	JSONValue []byte    `bson:"json_value"`
@@ -27,9 +27,9 @@ type mongoCacheEntry struct {
 // (e.g. jwk.Key) to round-trip correctly. A TTL index on `created_at`
 // provides automatic expiration. Enables HA by sharing state across instances.
 //
-// V must be JSON-serializable (implement json.Marshal/Unmarshal).
-// For interface types that require custom parsing, supply a MongoCacheOption
-// via WithDecoder.
+// V must be serializable by encoding/json. Interface or opaque types whose
+// concrete type cannot be inferred by json.Unmarshal (e.g. jwk.Key) require
+// a custom decoder supplied via WithDecoder.
 type MongoCache[V any] struct {
 	coll       *mongo.Collection
 	log        Logger

--- a/pkg/cache/generic_test.go
+++ b/pkg/cache/generic_test.go
@@ -2,9 +2,14 @@ package cache
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -205,6 +210,34 @@ func TestMongoCache_Bytes(t *testing.T) {
 func TestMongoCache_NilClient(t *testing.T) {
 	_, err := NewMongoCache[string](context.Background(), nil, "db", "col", 5*time.Minute, nil)
 	assert.Error(t, err)
+}
+
+func TestMongoCache_JWKKey(t *testing.T) {
+	client, cleanup := startMongoContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	c, err := NewMongoCache[jwk.Key](ctx, client, "test_generic", "cache_jwk", 10*time.Minute, nil, WithDecoder(func(data []byte) (jwk.Key, error) {
+		return jwk.ParseKey(data)
+	}))
+	require.NoError(t, err)
+
+	// Generate a fresh EC key
+	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	key, err := jwk.Import(raw)
+	require.NoError(t, err)
+
+	c.Set(ctx, "k1", key)
+	got, ok := c.Get(ctx, "k1")
+	require.True(t, ok, "expected jwk.Key to round-trip through MongoCache")
+
+	// Verify the key material survived by comparing JSON serializations
+	origJSON, err := json.Marshal(key)
+	require.NoError(t, err)
+	gotJSON, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(origJSON), string(gotJSON))
 }
 
 

--- a/pkg/cache/generic_test.go
+++ b/pkg/cache/generic_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // runGenericCacheContractTests runs the shared contract tests that every
@@ -238,4 +239,80 @@ func TestMongoCache_JWKKey(t *testing.T) {
 	gotJSON, err := json.Marshal(got)
 	require.NoError(t, err)
 	assert.JSONEq(t, string(origJSON), string(gotJSON))
+}
+
+func TestMongoCache_SetWithTTL_ShorterThanDefault(t *testing.T) {
+	client, cleanup := startMongoContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	// Collection TTL = 10 minutes.
+	c, err := NewMongoCache[string](ctx, client, "test_generic", "cache_ttl_short", 10*time.Minute, nil)
+	require.NoError(t, err)
+
+	// Store with a 2-minute TTL. created_at should be shifted 8 minutes into the past.
+	c.SetWithTTL(ctx, "short", "val", 2*time.Minute)
+
+	// Read the raw document to verify the created_at shift.
+	coll := client.Database("test_generic").Collection("cache_ttl_short")
+	var doc bson.M
+	err = coll.FindOne(ctx, bson.M{"_id": "short"}).Decode(&doc)
+	require.NoError(t, err)
+
+	createdAt := doc["created_at"].(bson.DateTime).Time()
+	age := time.Since(createdAt)
+	// created_at should be ~8 minutes in the past (shift = 10m - 2m).
+	assert.InDelta(t, 8*time.Minute, age, float64(5*time.Second),
+		"created_at should be shifted ~8 minutes into the past")
+
+	// Value should still be readable.
+	got, ok := c.Get(ctx, "short")
+	require.True(t, ok)
+	assert.Equal(t, "val", got)
+}
+
+func TestMongoCache_SetWithTTL_LongerThanDefault(t *testing.T) {
+	client, cleanup := startMongoContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	// Collection TTL = 5 minutes.
+	c, err := NewMongoCache[string](ctx, client, "test_generic", "cache_ttl_long", 5*time.Minute, nil)
+	require.NoError(t, err)
+
+	// Store with a 15-minute TTL. created_at should be shifted 10 minutes into the future.
+	c.SetWithTTL(ctx, "long", "val", 15*time.Minute)
+
+	coll := client.Database("test_generic").Collection("cache_ttl_long")
+	var doc bson.M
+	err = coll.FindOne(ctx, bson.M{"_id": "long"}).Decode(&doc)
+	require.NoError(t, err)
+
+	createdAt := doc["created_at"].(bson.DateTime).Time()
+	offset := time.Until(createdAt)
+	// created_at should be ~10 minutes in the future (shift = 5m - 15m = -10m).
+	assert.InDelta(t, 10*time.Minute, offset, float64(5*time.Second),
+		"created_at should be shifted ~10 minutes into the future")
+}
+
+func TestMongoCache_SetWithTTL_SameAsDefault(t *testing.T) {
+	client, cleanup := startMongoContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	c, err := NewMongoCache[string](ctx, client, "test_generic", "cache_ttl_same", 10*time.Minute, nil)
+	require.NoError(t, err)
+
+	c.SetWithTTL(ctx, "same", "val", 10*time.Minute)
+
+	coll := client.Database("test_generic").Collection("cache_ttl_same")
+	var doc bson.M
+	err = coll.FindOne(ctx, bson.M{"_id": "same"}).Decode(&doc)
+	require.NoError(t, err)
+
+	createdAt := doc["created_at"].(bson.DateTime).Time()
+	age := time.Since(createdAt)
+	// No shift; created_at should be ~now.
+	assert.InDelta(t, 0, age, float64(5*time.Second),
+		"created_at should be approximately now when TTL equals default")
 }

--- a/pkg/cache/generic_test.go
+++ b/pkg/cache/generic_test.go
@@ -239,5 +239,3 @@ func TestMongoCache_JWKKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.JSONEq(t, string(origJSON), string(gotJSON))
 }
-
-


### PR DESCRIPTION
…ey lacks bson marshaller, change to raw parsed json as []byte in mongo cache layer.

closes #363 