### PR TITLE
fix: remove trailing slashes from datastore swagger annotations

### DIFF
--- a/docs/apigw/docs.go
+++ b/docs/apigw/docs.go
@@ -58,83 +58,6 @@ const docTemplate = `{
             }
         },
         "/api/v1/datastore": {
-            "post": {
-                "description": "Get document endpoint",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "vc-platform"
-                ],
-                "summary": "DatastoreGet",
-                "operationId": "get-document",
-                "parameters": [
-                    {
-                        "description": " ",
-                        "name": "req",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.DatastoreGetRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.DatastoreGetReply"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "delete one document endpoint",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "vc-platform"
-                ],
-                "summary": "DatastoreDelete",
-                "operationId": "delete-document",
-                "parameters": [
-                    {
-                        "description": " ",
-                        "name": "req",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.DatastoreDeleteRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/datastore/": {
             "get": {
                 "description": "Get a document by authentic_source, scope, and document_id",
                 "consumes": [
@@ -1383,8 +1306,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "credential_offer": {
-                    "type": "object",
-                    "additionalProperties": {}
+                    "$ref": "#/definitions/openid4vci.CredentialOfferResult"
                 },
                 "credential_type": {
                     "type": "string"
@@ -1445,10 +1367,16 @@ const docTemplate = `{
         "apiv1_issuer.Jwk": {
             "type": "object",
             "properties": {
+                "alg": {
+                    "type": "string"
+                },
                 "crv": {
                     "type": "string"
                 },
                 "d": {
+                    "type": "string"
+                },
+                "e": {
                     "type": "string"
                 },
                 "ext": {
@@ -1464,6 +1392,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "kty": {
+                    "type": "string"
+                },
+                "n": {
+                    "type": "string"
+                },
+                "use": {
                     "type": "string"
                 },
                 "x": {
@@ -1610,7 +1544,7 @@ const docTemplate = `{
                     "maxLength": 128
                 },
                 "document_id": {
-                    "description": "required: true\nexample: 5e7a981c-c03f-11ee-b116-9b12c59362b9",
+                    "description": "required: false\nexample: 5e7a981c-c03f-11ee-b116-9b12c59362b9",
                     "type": "string",
                     "maxLength": 128
                 },
@@ -1817,6 +1751,28 @@ const docTemplate = `{
                 "vct": {
                     "description": "VCT REQUIRED. String as defined in Appendix A.3.2. This claim contains the type values the Wallet requests authorization for at the Credential Issuer. It MUST only be present if the format claim is present. It MUST not be present otherwise.",
                     "type": "string"
+                }
+            }
+        },
+        "openid4vci.CredentialOfferResult": {
+            "type": "object",
+            "required": [
+                "credential_configuration_ids",
+                "credential_issuer"
+            ],
+            "properties": {
+                "credential_configuration_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "credential_issuer": {
+                    "type": "string"
+                },
+                "grants": {
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             }
         },
@@ -2151,24 +2107,20 @@ const docTemplate = `{
         "openid4vci.TokenRequest": {
             "type": "object",
             "required": [
-                "client_id",
-                "code",
-                "dpop",
-                "grant_type",
-                "redirect_uri"
+                "grant_type"
             ],
             "properties": {
                 "client_id": {
-                    "description": "ClientID REQUIRED, if the client is not authenticating with the authorization server as described in Section 3.2.1.",
+                    "description": "ClientID REQUIRED for authorization_code grant (RFC 6749 §4.1.3).\nOPTIONAL for pre-authorized_code grant.",
                     "type": "string"
                 },
                 "code": {
-                    "description": "Code REQUIRED.  The authorization code received from the authorization server.",
+                    "description": "Code REQUIRED for authorization_code grant. The authorization code received from the authorization server.",
                     "type": "string",
                     "maxLength": 128
                 },
                 "code_verifier": {
-                    "description": "CodeVerifier OPTIONAL (required for public clients)",
+                    "description": "CodeVerifier OPTIONAL (required for public clients using authorization_code grant)",
                     "type": "string"
                 },
                 "dpop": {
@@ -2176,14 +2128,24 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "grant_type": {
-                    "description": "// Authorization Code Flow\nGrantType REQUIRED.  Value MUST be set to \"authorization_code\".",
+                    "description": "GrantType REQUIRED. \"authorization_code\" or \"urn:ietf:params:oauth:grant-type:pre-authorized_code\".",
                     "type": "string",
                     "enum": [
-                        "authorization_code"
+                        "authorization_code",
+                        "urn:ietf:params:oauth:grant-type:pre-authorized_code"
                     ]
                 },
+                "pre-authorized_code": {
+                    "description": "PreAuthorizedCode REQUIRED for pre-authorized_code grant. The code representing the authorization to obtain Credentials.",
+                    "type": "string",
+                    "maxLength": 128
+                },
                 "redirect_uri": {
-                    "description": "RedirectURI\tREQUIRED, if the \"redirect_uri\" parameter was included in the authorization request as described in Section 4.1.1, and their values MUST be identical.",
+                    "description": "RedirectURI REQUIRED for authorization_code grant, if the \"redirect_uri\" parameter was included in the authorization request.",
+                    "type": "string"
+                },
+                "tx_code": {
+                    "description": "TXCode OPTIONAL. String value containing a Transaction Code.",
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.json
+++ b/docs/apigw/swagger.json
@@ -50,83 +50,6 @@
             }
         },
         "/api/v1/datastore": {
-            "post": {
-                "description": "Get document endpoint",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "vc-platform"
-                ],
-                "summary": "DatastoreGet",
-                "operationId": "get-document",
-                "parameters": [
-                    {
-                        "description": " ",
-                        "name": "req",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.DatastoreGetRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.DatastoreGetReply"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "delete one document endpoint",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "vc-platform"
-                ],
-                "summary": "DatastoreDelete",
-                "operationId": "delete-document",
-                "parameters": [
-                    {
-                        "description": " ",
-                        "name": "req",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiv1.DatastoreDeleteRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/datastore/": {
             "get": {
                 "description": "Get a document by authentic_source, scope, and document_id",
                 "consumes": [
@@ -1375,8 +1298,7 @@
                     "type": "string"
                 },
                 "credential_offer": {
-                    "type": "object",
-                    "additionalProperties": {}
+                    "$ref": "#/definitions/openid4vci.CredentialOfferResult"
                 },
                 "credential_type": {
                     "type": "string"
@@ -1437,10 +1359,16 @@
         "apiv1_issuer.Jwk": {
             "type": "object",
             "properties": {
+                "alg": {
+                    "type": "string"
+                },
                 "crv": {
                     "type": "string"
                 },
                 "d": {
+                    "type": "string"
+                },
+                "e": {
                     "type": "string"
                 },
                 "ext": {
@@ -1456,6 +1384,12 @@
                     "type": "string"
                 },
                 "kty": {
+                    "type": "string"
+                },
+                "n": {
+                    "type": "string"
+                },
+                "use": {
                     "type": "string"
                 },
                 "x": {
@@ -1602,7 +1536,7 @@
                     "maxLength": 128
                 },
                 "document_id": {
-                    "description": "required: true\nexample: 5e7a981c-c03f-11ee-b116-9b12c59362b9",
+                    "description": "required: false\nexample: 5e7a981c-c03f-11ee-b116-9b12c59362b9",
                     "type": "string",
                     "maxLength": 128
                 },
@@ -1809,6 +1743,28 @@
                 "vct": {
                     "description": "VCT REQUIRED. String as defined in Appendix A.3.2. This claim contains the type values the Wallet requests authorization for at the Credential Issuer. It MUST only be present if the format claim is present. It MUST not be present otherwise.",
                     "type": "string"
+                }
+            }
+        },
+        "openid4vci.CredentialOfferResult": {
+            "type": "object",
+            "required": [
+                "credential_configuration_ids",
+                "credential_issuer"
+            ],
+            "properties": {
+                "credential_configuration_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "credential_issuer": {
+                    "type": "string"
+                },
+                "grants": {
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             }
         },
@@ -2143,24 +2099,20 @@
         "openid4vci.TokenRequest": {
             "type": "object",
             "required": [
-                "client_id",
-                "code",
-                "dpop",
-                "grant_type",
-                "redirect_uri"
+                "grant_type"
             ],
             "properties": {
                 "client_id": {
-                    "description": "ClientID REQUIRED, if the client is not authenticating with the authorization server as described in Section 3.2.1.",
+                    "description": "ClientID REQUIRED for authorization_code grant (RFC 6749 §4.1.3).\nOPTIONAL for pre-authorized_code grant.",
                     "type": "string"
                 },
                 "code": {
-                    "description": "Code REQUIRED.  The authorization code received from the authorization server.",
+                    "description": "Code REQUIRED for authorization_code grant. The authorization code received from the authorization server.",
                     "type": "string",
                     "maxLength": 128
                 },
                 "code_verifier": {
-                    "description": "CodeVerifier OPTIONAL (required for public clients)",
+                    "description": "CodeVerifier OPTIONAL (required for public clients using authorization_code grant)",
                     "type": "string"
                 },
                 "dpop": {
@@ -2168,14 +2120,24 @@
                     "type": "string"
                 },
                 "grant_type": {
-                    "description": "// Authorization Code Flow\nGrantType REQUIRED.  Value MUST be set to \"authorization_code\".",
+                    "description": "GrantType REQUIRED. \"authorization_code\" or \"urn:ietf:params:oauth:grant-type:pre-authorized_code\".",
                     "type": "string",
                     "enum": [
-                        "authorization_code"
+                        "authorization_code",
+                        "urn:ietf:params:oauth:grant-type:pre-authorized_code"
                     ]
                 },
+                "pre-authorized_code": {
+                    "description": "PreAuthorizedCode REQUIRED for pre-authorized_code grant. The code representing the authorization to obtain Credentials.",
+                    "type": "string",
+                    "maxLength": 128
+                },
                 "redirect_uri": {
-                    "description": "RedirectURI\tREQUIRED, if the \"redirect_uri\" parameter was included in the authorization request as described in Section 4.1.1, and their values MUST be identical.",
+                    "description": "RedirectURI REQUIRED for authorization_code grant, if the \"redirect_uri\" parameter was included in the authorization request.",
+                    "type": "string"
+                },
+                "tx_code": {
+                    "description": "TXCode OPTIONAL. String value containing a Transaction Code.",
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.yaml
+++ b/docs/apigw/swagger.yaml
@@ -267,8 +267,7 @@ definitions:
       credential:
         type: string
       credential_offer:
-        additionalProperties: {}
-        type: object
+        $ref: '#/definitions/openid4vci.CredentialOfferResult'
       credential_type:
         type: string
       message:
@@ -309,9 +308,13 @@ definitions:
     type: object
   apiv1_issuer.Jwk:
     properties:
+      alg:
+        type: string
       crv:
         type: string
       d:
+        type: string
+      e:
         type: string
       ext:
         type: boolean
@@ -322,6 +325,10 @@ definitions:
       kid:
         type: string
       kty:
+        type: string
+      "n":
+        type: string
+      use:
         type: string
       x:
         type: string
@@ -429,7 +436,7 @@ definitions:
         type: string
       document_id:
         description: |-
-          required: true
+          required: false
           example: 5e7a981c-c03f-11ee-b116-9b12c59362b9
         maxLength: 128
         type: string
@@ -709,6 +716,21 @@ definitions:
     required:
     - type
     type: object
+  openid4vci.CredentialOfferResult:
+    properties:
+      credential_configuration_ids:
+        items:
+          type: string
+        type: array
+      credential_issuer:
+        type: string
+      grants:
+        additionalProperties: {}
+        type: object
+    required:
+    - credential_configuration_ids
+    - credential_issuer
+    type: object
   openid4vci.CredentialRequest:
     properties:
       authorization:
@@ -977,38 +999,42 @@ definitions:
   openid4vci.TokenRequest:
     properties:
       client_id:
-        description: ClientID REQUIRED, if the client is not authenticating with the
-          authorization server as described in Section 3.2.1.
+        description: |-
+          ClientID REQUIRED for authorization_code grant (RFC 6749 §4.1.3).
+          OPTIONAL for pre-authorized_code grant.
         type: string
       code:
-        description: Code REQUIRED.  The authorization code received from the authorization
-          server.
+        description: Code REQUIRED for authorization_code grant. The authorization
+          code received from the authorization server.
         maxLength: 128
         type: string
       code_verifier:
-        description: CodeVerifier OPTIONAL (required for public clients)
+        description: CodeVerifier OPTIONAL (required for public clients using authorization_code
+          grant)
         type: string
       dpop:
         description: Header field
         type: string
       grant_type:
-        description: |-
-          // Authorization Code Flow
-          GrantType REQUIRED.  Value MUST be set to "authorization_code".
+        description: GrantType REQUIRED. "authorization_code" or "urn:ietf:params:oauth:grant-type:pre-authorized_code".
         enum:
         - authorization_code
+        - urn:ietf:params:oauth:grant-type:pre-authorized_code
+        type: string
+      pre-authorized_code:
+        description: PreAuthorizedCode REQUIRED for pre-authorized_code grant. The
+          code representing the authorization to obtain Credentials.
+        maxLength: 128
         type: string
       redirect_uri:
-        description: "RedirectURI\tREQUIRED, if the \"redirect_uri\" parameter was
-          included in the authorization request as described in Section 4.1.1, and
-          their values MUST be identical."
+        description: RedirectURI REQUIRED for authorization_code grant, if the "redirect_uri"
+          parameter was included in the authorization request.
+        type: string
+      tx_code:
+        description: TXCode OPTIONAL. String value containing a Transaction Code.
         type: string
     required:
-    - client_id
-    - code
-    - dpop
     - grant_type
-    - redirect_uri
     type: object
   openid4vci.TokenResponse:
     properties:
@@ -1110,57 +1136,6 @@ paths:
       tags:
       - OAuth
   /api/v1/datastore:
-    delete:
-      consumes:
-      - application/json
-      description: delete one document endpoint
-      operationId: delete-document
-      parameters:
-      - description: ' '
-        in: body
-        name: req
-        required: true
-        schema:
-          $ref: '#/definitions/apiv1.DatastoreDeleteRequest'
-      produces:
-      - application/json
-      responses:
-        "204":
-          description: No Content
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/helpers.ErrorResponse'
-      summary: DatastoreDelete
-      tags:
-      - vc-platform
-    post:
-      consumes:
-      - application/json
-      description: Get document endpoint
-      operationId: get-document
-      parameters:
-      - description: ' '
-        in: body
-        name: req
-        required: true
-        schema:
-          $ref: '#/definitions/apiv1.DatastoreGetRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Success
-          schema:
-            $ref: '#/definitions/apiv1.DatastoreGetReply'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/helpers.ErrorResponse'
-      summary: DatastoreGet
-      tags:
-      - vc-platform
-  /api/v1/datastore/:
     delete:
       consumes:
       - application/json

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -28,7 +28,7 @@ type DatastoreUploadReply struct {
 //	@Success		200	{object}	DatastoreUploadReply	"Success"
 //	@Failure		400	{object}	helpers.ErrorResponse	"Bad Request"
 //	@Param			req	body		vcclient.UploadRequest	true	" "
-//	@Router			/api/v1/datastore/ [post]
+//	@Router			/api/v1/datastore [post]
 func (c *Client) DatastoreUpload(ctx context.Context, req *vcclient.UploadRequest) (*DatastoreUploadReply, error) {
 	if req.Meta.DocumentID == "" {
 		id, err := uuid.NewV7()
@@ -242,7 +242,6 @@ type DatastoreDeleteRequest struct {
 //	@Success		204	"No Content"
 //	@Failure		400	{object}	helpers.ErrorResponse	"Bad Request"
 //	@Param			req	body		DatastoreDeleteRequest	true	" "
-//	@Router			/api/v1/datastore [delete]
 func (c *Client) DatastoreDelete(ctx context.Context, req *DatastoreDeleteRequest) error {
 	err := c.datastoreStore.Delete(ctx, &model.MetaData{
 		AuthenticSource: req.AuthenticSource,
@@ -279,7 +278,6 @@ type DatastoreGetReply struct {
 //	@Success		200	{object}	DatastoreGetReply		"Success"
 //	@Failure		400	{object}	helpers.ErrorResponse	"Bad Request"
 //	@Param			req	body		DatastoreGetRequest		true	" "
-//	@Router			/api/v1/datastore [post]
 func (c *Client) DatastoreGet(ctx context.Context, req *DatastoreGetRequest) (*DatastoreGetReply, error) {
 	doc, err := c.datastoreStore.Get(ctx, &model.MetaData{
 		AuthenticSource: req.AuthenticSource,
@@ -366,7 +364,7 @@ type DatastoreGetByKeyReply struct {
 //	@Param			authentic_source	query		string					true	"Authentic source"
 //	@Param			scope				query		string					true	"Scope"
 //	@Param			document_id			query		string					true	"Document ID"
-//	@Router			/api/v1/datastore/ [get]
+//	@Router			/api/v1/datastore [get]
 func (c *Client) DatastoreGetByKey(ctx context.Context, req *DatastoreGetByKeyRequest) (*DatastoreGetByKeyReply, error) {
 	doc, err := c.datastoreStore.GetByKey(ctx, req.AuthenticSource, req.Scope, req.DocumentID)
 	if err != nil {
@@ -449,7 +447,7 @@ type DatastoreDeleteByKeyRequest struct {
 //	@Success		204	"No Content"
 //	@Failure		400	{object}	helpers.ErrorResponse		"Bad Request"
 //	@Param			req	body		DatastoreDeleteByKeyRequest	true	" "
-//	@Router			/api/v1/datastore/ [delete]
+//	@Router			/api/v1/datastore [delete]
 func (c *Client) DatastoreDeleteByKey(ctx context.Context, req *DatastoreDeleteByKeyRequest) error {
 	return c.datastoreStore.DeleteByKey(ctx, req.AuthenticSource, req.Scope, req.DocumentID)
 }
@@ -465,7 +463,7 @@ func (c *Client) DatastoreDeleteByKey(ctx context.Context, req *DatastoreDeleteB
 //	@Success		200	"Success"
 //	@Failure		400	{object}	helpers.ErrorResponse	"Bad Request"
 //	@Param			req	body		vcclient.UploadRequest	true	" "
-//	@Router			/api/v1/datastore/ [put]
+//	@Router			/api/v1/datastore [put]
 func (c *Client) DatastoreReplace(ctx context.Context, req *vcclient.UploadRequest) error {
 	upload := &model.CompleteDocument{
 		Meta:               req.Meta,


### PR DESCRIPTION
## Problem

Swagger `@Router` annotations for datastore endpoints had trailing slashes (e.g. `/api/v1/datastore/`) while gin registers routes without them (`/api/v1/datastore`). This caused Swagger UI to send requests to the trailing-slash URL, which gin 307-redirected — dropping the POST body and resulting in no document being created.

Additionally, two dead handlers (`DatastoreGet` and `DatastoreDelete`) had `@Router` annotations that created confusing duplicate/overlapping entries in the swagger spec, even though they were never registered as gin routes.

## Changes

- **`DatastoreUpload`**: `@Router /api/v1/datastore/ [post]` → `/api/v1/datastore [post]`
- **`DatastoreGetByKey`**: `@Router /api/v1/datastore/ [get]` → `/api/v1/datastore [get]`
- **`DatastoreDeleteByKey`**: `@Router /api/v1/datastore/ [delete]` → `/api/v1/datastore [delete]`
- **`DatastoreReplace`**: `@Router /api/v1/datastore/ [put]` → `/api/v1/datastore [put]`
- **`DatastoreGet`**: Removed `@Router /api/v1/datastore [post]` (dead code — handler is never registered in gin; conflicted with `DatastoreUpload`)
- **`DatastoreDelete`**: Removed `@Router /api/v1/datastore [delete]` (dead code — registered DELETE handler calls `DatastoreDeleteByKey` instead)
- Regenerated swagger docs (`docs/apigw/`)

## Testing

Manually verified that `POST /api/v1/datastore` uploads documents without redirect.