### PR TITLE
fix: support multiple redirect URIs with wildcard path matching

### DIFF
--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -34,7 +34,7 @@ func (c *Client) OAuthPar(ctx context.Context, req *openid4vci.PARRequest) (*ope
 	c.log.Debug("OAuthPar", "req", req)
 	oauthClient, err := c.cfg.APIGW.Delivery.OpenID4VCI.Clients.Allow(req.ClientID, req.RedirectURI, req.Scope)
 	if err != nil {
-		c.log.Info("OAuthPar client validation failed", "client_id", req.ClientID, "error", err)
+		c.log.Debug("OAuthPar client validation failed", "client_id", req.ClientID, "error", err)
 		// Use a generic description to avoid leaking internal configuration details.
 		return nil, oauth2.NewOAuthErrorWithCause(oauth2.ErrCodeInvalidClient, "client validation failed", 401, err)
 	}

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -34,7 +34,9 @@ func (c *Client) OAuthPar(ctx context.Context, req *openid4vci.PARRequest) (*ope
 	c.log.Debug("OAuthPar", "req", req)
 	oauthClient, err := c.cfg.APIGW.Delivery.OpenID4VCI.Clients.Allow(req.ClientID, req.RedirectURI, req.Scope)
 	if err != nil {
-		return nil, oauth2.NewOAuthErrorWithCause(oauth2.ErrCodeInvalidClient, err.Error(), 401, err)
+		c.log.Info("OAuthPar client validation failed", "client_id", req.ClientID, "error", err)
+		// Use a generic description to avoid leaking internal configuration details.
+		return nil, oauth2.NewOAuthErrorWithCause(oauth2.ErrCodeInvalidClient, "client validation failed", 401, err)
 	}
 
 	// Public clients MUST use PKCE (RFC 6749 Section 2.1)

--- a/pkg/oauth2/clients.go
+++ b/pkg/oauth2/clients.go
@@ -139,6 +139,9 @@ func (c *Clients) Allow(clientID, redirectURI, scope string) (*Client, error) {
 		return nil, errors.New("client not found in config")
 	}
 
+	if len(client.RedirectURIs) == 0 {
+		return nil, errors.New("no redirect_uri configured for client")
+	}
 	if !client.RedirectURIs.Contains(redirectURI) {
 		return nil, errors.New("redirect_uri does not match any allowed URI")
 	}

--- a/pkg/oauth2/clients.go
+++ b/pkg/oauth2/clients.go
@@ -125,7 +125,7 @@ type Clients map[string]*Client
 // Get returns the Client for the given clientID, or an error if not found.
 func (c *Clients) Get(clientID string) (*Client, error) {
 	client, ok := (*c)[clientID]
-	if !ok {
+	if !ok || client == nil {
 		return nil, errors.New("client not found in config")
 	}
 	return client, nil
@@ -135,7 +135,7 @@ func (c *Clients) Get(clientID string) (*Client, error) {
 // The caller can inspect the returned Client (e.g. Type) to enforce additional constraints.
 func (c *Clients) Allow(clientID, redirectURI, scope string) (*Client, error) {
 	client, ok := (*c)[clientID]
-	if !ok {
+	if !ok || client == nil {
 		return nil, errors.New("client not found in config")
 	}
 

--- a/pkg/oauth2/clients_test.go
+++ b/pkg/oauth2/clients_test.go
@@ -18,6 +18,12 @@ var mockClients = Clients{
 		RedirectURIs: RedirectURIs{"https://example.com/callback"},
 		Scopes:       []string{"diploma", "elm"},
 	},
+	"client_no_redirect": {
+		Type:         "public",
+		RedirectURIs: RedirectURIs{},
+		Scopes:       []string{"ehic"},
+	},
+	"client_nil": nil,
 }
 
 func TestAllow(t *testing.T) {
@@ -78,21 +84,15 @@ func TestAllow(t *testing.T) {
 			clientID:    "client_no_redirect",
 			redirectURI: "https://example.com/callback",
 			scope:       "ehic",
-			clients: Clients{
-				"client_no_redirect": {
-					Type:         "public",
-					RedirectURIs: RedirectURIs{},
-					Scopes:       []string{"ehic"},
-				},
-			},
-			want: want{client: nil, err: errors.New("no redirect_uri configured for client")},
+			clients:     mockClients,
+			want:        want{client: nil, err: errors.New("no redirect_uri configured for client")},
 		},
 		{
 			name:        "nil client value in config",
 			clientID:    "client_nil",
 			redirectURI: "https://example.com/callback",
 			scope:       "ehic",
-			clients:     Clients{"client_nil": nil},
+			clients:     mockClients,
 			want:        want{client: nil, err: errors.New("client not found in config")},
 		},
 	}

--- a/pkg/oauth2/clients_test.go
+++ b/pkg/oauth2/clients_test.go
@@ -73,6 +73,20 @@ func TestAllow(t *testing.T) {
 			clients:     mockClients,
 			want:        want{client: nil, err: errors.New("redirect_uri does not match any allowed URI")},
 		},
+		{
+			name:        "client with no redirect URIs configured",
+			clientID:    "client_no_redirect",
+			redirectURI: "https://example.com/callback",
+			scope:       "ehic",
+			clients: Clients{
+				"client_no_redirect": {
+					Type:         "public",
+					RedirectURIs: RedirectURIs{},
+					Scopes:       []string{"ehic"},
+				},
+			},
+			want: want{client: nil, err: errors.New("no redirect_uri configured for client")},
+		},
 	}
 
 	for _, tt := range tts {
@@ -136,9 +150,9 @@ func TestRedirectURIsContains(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "wildcard path traversal via dot-segments",
+			name:     "wildcard path traversal via percent-encoded dot-segments",
 			uris:     RedirectURIs{"https://example.com/test/a/*"},
-			check:    "https://example.com/test/a/../evil",
+			check:    "https://example.com/test/a/%2e%2e/evil",
 			expected: false,
 		},
 		{

--- a/pkg/oauth2/clients_test.go
+++ b/pkg/oauth2/clients_test.go
@@ -136,6 +136,12 @@ func TestRedirectURIsContains(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "wildcard path traversal via dot-segments",
+			uris:     RedirectURIs{"https://example.com/test/a/*"},
+			check:    "https://example.com/test/a/../evil",
+			expected: false,
+		},
+		{
 			name:     "multiple uris first matches",
 			uris:     RedirectURIs{"https://example.com/cb", "https://other.com/cb"},
 			check:    "https://example.com/cb",

--- a/pkg/oauth2/clients_test.go
+++ b/pkg/oauth2/clients_test.go
@@ -87,6 +87,14 @@ func TestAllow(t *testing.T) {
 			},
 			want: want{client: nil, err: errors.New("no redirect_uri configured for client")},
 		},
+		{
+			name:        "nil client value in config",
+			clientID:    "client_nil",
+			redirectURI: "https://example.com/callback",
+			scope:       "ehic",
+			clients:     Clients{"client_nil": nil},
+			want:        want{client: nil, err: errors.New("client not found in config")},
+		},
 	}
 
 	for _, tt := range tts {


### PR DESCRIPTION
Replace `Client.RedirectURI` (single string) with `Client.RedirectURIs` (custom type that accepts single string or array in YAML/JSON).

## Changes

- **`RedirectURIs` type**: flexible unmarshalling (single string or array) for both YAML and JSON
- **`Contains()` method**: exact matching + `/*` suffix wildcard (enforces scheme+host equality, only path prefix is flexible)
- **`Allow()`**: uses `Contains()` instead of `reflect.DeepEqual`
- **`endpoints_users.go`**: updated to use `client.RedirectURIs[0]` instead of `client.RedirectURI`
- **Tests**: 7 test cases for `TestRedirectURIsContains` covering exact, wildcard, wrong host/scheme, multiple URIs

## Motivation

The conformance suite uses dynamic redirect URIs with path suffixes. The old single-string `RedirectURI` with exact equality can't match these. Wildcard support allows configuring `https://host/*` in config.

Fixes #440