### PR TITLE
fix: credential_identifiers end-to-end — token persistence, format resolution, DataSource

### DIFF
--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -308,7 +308,7 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 	}
 
 	// Determine credential format from credential_configuration_id or credential_identifier
-	format, err := req.ResolveCredentialFormat(c.issuerMetadata, authContext.AuthorizationDetails)
+	format, err := req.ResolveCredentialFormatWithAuthDetails(c.issuerMetadata, authContext.AuthorizationDetails)
 	if err != nil {
 		c.log.Error(err, "failed to resolve credential format")
 		return nil, err

--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -308,7 +308,7 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 	}
 
 	// Determine credential format from credential_configuration_id or credential_identifier
-	format, err := req.ResolveCredentialFormat(c.issuerMetadata)
+	format, err := req.ResolveCredentialFormat(c.issuerMetadata, authContext.AuthorizationDetails)
 	if err != nil {
 		c.log.Error(err, "failed to resolve credential format")
 		return nil, err

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -308,6 +308,10 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 			responseDetails[i].CredentialIdentifiers = []string{uuid.NewString()}
 		}
 		reply.AuthorizationDetails = responseDetails
+
+		// Persist credential_identifiers back so the credential endpoint can
+		// match them when the client presents the access token.
+		authorizationContext.AuthorizationDetails = responseDetails
 	}
 
 	tokenDoc := &cache.Token{
@@ -315,8 +319,13 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		ExpiresAt:   time.Now().Add(time.Duration(reply.ExpiresIn) * time.Second).Unix(),
 	}
 
