### PR TITLE
fix: omit empty tx_code from credential offer JSON serialization

### DIFF
--- a/pkg/openid4vci/credential_offer.go
+++ b/pkg/openid4vci/credential_offer.go
@@ -47,15 +47,15 @@ type GrantAuthorizationCode struct {
 // GrantPreAuthorizedCode authorization code grant
 type GrantPreAuthorizedCode struct {
 	PreAuthorizedCode   string `json:"pre-authorized_code" bson:"pre-authorized_code" validate:"required"`
-	TXCode              TXCode `json:"tx_code" bson:"tx_code,omitempty"`
-	AuthorizationServer string `json:"authorization_server,omitempty" bson:"authorization_server,omitempty"`
+	TXCode              *TXCode `json:"tx_code,omitempty" bson:"tx_code,omitempty"`
+	AuthorizationServer string  `json:"authorization_server,omitempty" bson:"authorization_server,omitempty"`
 }
 
 // TXCode Transaction Code
 type TXCode struct {
-	InputMode   string `json:"input_mode" bson:"input_mode" validate:"oneof=numeric text"`
-	Length      int    `json:"length"`
-	Description string `json:"description"`
+	InputMode   string `json:"input_mode,omitempty" bson:"input_mode" validate:"oneof=numeric text"`
+	Length      int    `json:"length,omitempty" bson:"length,omitempty"`
+	Description string `json:"description,omitempty" bson:"description,omitempty"`
 }
 
 type CredentialOfferURIRequest struct {

--- a/pkg/openid4vci/credential_offer.go
+++ b/pkg/openid4vci/credential_offer.go
@@ -53,7 +53,7 @@ type GrantPreAuthorizedCode struct {
 
 // TXCode Transaction Code
 type TXCode struct {
-	InputMode   string `json:"input_mode,omitempty" bson:"input_mode" validate:"oneof=numeric text"`
+	InputMode   string `json:"input_mode,omitempty" bson:"input_mode,omitempty" validate:"omitempty,oneof=numeric text"`
 	Length      int    `json:"length,omitempty" bson:"length,omitempty"`
 	Description string `json:"description,omitempty" bson:"description,omitempty"`
 }

--- a/pkg/openid4vci/credential_offer_test.go
+++ b/pkg/openid4vci/credential_offer_test.go
@@ -731,3 +731,18 @@ func TestNewCredentialOffer(t *testing.T) {
 		assert.NotEqual(t, r1.ID, r2.ID, "each offer must have a unique token")
 	})
 }
+
+func TestGrantPreAuthorizedCode_TXCodeOmitted(t *testing.T) {
+	grant := &GrantPreAuthorizedCode{
+		PreAuthorizedCode: "test-code",
+		TXCode:            nil,
+	}
+	data, err := json.Marshal(grant)
+	assert.NoError(t, err)
+
+	var decoded map[string]any
+	err = json.Unmarshal(data, &decoded)
+	assert.NoError(t, err)
+	_, hasTXCode := decoded["tx_code"]
+	assert.False(t, hasTXCode, "tx_code key must be absent from JSON when TXCode is nil")
+}

--- a/pkg/openid4vci/credential_offer_test.go
+++ b/pkg/openid4vci/credential_offer_test.go
@@ -43,7 +43,7 @@ func TestCredentialOffer(t *testing.T) {
 				Grants: map[string]any{
 					"urn:ietf:params:oauth:grant-type:pre-authorized_code": &GrantPreAuthorizedCode{
 						PreAuthorizedCode: "oaKazRN8I0IbtZ0C7JuMn5",
-						TXCode: TXCode{
+						TXCode: &TXCode{
 							InputMode:   "numeric",
 							Length:      4,
 							Description: "Please provide the one-time code that was sent via e-mail",
@@ -177,7 +177,7 @@ func TestCredentialOfferParameters_CredentialOffer(t *testing.T) {
 				Grants: map[string]any{
 					"urn:ietf:params:oauth:grant-type:pre-authorized_code": GrantPreAuthorizedCode{
 						PreAuthorizedCode: "test-pre-auth-code-123",
-						TXCode: TXCode{
+						TXCode: &TXCode{
 							InputMode:   "numeric",
 							Length:      6,
 							Description: "Enter the 6-digit code",
@@ -363,7 +363,7 @@ func TestCredentialOfferParameters_CredentialOffer_RoundTrip(t *testing.T) {
 				Grants: map[string]any{
 					"urn:ietf:params:oauth:grant-type:pre-authorized_code": GrantPreAuthorizedCode{
 						PreAuthorizedCode: "test-code-xyz",
-						TXCode: TXCode{
+						TXCode: &TXCode{
 							InputMode:   "text",
 							Length:      8,
 							Description: "Enter the code",
@@ -409,7 +409,7 @@ func TestParseCredentialOffer(t *testing.T) {
 				Grants: map[string]any{
 					"urn:ietf:params:oauth:grant-type:pre-authorized_code": &GrantPreAuthorizedCode{
 						PreAuthorizedCode:   "d270fee1-9185-4e60-9901-d291e1338d7a",
-						TXCode:              TXCode{},
+						TXCode:              nil,
 						AuthorizationServer: "",
 					},
 				},

--- a/pkg/openid4vci/token_test.go
+++ b/pkg/openid4vci/token_test.go
@@ -17,7 +17,7 @@ func TestTokenRequestValidationCredentialOfferRequest(t *testing.T) {
 				Grants: map[string]any{
 					"ietf:params:oauth:grant-type:pre-authorized_code": GrantPreAuthorizedCode{
 						PreAuthorizedCode: "",
-						TXCode: TXCode{
+						TXCode: &TXCode{
 							InputMode:   "numeric",
 							Length:      1234,
 							Description: "Pincode for the transaction",


### PR DESCRIPTION
## Problem

When no `tx_code` is configured, the credential offer still includes it:
```json
{"tx_code": {"input_mode": "", "length": 0, "description": ""}}
```

The conformance suite interprets this as requiring user PIN entry.

## Changes

- `GrantPreAuthorizedCode.TXCode`: changed from `TXCode` (value) to `*TXCode` (pointer) with `json:"tx_code,omitempty"`
- `TXCode` struct fields: added `omitempty` to all JSON tags
- Tests updated to use pointer initialization

Fixes #444