### PR TITLE
fix: preserve redirect_uri query parameters in authorization redirect

### DIFF
--- a/internal/apigw/apiv1/handlers_users.go
+++ b/internal/apigw/apiv1/handlers_users.go
@@ -78,7 +78,12 @@ func (c *Client) UserLookup(ctx context.Context, req *vcclient.UserLookupRequest
 		return nil, fmt.Errorf("failed to parse redirect URI %s: %w", authorizationContext.WalletURI, err)
 	}
 
-	redirectURL.RawQuery = url.Values{"code": {authorizationContext.Code}, "state": {authorizationContext.State}}.Encode()
+	// Preserve any existing query parameters from the registered redirect_uri
+	// (RFC 6749 §3.1.2) and add the authorization response parameters.
+	q := redirectURL.Query()
+	q.Set("code", authorizationContext.Code)
+	q.Set("state", authorizationContext.State)
+	redirectURL.RawQuery = q.Encode()
 
 	var svgTemplateClaims map[string]sdjwtvc.SVGValue
 	var presentationClaims map[string]any

--- a/internal/apigw/apiv1/handlers_users.go
+++ b/internal/apigw/apiv1/handlers_users.go
@@ -68,22 +68,16 @@ func (c *Client) UserLookup(ctx context.Context, req *vcclient.UserLookupRequest
 	})
 	if err != nil {
 		c.log.Error(err, "failed to get authorization for user", "request_uri", req.RequestURI)
+		return nil, err
 	}
 
 	c.log.Debug("UserLookup", "auth", authorizationContext)
 
-	redirectURL, err := url.Parse(authorizationContext.WalletURI)
+	redirectResult, err := buildAuthorizationRedirectURL(authorizationContext.WalletURI, authorizationContext.Code, authorizationContext.State, c.cfg.APIGW.PublicURL)
 	if err != nil {
-		c.log.Error(err, "failed to parse redirect URI", "redirect_uri", authorizationContext.WalletURI)
-		return nil, fmt.Errorf("failed to parse redirect URI %s: %w", authorizationContext.WalletURI, err)
+		c.log.Error(err, "failed to build redirect URL", "redirect_uri", authorizationContext.WalletURI)
+		return nil, err
 	}
-
-	// Preserve any existing query parameters from the registered redirect_uri
-	// (RFC 6749 §3.1.2) and add the authorization response parameters.
-	q := redirectURL.Query()
-	q.Set("code", authorizationContext.Code)
-	q.Set("state", authorizationContext.State)
-	redirectURL.RawQuery = q.Encode()
 
 	var svgTemplateClaims map[string]sdjwtvc.SVGValue
 	var presentationClaims map[string]any
@@ -163,7 +157,7 @@ func (c *Client) UserLookup(ctx context.Context, req *vcclient.UserLookupRequest
 	reply := &vcclient.UserLookupReply{
 		SVGTemplateClaims:  svgTemplateClaims,
 		PresentationClaims: presentationClaims,
-		RedirectURL:        redirectURL.String(),
+		RedirectURL:        redirectResult,
 	}
 
 	return reply, nil
@@ -213,4 +207,23 @@ func normalizeBSONValue(v any) any {
 	default:
 		return v
 	}
+}
+
+// buildAuthorizationRedirectURL constructs the authorization response redirect URL
+// by preserving existing query parameters and appending code, state, and iss.
+func buildAuthorizationRedirectURL(walletURI, code, state, issuer string) (string, error) {
+	redirectURL, err := url.Parse(walletURI)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse redirect URI %s: %w", walletURI, err)
+	}
+
+	q, parseErr := url.ParseQuery(redirectURL.RawQuery)
+	if parseErr != nil {
+		return "", fmt.Errorf("malformed query in redirect URI: %w", parseErr)
+	}
+	q.Set("code", code)
+	q.Set("state", state)
+	q.Set("iss", issuer)
+	redirectURL.RawQuery = q.Encode()
+	return redirectURL.String(), nil
 }

--- a/internal/apigw/apiv1/handlers_users_test.go
+++ b/internal/apigw/apiv1/handlers_users_test.go
@@ -1,0 +1,84 @@
+package apiv1
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildAuthorizationRedirectURL tests the helper used by UserLookup to construct
+// the authorization response redirect URL with code, state, and iss parameters.
+func TestBuildAuthorizationRedirectURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		walletURI string
+		code      string
+		state     string
+		iss       string
+		wantCode  string
+		wantState string
+		wantISS   string
+		wantExtra map[string]string // pre-existing query params that must survive
+		wantErr   bool
+	}{
+		{
+			name:      "plain redirect URI",
+			walletURI: "https://wallet.example.com/callback",
+			code:      "auth-code-123",
+			state:     "state-xyz",
+			iss:       "https://issuer.example.com",
+			wantCode:  "auth-code-123",
+			wantState: "state-xyz",
+			wantISS:   "https://issuer.example.com",
+		},
+		{
+			name:      "redirect URI with existing query params",
+			walletURI: "https://wallet.example.com/callback?client_ref=abc&session=42",
+			code:      "auth-code-456",
+			state:     "state-abc",
+			iss:       "https://issuer.example.com",
+			wantCode:  "auth-code-456",
+			wantState: "state-abc",
+			wantISS:   "https://issuer.example.com",
+			wantExtra: map[string]string{
+				"client_ref": "abc",
+				"session":    "42",
+			},
+		},
+		{
+			name:      "redirect URI with trailing slash",
+			walletURI: "https://wallet.example.com/callback/",
+			code:      "code-789",
+			state:     "s1",
+			iss:       "https://issuer.example.com",
+			wantCode:  "code-789",
+			wantState: "s1",
+			wantISS:   "https://issuer.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := buildAuthorizationRedirectURL(tt.walletURI, tt.code, tt.state, tt.iss)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			parsed, err := url.Parse(result)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantCode, parsed.Query().Get("code"))
+			assert.Equal(t, tt.wantState, parsed.Query().Get("state"))
+			assert.Equal(t, tt.wantISS, parsed.Query().Get("iss"))
+
+			for k, v := range tt.wantExtra {
+				assert.Equal(t, v, parsed.Query().Get(k),
+					"pre-existing query param %q must be preserved", k)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The authorization redirect was overwriting the registered redirect_uri query parameters with only `code` and `state`. Per RFC 6749 §3.1.2 the original query component must be preserved. Additionally, the `iss` parameter is now included per RFC 9207 (Authorization Server Issuer Identification).

**Before:** `/callback?code=ABC&state=XYZ` (registered `?dummy1=lorem&dummy2=ipsum` lost, no `iss`)
**After:** `/callback?dummy1=lorem&dummy2=ipsum&code=ABC&iss=https%3A%2F%2Fissuer.example.com&state=XYZ`

Fixes #455