-	if err := c.cacheService.AuthContext.AddToken(ctx, authorizationContext.Code, tokenDoc); err != nil {
-		c.log.Error(err, "failed to add token")
+	// Set the token on the in-memory struct so that Update() persists it
+	// alongside any updated AuthorizationDetails (credential_identifiers).
+	// Using Update() instead of AddToken() avoids a race where AddToken
+	// writes the token and a subsequent Update() overwrites it with nil.
+	authorizationContext.Token = tokenDoc
+	if err := c.cacheService.AuthContext.Update(ctx, authorizationContext); err != nil {
+		c.log.Error(err, "failed to persist token and authorization details")
 		return nil, err
 	}
 

--- a/internal/apigw/apiv1/handlers_oidcrp.go
+++ b/internal/apigw/apiv1/handlers_oidcrp.go
@@ -295,6 +295,19 @@ func (c *Client) OIDCRPCallback(ctx context.Context, req *OIDCRPCallbackRequest,
 		c.log.Debug("standalone OIDC: could not resolve data source", "error", credSourceErr)
 	}
 
+	// Fail fast if we have neither an identifier nor a resolved data source —
+	// a credential offer created without either cannot be redeemed.
+	if identifier == "" && credSourceErr != nil {
+		span.SetStatus(codes.Error, "cannot create credential offer without identifier or data source")
+		return nil, fmt.Errorf("failed to resolve data source for credential type %q: %w (identifier error: %v)", session.CredentialType, credSourceErr, resolveErr)
+	}
+
+	// Fail fast if the data source requires an identifier but none was resolved.
+	if identifier == "" && credSourceErr == nil && credSource.DataSource != model.DataSourceAssertion {
+		span.SetStatus(codes.Error, "data source requires identifier but none was resolved")
+		return nil, fmt.Errorf("data source %q for credential type %q requires an identifier", credSource.DataSource, session.CredentialType)
+	}
+
 	authCtx := &cache.AuthorizationContext{
 		SessionID:    preAuthCode,
 		Code:         preAuthCode,

--- a/internal/apigw/apiv1/handlers_oidcrp.go
+++ b/internal/apigw/apiv1/handlers_oidcrp.go
@@ -287,6 +287,14 @@ func (c *Client) OIDCRPCallback(ctx context.Context, req *OIDCRPCallbackRequest,
 		c.log.Debug("standalone OIDC: could not resolve identifier", "error", resolveErr)
 	}
 
+	// Resolve the data source for this credential type so that the credential
+	// endpoint knows whether the identity is assertion-based (and can skip
+	// the identifier requirement).
+	credSource, credSourceErr := c.cfg.APIGW.DataSources.ResolveDataSource(session.CredentialType, string(model.AuthProviderOIDC))
+	if credSourceErr != nil {
+		c.log.Debug("standalone OIDC: could not resolve data source", "error", credSourceErr)
+	}
+
 	authCtx := &cache.AuthorizationContext{
 		SessionID:    preAuthCode,
 		Code:         preAuthCode,
@@ -303,6 +311,9 @@ func (c *Client) OIDCRPCallback(ctx context.Context, req *OIDCRPCallbackRequest,
 				CredentialConfigurationID: session.CredentialType,
 			},
 		},
+	}
+	if credSourceErr == nil {
+		authCtx.DataSource = string(credSource.DataSource)
 	}
 	if saveErr := c.cacheService.AuthContext.Save(ctx, authCtx); saveErr != nil {
 		span.SetStatus(codes.Error, "pre-auth code persistence failed")

--- a/pkg/openid4vci/credential.go
+++ b/pkg/openid4vci/credential.go
@@ -234,7 +234,9 @@ type CredentialResponseEncryption struct {
 // ResolveCredentialFormat determines the credential format from the request.
 // According to OpenID4VCI spec, the format is derived from the credential_configuration_id
 // which maps to a credential configuration in the issuer metadata.
-func (req *CredentialRequest) ResolveCredentialFormat(metadata *CredentialIssuerMetadataParameters) (string, error) {
+// When credential_identifier is used, the authorizationDetails from the token response
+// are needed to map the identifier to a credential_configuration_id.
+func (req *CredentialRequest) ResolveCredentialFormat(metadata *CredentialIssuerMetadataParameters, authorizationDetails []AuthorizationDetailsParameter) (string, error) {
 	if metadata == nil {
 		return "", fmt.Errorf("metadata is required")
 	}
@@ -249,18 +251,21 @@ func (req *CredentialRequest) ResolveCredentialFormat(metadata *CredentialIssuer
 		return "", fmt.Errorf("unknown credential_configuration_id: %s", req.CredentialConfigurationID)
 	}
 
-	// Use credential_identifier to look up the format
-	// The credential_identifier maps to a credential configuration via authorization_details from the token response
-	// For now, we'll attempt to find a matching configuration by identifier
+	// Use credential_identifier to look up the format via authorization_details.
+	// The credential_identifier maps to a credential_configuration_id in the
+	// authorization_details that were returned in the token response.
 	if req.CredentialIdentifier != "" {
-		if metadata.CredentialConfigurationsSupported != nil {
-			// Try to match by credential identifier (may be same as configuration ID in some cases)
-			if config, ok := metadata.CredentialConfigurationsSupported[req.CredentialIdentifier]; ok {
-				return config.Format, nil
+		for _, ad := range authorizationDetails {
+			if slices.Contains(ad.CredentialIdentifiers, req.CredentialIdentifier) {
+				if metadata.CredentialConfigurationsSupported != nil {
+					if config, ok := metadata.CredentialConfigurationsSupported[ad.CredentialConfigurationID]; ok {
+						return config.Format, nil
+					}
+				}
+				return "", fmt.Errorf("credential_configuration_id %q from authorization_details not found in issuer metadata", ad.CredentialConfigurationID)
 			}
-			return "", fmt.Errorf("could not resolve credential_identifier %q to a credential configuration", req.CredentialIdentifier)
 		}
-		return "", fmt.Errorf("unknown credential_identifier: %s", req.CredentialIdentifier)
+		return "", fmt.Errorf("could not resolve credential_identifier %q to a credential configuration", req.CredentialIdentifier)
 	}
 
 	return "", fmt.Errorf("either credential_configuration_id or credential_identifier must be provided")

--- a/pkg/openid4vci/credential.go
+++ b/pkg/openid4vci/credential.go
@@ -234,9 +234,16 @@ type CredentialResponseEncryption struct {
 // ResolveCredentialFormat determines the credential format from the request.
 // According to OpenID4VCI spec, the format is derived from the credential_configuration_id
 // which maps to a credential configuration in the issuer metadata.
+//
+// Deprecated: Use ResolveCredentialFormatWithAuthDetails for credential_identifier support.
+func (req *CredentialRequest) ResolveCredentialFormat(metadata *CredentialIssuerMetadataParameters) (string, error) {
+	return req.ResolveCredentialFormatWithAuthDetails(metadata, nil)
+}
+
+// ResolveCredentialFormatWithAuthDetails determines the credential format from the request.
 // When credential_identifier is used, the authorizationDetails from the token response
 // are needed to map the identifier to a credential_configuration_id.
-func (req *CredentialRequest) ResolveCredentialFormat(metadata *CredentialIssuerMetadataParameters, authorizationDetails []AuthorizationDetailsParameter) (string, error) {
+func (req *CredentialRequest) ResolveCredentialFormatWithAuthDetails(metadata *CredentialIssuerMetadataParameters, authorizationDetails []AuthorizationDetailsParameter) (string, error) {
 	if metadata == nil {
 		return "", fmt.Errorf("metadata is required")
 	}
@@ -257,6 +264,11 @@ func (req *CredentialRequest) ResolveCredentialFormat(metadata *CredentialIssuer
 	if req.CredentialIdentifier != "" {
 		for _, ad := range authorizationDetails {
 			if slices.Contains(ad.CredentialIdentifiers, req.CredentialIdentifier) {
+				// Format-based authorization_details: the entry carries Format directly
+				// instead of CredentialConfigurationID (OID4VCI §5.1.1).
+				if ad.CredentialConfigurationID == "" && ad.Format != "" {
+					return ad.Format, nil
+				}
 				if metadata.CredentialConfigurationsSupported != nil {
 					if config, ok := metadata.CredentialConfigurationsSupported[ad.CredentialConfigurationID]; ok {
 						return config.Format, nil

--- a/pkg/openid4vci/credential_test.go
+++ b/pkg/openid4vci/credential_test.go
@@ -334,11 +334,30 @@ func TestResolveCredentialFormat(t *testing.T) {
 			wantFormat: "ldp_vc",
 			wantErr:    false,
 		},
+		{
+			name: "resolve by credential_identifier via format-based authorization_details",
+			request: &CredentialRequest{
+				CredentialIdentifier: "format_based_id",
+			},
+			metadata: &CredentialIssuerMetadataParameters{
+				CredentialConfigurationsSupported: map[string]CredentialConfigurationsSupported{},
+			},
+			authorizationDetails: []AuthorizationDetailsParameter{
+				{
+					Type:                  "openid_credential",
+					Format:                "vc+sd-jwt",
+					VCT:                   "VerifiablePortableDocumentA1",
+					CredentialIdentifiers: []string{"format_based_id"},
+				},
+			},
+			wantFormat: "vc+sd-jwt",
+			wantErr:    false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			format, err := tt.request.ResolveCredentialFormat(tt.metadata, tt.authorizationDetails)
+			format, err := tt.request.ResolveCredentialFormatWithAuthDetails(tt.metadata, tt.authorizationDetails)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/openid4vci/credential_test.go
+++ b/pkg/openid4vci/credential_test.go
@@ -198,12 +198,13 @@ func TestExtractJWK(t *testing.T) {
 
 func TestResolveCredentialFormat(t *testing.T) {
 	tests := []struct {
-		name        string
-		request     *CredentialRequest
-		metadata    *CredentialIssuerMetadataParameters
-		wantFormat  string
-		wantErr     bool
-		errContains string
+		name                 string
+		request              *CredentialRequest
+		metadata             *CredentialIssuerMetadataParameters
+		authorizationDetails []AuthorizationDetailsParameter
+		wantFormat           string
+		wantErr              bool
+		errContains          string
 	}{
 		{
 			name: "resolve by credential_configuration_id",
@@ -221,15 +222,22 @@ func TestResolveCredentialFormat(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name: "resolve by credential_identifier",
+			name: "resolve by credential_identifier via authorization_details",
 			request: &CredentialRequest{ // #nosec G101
 				CredentialIdentifier: "ehic_identifier",
 			},
 			metadata: &CredentialIssuerMetadataParameters{
 				CredentialConfigurationsSupported: map[string]CredentialConfigurationsSupported{
-					"ehic_identifier": {
+					"ehic_config": {
 						Format: "mso_mdoc",
 					},
+				},
+			},
+			authorizationDetails: []AuthorizationDetailsParameter{
+				{
+					Type:                      "openid_credential",
+					CredentialConfigurationID: "ehic_config",
+					CredentialIdentifiers:     []string{"ehic_identifier"},
 				},
 			},
 			wantFormat: "mso_mdoc",
@@ -245,6 +253,13 @@ func TestResolveCredentialFormat(t *testing.T) {
 					"pid_config": {
 						Format: "dc+sd-jwt",
 					},
+				},
+			},
+			authorizationDetails: []AuthorizationDetailsParameter{
+				{
+					Type:                      "openid_credential",
+					CredentialConfigurationID: "pid_config",
+					CredentialIdentifiers:     []string{"other_identifier"},
 				},
 			},
 			wantErr:     true,
@@ -323,7 +338,7 @@ func TestResolveCredentialFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			format, err := tt.request.ResolveCredentialFormat(tt.metadata)
+			format, err := tt.request.ResolveCredentialFormat(tt.metadata, tt.authorizationDetails)
 
 			if tt.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Three interconnected bugs preventing OID4VCI credential issuance via `credential_identifier`:

## Bug 1: Token persistence race (#439)

`AddToken()` writes token to MongoDB, then `Update()` replaces the entire document with in-memory struct having `Token: nil`, erasing the token. Fix: set token on struct, use single `Update()`.

## Bug 2: Format resolution with credential_identifier (#441)

`ResolveCredentialFormat()` looked up UUID `credential_identifier` directly in `metadata.CredentialConfigurationsSupported` (keyed by `credential_configuration_id`). These are different values. Fix: accept `authorizationDetails` parameter, map `identifier → config_id → format`.

## Bug 3: Missing DataSource on pre-auth context (#442)

Pre-auth flow in `handlers_oidcrp.go` didn't set `DataSource`, causing `requireIdentifier()` to reject empty identifiers. Fix: resolve DataSource from config.

## Files changed

- `internal/apigw/apiv1/handlers_oauth.go` — token persistence
- `internal/apigw/apiv1/handlers_issuer.go` — pass authorizationDetails to resolver
- `internal/apigw/apiv1/handlers_oidcrp.go` — set DataSource on pre-auth context
- `pkg/openid4vci/credential.go` — ResolveCredentialFormat accepts authorizationDetails
- `pkg/openid4vci/credential_test.go` — updated tests

Fixes #439, fixes #441, fixes #442