### PR TITLE
fix(apigw): pre-authorized OID4VCI credential flow

### DIFF
--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -308,7 +308,7 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 	}
 
 	// Determine credential format from credential_configuration_id or credential_identifier
-	format, err := req.ResolveCredentialFormat(c.issuerMetadata)
+	format, err := req.ResolveCredentialFormat(c.issuerMetadata, authContext.AuthorizationDetails...)
 	if err != nil {
 		c.log.Error(err, "failed to resolve credential format")
 		return nil, err

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -308,6 +308,17 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 			responseDetails[i].CredentialIdentifiers = []string{uuid.NewString()}
 		}
 		reply.AuthorizationDetails = responseDetails
+
+		// Persist the generated credential_identifiers onto the authorization context so the
+		// Credential Endpoint can validate the credential_identifier the wallet echoes back
+		// (CredentialRequest.Validate checks membership in authContext.AuthorizationDetails).
+		// Without this the response advertises identifiers that are never stored, so every
+		// credential request fails with "credential_identifier ... not found".
+		authorizationContext.AuthorizationDetails = responseDetails
+		if err := c.cacheService.AuthContext.Update(ctx, authorizationContext); err != nil {
+			c.log.Error(err, "failed to persist credential_identifiers onto authorization context")
+			return nil, err
+		}
 	}
 
 	tokenDoc := &cache.Token{

--- a/internal/apigw/apiv1/handlers_oidcrp.go
+++ b/internal/apigw/apiv1/handlers_oidcrp.go
@@ -296,6 +296,12 @@ func (c *Client) OIDCRPCallback(ctx context.Context, req *OIDCRPCallbackRequest,
 		Scopes:       []string{session.CredentialType},
 		Nonce:        nonce,
 		AuthProvider: model.AuthProviderOIDC,
+		// Standalone OIDC RP trusts the IdP claims and stores them directly as the
+		// credential document (see StoreVCIDocuments below), i.e. assertion-based
+		// issuance. Mark the data source accordingly so the credential endpoint treats
+		// the registry identifier as best-effort (ResolveIdentifier above is allowed to
+		// fail with NO_IDENTITY_FOUND for subjects without an identity mapping).
+		DataSource:   string(model.DataSourceAssertion),
 		Identifier:   identifier,
 		AuthorizationDetails: []openid4vci.AuthorizationDetailsParameter{
 			{

--- a/pkg/openid4vci/credential.go
+++ b/pkg/openid4vci/credential.go
@@ -234,7 +234,9 @@ type CredentialResponseEncryption struct {
 // ResolveCredentialFormat determines the credential format from the request.
 // According to OpenID4VCI spec, the format is derived from the credential_configuration_id
 // which maps to a credential configuration in the issuer metadata.
-func (req *CredentialRequest) ResolveCredentialFormat(metadata *CredentialIssuerMetadataParameters) (string, error) {
+// authDetails is variadic so existing single-argument call sites keep compiling; callers
+// that have the Token Response authorization_details should expand them with `...`.
+func (req *CredentialRequest) ResolveCredentialFormat(metadata *CredentialIssuerMetadataParameters, authDetails ...AuthorizationDetailsParameter) (string, error) {
 	if metadata == nil {
 		return "", fmt.Errorf("metadata is required")
 	}
@@ -249,18 +251,27 @@ func (req *CredentialRequest) ResolveCredentialFormat(metadata *CredentialIssuer
 		return "", fmt.Errorf("unknown credential_configuration_id: %s", req.CredentialConfigurationID)
 	}
 
-	// Use credential_identifier to look up the format
-	// The credential_identifier maps to a credential configuration via authorization_details from the token response
-	// For now, we'll attempt to find a matching configuration by identifier
+	// Use credential_identifier to look up the format. Per OID4VCI the credential_identifier
+	// is an opaque value returned in the Token Response authorization_details; map it back to
+	// its credential_configuration_id via those authorization_details, then resolve the format.
 	if req.CredentialIdentifier != "" {
+		for _, ad := range authDetails {
+			if ad.CredentialConfigurationID != "" && slices.Contains(ad.CredentialIdentifiers, req.CredentialIdentifier) {
+				if metadata.CredentialConfigurationsSupported != nil {
+					if config, ok := metadata.CredentialConfigurationsSupported[ad.CredentialConfigurationID]; ok {
+						return config.Format, nil
+					}
+				}
+				return "", fmt.Errorf("unknown credential_configuration_id %q mapped from credential_identifier %q", ad.CredentialConfigurationID, req.CredentialIdentifier)
+			}
+		}
+		// Legacy fallback: some issuers use the configuration id directly as the identifier.
 		if metadata.CredentialConfigurationsSupported != nil {
-			// Try to match by credential identifier (may be same as configuration ID in some cases)
 			if config, ok := metadata.CredentialConfigurationsSupported[req.CredentialIdentifier]; ok {
 				return config.Format, nil
 			}
-			return "", fmt.Errorf("could not resolve credential_identifier %q to a credential configuration", req.CredentialIdentifier)
 		}
-		return "", fmt.Errorf("unknown credential_identifier: %s", req.CredentialIdentifier)
+		return "", fmt.Errorf("could not resolve credential_identifier %q to a credential configuration", req.CredentialIdentifier)
 	}
 
 	return "", fmt.Errorf("either credential_configuration_id or credential_identifier must be provided")

--- a/pkg/openid4vci/credential_test.go
+++ b/pkg/openid4vci/credential_test.go
@@ -201,6 +201,7 @@ func TestResolveCredentialFormat(t *testing.T) {
 		name        string
 		request     *CredentialRequest
 		metadata    *CredentialIssuerMetadataParameters
+		authDetails []AuthorizationDetailsParameter
 		wantFormat  string
 		wantErr     bool
 		errContains string
@@ -233,6 +234,28 @@ func TestResolveCredentialFormat(t *testing.T) {
 				},
 			},
 			wantFormat: "mso_mdoc",
+			wantErr:    false,
+		},
+		{
+			name: "resolve credential_identifier via authorization_details mapping",
+			request: &CredentialRequest{ // #nosec G101
+				CredentialIdentifier: "f08b0aa2-d7aa-4334-8ab0-d6845a972e19",
+			},
+			metadata: &CredentialIssuerMetadataParameters{
+				CredentialConfigurationsSupported: map[string]CredentialConfigurationsSupported{
+					"pid_config": {
+						Format: "dc+sd-jwt",
+					},
+				},
+			},
+			authDetails: []AuthorizationDetailsParameter{
+				{
+					Type:                      "openid_credential",
+					CredentialConfigurationID: "pid_config",
+					CredentialIdentifiers:     []string{"f08b0aa2-d7aa-4334-8ab0-d6845a972e19"},
+				},
+			},
+			wantFormat: "dc+sd-jwt",
 			wantErr:    false,
 		},
 		{
@@ -323,7 +346,7 @@ func TestResolveCredentialFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			format, err := tt.request.ResolveCredentialFormat(tt.metadata)
+			format, err := tt.request.ResolveCredentialFormat(tt.metadata, tt.authDetails...)
 
 			if tt.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
The credential endpoint rejected every pre-authorized issuance because the token-response credential_identifiers were never usable downstream, and the standalone OIDC-RP offer demanded a registry identifier it could not resolve.

- handlers_oauth.go (Token): persist the generated credential_identifiers onto the authorization context via AuthContext.Update. They were only added to the response copy and never stored, so CredentialRequest.Validate could never find them ("credential_identifier ... not found in Token Response authorization_details").
- pkg/openid4vci/credential.go (ResolveCredentialFormat): map credential_identifier back to its credential_configuration_id through the authorization_details, then resolve the format from issuer metadata. It previously looked the random UUID up directly as a config key ("could not resolve credential_identifier ...").
- handlers_issuer.go: pass authContext.AuthorizationDetails to ResolveCredentialFormat.
- handlers_oidcrp.go (standalone offer): set DataSource = assertion so the registry identifier is best-effort; the flow already stores the trusted IdP claims as the document, so an unmapped subject no longer fails with "no identifier in auth context".