### PR TITLE
fix: add Cache-Control: no-store to nonce endpoint response

### DIFF
--- a/internal/apigw/httpserver/endpoints.go
+++ b/internal/apigw/httpserver/endpoints.go
@@ -56,12 +56,14 @@ func (s *Service) endpointVCINonce(ctx context.Context, c *gin.Context) (any, er
 	ctx, span := s.tracer.Start(ctx, "httpserver:endpointNonce")
 	defer span.End()
 
+	// Set Cache-Control unconditionally per spec requirement
+	c.Header("Cache-Control", "no-store")
+
 	reply, err := s.apiv1.VCINonce(ctx)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
-	c.Header("Cache-Control", "no-store")
 	return reply, nil
 }
 

--- a/internal/apigw/httpserver/endpoints.go
+++ b/internal/apigw/httpserver/endpoints.go
@@ -61,6 +61,7 @@ func (s *Service) endpointVCINonce(ctx context.Context, c *gin.Context) (any, er
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
+	c.Header("Cache-Control", "no-store")
 	return reply, nil
 }
 


### PR DESCRIPTION
## Problem

The nonce endpoint (`POST /nonce`) does not include `Cache-Control: no-store` in its response headers.

**Spec reference:** OID4VCI §12.2.2 — the nonce endpoint response MUST include `Cache-Control: no-store`.

**Conformance check:** `VCICheckNonceCacheControlHeader` fails without this header.

## Fix

Set `Cache-Control: no-store` in `endpointVCINonce` before returning the response. One-line change.

Previously this was handled only by the nginx reverse proxy config (`add_header`), which masks the app-level gap.

Fixes #443