### PR TITLE
fix: add OID4VCI endpoints to isOIDCEndpoint for correct content negotiation

### DIFF
--- a/pkg/httphelpers/rendering.go
+++ b/pkg/httphelpers/rendering.go
@@ -56,6 +56,10 @@ func isOIDCEndpoint(path string) bool {
 		"/oidcrp/",
 		"/samlsp/",
 		"/op/par",
+		"/nonce",
+		"/credential",
+		"/deferred_credential",
+		"/notification",
 	}
 
 	for _, indicator := range oidcIndicators {

--- a/pkg/httphelpers/rendering_test.go
+++ b/pkg/httphelpers/rendering_test.go
@@ -1,0 +1,40 @@
+package httphelpers
+
+import "testing"
+
+func TestIsOIDCEndpoint(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// Existing OIDC/OAuth2 endpoints
+		{"/.well-known/openid-configuration", true},
+		{"/op/jwks", true},
+		{"/op/register", true},
+		{"/op/token", true},
+		{"/op/userinfo", true},
+		{"/oidcrp/callback", true},
+		{"/samlsp/acs", true},
+		{"/op/par", true},
+
+		// OID4VCI endpoints (issue #437)
+		{"/nonce", true},
+		{"/credential", true},
+		{"/credential-offer/abc123", true},
+		{"/deferred_credential", true},
+		{"/notification", true},
+
+		// Non-OIDC endpoints should return false
+		{"/api/v1/users", false},
+		{"/health", false},
+		{"/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isOIDCEndpoint(tt.path); got != tt.want {
+				t.Errorf("isOIDCEndpoint(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add OID4VCI endpoints (`/nonce`, `/credential`, `/deferred_credential`, `/notification`) to the `isOIDCEndpoint()` allowlist in `pkg/httphelpers/rendering.go`.

## Problem

When a client sends `Accept: text/plain, application/json, ...` (with `text/plain` listed first), OID4VCI endpoints return Go struct literals (`%v` format) instead of JSON. The OpenID Foundation conformance suite uses exactly this Accept header, causing all 20 non-metadata VCI tests to fail with `MalformedJsonException`.

## Fix

The existing `isOIDCEndpoint()` safeguard already forces JSON for known OIDC/OAuth2 paths but was missing the OID4VCI endpoints. This PR adds the four missing path indicators:
- `/nonce`
- `/credential` (also covers `/credential-offer`)
- `/deferred_credential`
- `/notification`

Also adds unit tests for `isOIDCEndpoint()`.

Fixes #437