### PR TITLE
fix: verify DPoP key binding between token and credential endpoints (RFC 9449)

### DIFF
--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -245,6 +245,17 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 		return nil, err
 	}
 
+	// Verify DPoP key binding: the proof's public key must match the one used
+	// at token issuance (RFC 9449 §4.3).
+	if authContext.Token != nil && authContext.Token.DPoPThumbprint != "" {
+		if dpop.Thumbprint != authContext.Token.DPoPThumbprint {
+			return nil, &openid4vci.Error{
+				Err:              openid4vci.ErrInvalidCredentialRequest,
+				ErrorDescription: "DPoP key does not match the key bound to the access token",
+			}
+		}
+	}
+
 	// Validate credential request against authorization details per OID4VCI 1.0 Section 7.1
 	if err := req.Validate(ctx, authContext.AuthorizationDetails); err != nil {
 		c.log.Error(err, "credential request validation failed")

--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -247,13 +247,8 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 
 	// Verify DPoP key binding: the proof's public key must match the one used
 	// at token issuance (RFC 9449 §4.3).
-	if authContext.Token != nil && authContext.Token.DPoPThumbprint != "" {
-		if dpop.Thumbprint != authContext.Token.DPoPThumbprint {
-			return nil, &openid4vci.Error{
-				Err:              openid4vci.ErrInvalidCredentialRequest,
-				ErrorDescription: "DPoP key does not match the key bound to the access token",
-			}
-		}
+	if err := verifyDPoPKeyBinding(dpop.Thumbprint, authContext.Token); err != nil {
+		return nil, err
 	}
 
 	// Validate credential request against authorization details per OID4VCI 1.0 Section 7.1
@@ -607,4 +602,23 @@ func (c *Client) VCIMetadata(ctx context.Context) (*openid4vci.CredentialIssuerM
 	}
 
 	return &metadata, nil
+}
+
+// verifyDPoPKeyBinding checks that the DPoP proof's JWK thumbprint matches the
+// thumbprint bound to the access token at issuance time (RFC 9449 §4.3).
+// When the token was issued without DPoP binding (e.g. pre-authorized_code flow
+// where the client did not present DPoP), the stored thumbprint is empty and the
+// check is skipped — the token was not bound to a specific key.
+func verifyDPoPKeyBinding(proofThumbprint string, token *cache.Token) error {
+	if token == nil || token.DPoPThumbprint == "" {
+		return nil
+	}
+	if proofThumbprint != token.DPoPThumbprint {
+		return oauth2.NewOAuthError(
+			oauth2.ErrCodeInvalidDPoPProof,
+			"DPoP key does not match the key bound to the access token",
+			400,
+		)
+	}
+	return nil
 }

--- a/internal/apigw/apiv1/handlers_issuer_test.go
+++ b/internal/apigw/apiv1/handlers_issuer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SUNET/vc/pkg/cache"
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/oauth2"
 	"github.com/SUNET/vc/pkg/openid4vci"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -388,4 +389,63 @@ func TestVCICredential_SuccessfulIssuance(t *testing.T) {
 	t.Log("  1. Inject mock db collections (auth context, datastore)")
 	t.Log("  2. Inject mock gRPC client factory")
 	t.Log("  3. Then call client.VCICredential(ctx, req) and verify response")
+}
+
+// TestDPoPThumbprintBinding verifies the verifyDPoPKeyBinding helper:
+// - Matching thumbprints pass
+// - Mismatched thumbprints produce an invalid_dpop_proof error (400)
+// - Empty stored thumbprint (no DPoP binding) is skipped
+// - Nil token is skipped
+func TestDPoPThumbprintBinding(t *testing.T) {
+	tests := []struct {
+		name            string
+		token           *cache.Token
+		proofPrint      string
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:       "matching thumbprints",
+			token:      &cache.Token{DPoPThumbprint: "abc123"},
+			proofPrint: "abc123",
+			wantErr:    false,
+		},
+		{
+			name:            "mismatched thumbprints",
+			token:           &cache.Token{DPoPThumbprint: "abc123"},
+			proofPrint:      "xyz789",
+			wantErr:         true,
+			wantErrContains: "DPoP key does not match",
+		},
+		{
+			name:       "empty stored thumbprint (no binding)",
+			token:      &cache.Token{DPoPThumbprint: ""},
+			proofPrint: "xyz789",
+			wantErr:    false,
+		},
+		{
+			name:       "nil token (no binding)",
+			token:      nil,
+			proofPrint: "xyz789",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyDPoPKeyBinding(tt.proofPrint, tt.token)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				var oauthErr *oauth2.OAuthError
+				if assert.ErrorAs(t, err, &oauthErr) {
+					assert.Equal(t, 400, oauthErr.HTTPStatus)
+					assert.Equal(t, oauth2.ErrCodeInvalidDPoPProof, oauthErr.ErrorCode)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -236,6 +236,14 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 	} else if !isPreAuthFlow {
 		return nil, oauth2.OAuthErrDPoPRequired
 	}
+	// NOTE: For pre-authorized_code flow, DPoP is optional per OID4VCI §4.1.1.
+	// When DPoP is absent, dpopThumbprint remains empty. The credential endpoint
+	// (verifyDPoPKeyBinding) skips key-binding verification when the stored
+	// thumbprint is empty — see handlers_issuer.go verifyDPoPKeyBinding().
+	// Security: the one-time pre-authorized code and (optionally) tx_code provide
+	// the primary security mechanism for this flow.
+	// TODO: Consider requiring DPoP for pre-auth flow to achieve sender-constrained
+	// tokens across all flows (RFC 9449).
 
 	// Verify client_id and redirect_uri BEFORE consuming the authorization code
 	// (RFC 6749 §4.1.3). A mismatched client_id must not burn the code, otherwise

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -199,6 +199,7 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 
 	// Validate DPoP BEFORE consuming the authorization code (RFC 9449 §4).
 	// This ensures a stolen code cannot be consumed without a valid DPoP proof.
+	var dpopThumbprint string
 	if req.DPOP != "" {
 		dpop, dpopErr := oauth2.ValidateAndParseDPoPJWT(req.DPOP)
 		if dpopErr != nil {
@@ -231,6 +232,7 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		}
 
 		c.log.Debug("DPoP claims", "jti", dpop.JTI, "htu", dpop.HTU, "htm", dpop.HTM)
+		dpopThumbprint = dpop.Thumbprint
 	} else if !isPreAuthFlow {
 		return nil, oauth2.OAuthErrDPoPRequired
 	}
@@ -311,8 +313,9 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 	}
 
 	tokenDoc := &cache.Token{
-		AccessToken: accessToken,
-		ExpiresAt:   time.Now().Add(time.Duration(reply.ExpiresIn) * time.Second).Unix(),
+		AccessToken:    accessToken,
+		ExpiresAt:      time.Now().Add(time.Duration(reply.ExpiresIn) * time.Second).Unix(),
+		DPoPThumbprint: dpopThumbprint,
 	}
 
 	if err := c.cacheService.AuthContext.AddToken(ctx, authorizationContext.Code, tokenDoc); err != nil {

--- a/pkg/cache/authcontext_types.go
+++ b/pkg/cache/authcontext_types.go
@@ -26,8 +26,9 @@ const (
 
 // Token represents an access token with expiration
 type Token struct {
-	AccessToken string `json:"access_token" bson:"access_token" validate:"required,max=4096,printascii"`
-	ExpiresAt   int64  `json:"expires_at" bson:"expires_at" validate:"required"`
+	AccessToken    string `json:"access_token" bson:"access_token" validate:"required,max=4096,printascii"`
+	ExpiresAt      int64  `json:"expires_at" bson:"expires_at" validate:"required"`
+	DPoPThumbprint string `json:"dpop_thumbprint,omitempty" bson:"dpop_thumbprint,omitempty" validate:"omitempty,max=128,printascii"`
 }
 
 // AuthorizationContext is the unified model for OIDC/OpenID4VP sessions


### PR DESCRIPTION
Per **RFC 9449 §4.3**, the resource server must verify that the DPoP proof's public key matches the one used when the access token was issued. Previously the DPoP thumbprint was validated independently at each endpoint but never bound to the token.

## Changes

1. **`pkg/cache/authcontext_types.go`** — Add `DPoPThumbprint` field to `Token` struct
2. **`handlers_oauth.go`** — Store `dpop.Thumbprint` in the token document at issuance
3. **`handlers_issuer.go`** — Verify the credential request's DPoP thumbprint matches the stored one

## Security impact

Without this fix, an attacker who obtains a leaked access token can create a new DPoP proof with their own key and use it at the credential endpoint. The server would accept it because there was no binding between the token and the original DPoP key.

## Conformance impact

Fixes the `happy-flow-multiple-clients` test (`EnsureHttpStatusCodeIs4xx`): the test uses client 1's access token with client 2's DPoP key and expects 4xx.

Fixes #456