### PR TITLE
fix(oid4vci): allow pre-authorized code redemption by multiple clients

### DIFF
--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -271,18 +271,25 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 
 	document := &model.CompleteDocument{}
 
-	c.log.Debug("VCICredential: retrieving credential data", "auth_provider", authContext.AuthProvider, "scope", scope, "session_id", authContext.SessionID)
+	// For child sessions created in the pre-auth multi-client flow, use the
+	// source session ID (the original pre-auth code) for document lookup.
+	docSessionID := authContext.SessionID
+	if authContext.SourceSessionID != "" {
+		docSessionID = authContext.SourceSessionID
+	}
+
+	c.log.Debug("VCICredential: retrieving credential data", "auth_provider", authContext.AuthProvider, "scope", scope, "session_id", authContext.SessionID, "doc_session_id", docSessionID)
 	// Retrieve credential data based on the auth provider used during authorization
 	switch authContext.AuthProvider {
 	case model.AuthProviderOpenID4VP, model.AuthProviderSAML, model.AuthProviderOIDC:
 		// Session-based auth providers: retrieve from session cache
-		docs, ok := c.cacheService.Document.Get(ctx, authContext.SessionID)
+		docs, ok := c.cacheService.Document.Get(ctx, docSessionID)
 		if !ok || len(docs) == 0 {
-			c.log.Error(nil, "no documents found in cache for session", "session_id", authContext.SessionID)
-			return nil, errors.New("no documents found for session " + authContext.SessionID)
+			c.log.Error(nil, "no documents found in cache for session", "session_id", docSessionID)
+			return nil, errors.New("no documents found for session " + docSessionID)
 		}
 		if len(docs) > 1 {
-			c.log.Info("multiple documents in cache for session, using first", "session_id", authContext.SessionID, "count", len(docs))
+			c.log.Info("multiple documents in cache for session, using first", "session_id", docSessionID, "count", len(docs))
 		}
 		for _, doc := range docs {
 			document = doc

--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -273,10 +273,7 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 
 	// For child sessions created in the pre-auth multi-client flow, use the
 	// source session ID (the original pre-auth code) for document lookup.
-	docSessionID := authContext.SessionID
-	if authContext.SourceSessionID != "" {
-		docSessionID = authContext.SourceSessionID
-	}
+	docSessionID := docLookupSessionID(authContext)
 
 	c.log.Debug("VCICredential: retrieving credential data", "auth_provider", authContext.AuthProvider, "scope", scope, "session_id", authContext.SessionID, "doc_session_id", docSessionID)
 	// Retrieve credential data based on the auth provider used during authorization
@@ -296,7 +293,7 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 			break
 		}
 		if document == nil || document.DocumentData == nil {
-			return nil, errors.New("cached document is empty for session " + authContext.SessionID)
+			return nil, errors.New("cached document is empty for session " + docSessionID)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported or missing auth provider: %q", authContext.AuthProvider)
@@ -729,4 +726,14 @@ func verifyDPoPKeyBinding(proofThumbprint string, token *cache.Token) error {
 		)
 	}
 	return nil
+}
+
+// docLookupSessionID returns the session ID to use for document lookup.
+// For child sessions created in the pre-auth multi-client flow, the source
+// session ID (original pre-auth code) is used instead of the child's own ID.
+func docLookupSessionID(authContext *cache.AuthorizationContext) string {
+	if authContext.SourceSessionID != "" {
+		return authContext.SourceSessionID
+	}
+	return authContext.SessionID
 }

--- a/internal/apigw/apiv1/handlers_issuer_test.go
+++ b/internal/apigw/apiv1/handlers_issuer_test.go
@@ -449,3 +449,28 @@ func TestDPoPThumbprintBinding(t *testing.T) {
 		})
 	}
 }
+
+// TestChildSessionDocLookup verifies that child sessions (created in the
+// pre-auth multi-client flow) use SourceSessionID for document lookup,
+// while regular sessions use their own SessionID.
+func TestDocLookupSessionID(t *testing.T) {
+	tests := []struct {
+		name             string
+		sessionID        string
+		sourceSessionID  string
+		wantDocSessionID string
+	}{
+		{"regular session uses own SessionID", "session-abc", "", "session-abc"},
+		{"child session uses SourceSessionID", "child-session-xyz", "parent-session-abc", "parent-session-abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authCtx := &cache.AuthorizationContext{
+				SessionID:       tt.sessionID,
+				SourceSessionID: tt.sourceSessionID,
+			}
+			assert.Equal(t, tt.wantDocSessionID, docLookupSessionID(authCtx))
+		})
+	}
+}

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -392,10 +392,13 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 			responseDetails[i].CredentialIdentifiers = []string{uuid.NewString()}
 		}
 		reply.AuthorizationDetails = responseDetails
-
-		// Persist credential_identifiers back so the credential endpoint can
-		// match them when the client presents the access token.
-		authorizationContext.AuthorizationDetails = responseDetails
+		// Do not mutate the shared parent authorizationContext here. The
+		// credential_identifiers are persisted per flow below: the pre-auth flow
+		// stores them on the independent child session, and the authorization_code
+		// flow assigns them before its Update() call. Mutating the parent here
+		// would persist implicitly in MemoryStore (shared pointer) but not in
+		// MongoStore (no Update), causing HA/non-HA inconsistency and unnecessary
+		// overwrites of the shared context across pre-auth clients.
 	}
 
 	tokenDoc := &cache.Token{

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -410,6 +410,18 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		if genErr != nil {
 			return nil, fmt.Errorf("failed to generate child session ID: %w", genErr)
 		}
+		// Generate a fresh c_nonce for this child session so each client gets its
+		// own nonce. The parent's nonce is shared and would be consumed (GetAndDelete)
+		// by the first client to call /credential, breaking subsequent clients.
+		childNonce, nonceErr := crypto.GenerateSecureToken(0, 32)
+		if nonceErr != nil {
+			return nil, fmt.Errorf("failed to generate child c_nonce: %w", nonceErr)
+		}
+		if c.cacheService.VCINonce != nil {
+			c.cacheService.VCINonce.Set(ctx, childNonce, true)
+		}
+		reply.CNonce = childNonce
+
 		childSession := &cache.AuthorizationContext{
 			SessionID:            childSessionID,
 			SourceSessionID:      authorizationContext.SessionID,
@@ -417,7 +429,7 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 			CreatedAt:            time.Now(),
 			ExpiresAt:            tokenDoc.ExpiresAt, // Use token TTL, not parent code TTL
 			Scopes:               authorizationContext.Scopes,
-			Nonce:                authorizationContext.Nonce,
+			Nonce:                childNonce,
 			AuthorizationDetails: responseDetails, // Use details with credential_identifiers from token response
 			AuthProvider:         authorizationContext.AuthProvider,
 			Identifier:           authorizationContext.Identifier,
@@ -434,17 +446,12 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		// Using Update() instead of AddToken() avoids a race where AddToken
 		// writes the token and a subsequent Update() overwrites it with nil.
 		authorizationContext.Token = tokenDoc
+		if len(responseDetails) > 0 {
+			authorizationContext.AuthorizationDetails = responseDetails
+		}
 		if err := c.cacheService.AuthContext.Update(ctx, authorizationContext); err != nil {
 			c.log.Error(err, "failed to persist token and authorization details")
 			return nil, err
-		}
-		// Persist credential_identifiers so VCICredential can validate them later.
-		if len(responseDetails) > 0 {
-			authorizationContext.AuthorizationDetails = responseDetails
-			if err := c.cacheService.AuthContext.Update(ctx, authorizationContext); err != nil {
-				c.log.Error(err, "failed to update authorization_details with credential_identifiers")
-				return nil, err
-			}
 		}
 	}
 

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -323,13 +323,14 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 	// Now consume the authorization code (after DPoP and client binding are validated)
 	var authorizationContext *cache.AuthorizationContext
 	var err error
-	if isPreAuthFlow {
-		// Pre-authorized codes can be redeemed by multiple distinct clients
-		// (each identified by a unique DPoP key). This supports the OID4VCI
-		// happy-flow-multiple-clients scenario where one credential offer
-		// serves multiple wallets.
+	if isPreAuthFlow && dpopThumbprint != "" {
+		// Pre-authorized codes with DPoP can be redeemed by multiple distinct
+		// clients (each identified by a unique DPoP key). This supports the
+		// OID4VCI happy-flow-multiple-clients scenario where one credential
+		// offer serves multiple wallets.
 		authorizationContext, err = c.cacheService.AuthContext.RedeemPreAuthorizedCode(ctx, code, dpopThumbprint)
 	} else {
+		// Without DPoP, pre-authorized codes are single-use (standard forfeit).
 		authorizationContext, err = c.cacheService.AuthContext.ForfeitAuthorizationCode(ctx, &cache.AuthorizationContext{
 			Code: code,
 		})
@@ -382,8 +383,9 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 
 	// Per OID4VCI 1.0 Section 6.2: authorization_details is REQUIRED in the Token Response when
 	// authorization_details was used in the Authorization Request, with credential_identifiers added.
+	var responseDetails []openid4vci.AuthorizationDetailsParameter
 	if len(authorizationContext.AuthorizationDetails) > 0 {
-		responseDetails := make([]openid4vci.AuthorizationDetailsParameter, len(authorizationContext.AuthorizationDetails))
+		responseDetails = make([]openid4vci.AuthorizationDetailsParameter, len(authorizationContext.AuthorizationDetails))
 		for i, ad := range authorizationContext.AuthorizationDetails {
 			responseDetails[i] = ad
 			responseDetails[i].CredentialIdentifiers = []string{uuid.NewString()}
@@ -411,12 +413,12 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		childSession := &cache.AuthorizationContext{
 			SessionID:            childSessionID,
 			SourceSessionID:      authorizationContext.SessionID,
-			Status:               "token_issued",
+			Status:               cache.SessionStatusTokenIssued,
 			CreatedAt:            time.Now(),
-			ExpiresAt:            authorizationContext.ExpiresAt,
+			ExpiresAt:            tokenDoc.ExpiresAt, // Use token TTL, not parent code TTL
 			Scopes:               authorizationContext.Scopes,
 			Nonce:                authorizationContext.Nonce,
-			AuthorizationDetails: authorizationContext.AuthorizationDetails,
+			AuthorizationDetails: responseDetails, // Use details with credential_identifiers from token response
 			AuthProvider:         authorizationContext.AuthProvider,
 			Identifier:           authorizationContext.Identifier,
 			DataSource:           authorizationContext.DataSource,
@@ -435,6 +437,14 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		if err := c.cacheService.AuthContext.Update(ctx, authorizationContext); err != nil {
 			c.log.Error(err, "failed to persist token and authorization details")
 			return nil, err
+		}
+		// Persist credential_identifiers so VCICredential can validate them later.
+		if len(responseDetails) > 0 {
+			authorizationContext.AuthorizationDetails = responseDetails
+			if err := c.cacheService.AuthContext.Update(ctx, authorizationContext); err != nil {
+				c.log.Error(err, "failed to update authorization_details with credential_identifiers")
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -288,7 +288,6 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		}
 
 		c.log.Debug("DPoP claims", "jti", dpop.JTI, "htu", dpop.HTU, "htm", dpop.HTM)
-		dpopThumbprint = dpop.Thumbprint
 	} else if !isPreAuthFlow {
 		return nil, oauth2.OAuthErrDPoPRequired
 	}
@@ -376,8 +375,10 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		CNonceExpiresIn: 3600,
 	}
 
-	// Store the c_nonce in the nonce cache so proof verification can find it
-	if c.cacheService.VCINonce != nil {
+	// Store the c_nonce in the nonce cache so proof verification can find it.
+	// For pre-auth flow, this is deferred to child session creation below
+	// (each client gets its own nonce).
+	if !isPreAuthFlow && c.cacheService.VCINonce != nil {
 		c.cacheService.VCINonce.Set(ctx, authorizationContext.Nonce, true)
 	}
 

--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -262,6 +262,8 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 				dpopErr.Error(), 400, dpopErr)
 		}
 
+		dpopThumbprint = dpop.Thumbprint
+
 		unique, err := c.cacheService.DPopJTI.SetNX(ctx, dpop.JTI, true)
 		if err != nil {
 			c.log.Error(err, "DPoP JTI cache error", "jti", dpop.JTI)
@@ -319,9 +321,19 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 	}
 
 	// Now consume the authorization code (after DPoP and client binding are validated)
-	authorizationContext, err := c.cacheService.AuthContext.ForfeitAuthorizationCode(ctx, &cache.AuthorizationContext{
-		Code: code,
-	})
+	var authorizationContext *cache.AuthorizationContext
+	var err error
+	if isPreAuthFlow {
+		// Pre-authorized codes can be redeemed by multiple distinct clients
+		// (each identified by a unique DPoP key). This supports the OID4VCI
+		// happy-flow-multiple-clients scenario where one credential offer
+		// serves multiple wallets.
+		authorizationContext, err = c.cacheService.AuthContext.RedeemPreAuthorizedCode(ctx, code, dpopThumbprint)
+	} else {
+		authorizationContext, err = c.cacheService.AuthContext.ForfeitAuthorizationCode(ctx, &cache.AuthorizationContext{
+			Code: code,
+		})
+	}
 	if err != nil {
 		c.log.Error(err, "failed to get authorization")
 		return nil, oauth2.NewOAuthErrorWithCause(oauth2.ErrCodeInvalidGrant,
@@ -389,17 +401,41 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		DPoPThumbprint: dpopThumbprint,
 	}
 
-	// Set the token on the in-memory struct so that Update() persists it
-	// alongside any updated AuthorizationDetails (credential_identifiers).
-	// Using Update() instead of AddToken() avoids a race where AddToken
-	// writes the token and a subsequent Update() overwrites it with nil.
-	// NOTE: Update() uses ReplaceOne which could clobber concurrent writes,
-	// but this is safe here: only one token exchange runs per authorization code
-	// (the code is consumed atomically above), so there are no concurrent writers.
-	authorizationContext.Token = tokenDoc
-	if err := c.cacheService.AuthContext.Update(ctx, authorizationContext); err != nil {
-		c.log.Error(err, "failed to persist token and authorization details")
-		return nil, err
+	if isPreAuthFlow {
+		// Pre-auth flow: create an independent child session for this client.
+		// The shared auth context remains intact so other clients can also redeem.
+		childSessionID, genErr := crypto.GenerateSecureToken(0, 32)
+		if genErr != nil {
+			return nil, fmt.Errorf("failed to generate child session ID: %w", genErr)
+		}
+		childSession := &cache.AuthorizationContext{
+			SessionID:            childSessionID,
+			SourceSessionID:      authorizationContext.SessionID,
+			Status:               "token_issued",
+			CreatedAt:            time.Now(),
+			ExpiresAt:            authorizationContext.ExpiresAt,
+			Scopes:               authorizationContext.Scopes,
+			Nonce:                authorizationContext.Nonce,
+			AuthorizationDetails: authorizationContext.AuthorizationDetails,
+			AuthProvider:         authorizationContext.AuthProvider,
+			Identifier:           authorizationContext.Identifier,
+			DataSource:           authorizationContext.DataSource,
+			Token:                tokenDoc,
+		}
+		if err := c.cacheService.AuthContext.Save(ctx, childSession); err != nil {
+			c.log.Error(err, "failed to save child session for pre-auth client")
+			return nil, err
+		}
+	} else {
+		// Set the token on the in-memory struct so that Update() persists it
+		// alongside any updated AuthorizationDetails (credential_identifiers).
+		// Using Update() instead of AddToken() avoids a race where AddToken
+		// writes the token and a subsequent Update() overwrites it with nil.
+		authorizationContext.Token = tokenDoc
+		if err := c.cacheService.AuthContext.Update(ctx, authorizationContext); err != nil {
+			c.log.Error(err, "failed to persist token and authorization details")
+			return nil, err
+		}
 	}
 
 	c.log.Debug("OAuthToken complete")

--- a/pkg/cache/authcontext.go
+++ b/pkg/cache/authcontext.go
@@ -229,6 +229,9 @@ func (c *MemoryStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThu
 	if dpopThumbprint == "" {
 		return nil, errors.New("dpop thumbprint is required for pre-authorized code redemption")
 	}
+	if len(dpopThumbprint) > 128 {
+		return nil, errors.New("dpop thumbprint exceeds maximum length")
+	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/cache/authcontext.go
+++ b/pkg/cache/authcontext.go
@@ -217,6 +217,48 @@ func (c *MemoryStore) ForfeitAuthorizationCode(ctx context.Context, query *Autho
 	return doc, nil
 }
 
+// RedeemPreAuthorizedCode allows a pre-authorized code to be redeemed by
+// multiple distinct clients (identified by DPoP thumbprint). Each client may
+// redeem the code only once. This implements OID4VCI §4.1.1 "single use" on a
+// per-client basis: the code is single-use for each wallet, but the same
+// credential offer can serve multiple wallets.
+func (c *MemoryStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThumbprint string) (*AuthorizationContext, error) {
+	if code == "" {
+		return nil, errors.New("code cannot be empty")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	indexKey := fmt.Sprintf("code:%s", code)
+	sessionID, ok := c.indices[indexKey]
+	if !ok {
+		return nil, ErrNoDocuments
+	}
+
+	item := c.cache.Get(sessionID)
+	if item == nil {
+		return nil, ErrNoDocuments
+	}
+
+	doc := item.Value()
+
+	// Check if this specific client (DPoP thumbprint) already redeemed the code
+	if dpopThumbprint != "" {
+		for _, tp := range doc.RedeemedBy {
+			if tp == dpopThumbprint {
+				return nil, errors.New("pre-authorized code already redeemed by this client")
+			}
+		}
+	}
+
+	// Record this client as having redeemed the code
+	doc.RedeemedBy = append(doc.RedeemedBy, dpopThumbprint)
+	c.cache.Set(sessionID, doc, ttlcache.DefaultTTL)
+
+	return doc, nil
+}
+
 // Consent marks an authorization context as consented
 func (c *MemoryStore) Consent(ctx context.Context, query *AuthorizationContext) error {
 	if query == nil || query.RequestURI == "" {

--- a/pkg/cache/authcontext.go
+++ b/pkg/cache/authcontext.go
@@ -226,6 +226,9 @@ func (c *MemoryStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThu
 	if code == "" {
 		return nil, errors.New("code cannot be empty")
 	}
+	if dpopThumbprint == "" {
+		return nil, errors.New("dpop thumbprint is required for pre-authorized code redemption")
+	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -243,18 +246,24 @@ func (c *MemoryStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThu
 
 	doc := item.Value()
 
+	// Reject redemption if the code was forfeited (e.g. non-DPoP redemption
+	// already consumed it via ForfeitAuthorizationCode).
+	if doc.Forfeited {
+		return nil, errors.New("pre-authorized code has been forfeited")
+	}
+
 	// Check if this specific client (DPoP thumbprint) already redeemed the code
-	if dpopThumbprint != "" {
-		for _, tp := range doc.RedeemedBy {
-			if tp == dpopThumbprint {
-				return nil, errors.New("pre-authorized code already redeemed by this client")
-			}
+	for _, tp := range doc.RedeemedBy {
+		if tp == dpopThumbprint {
+			return nil, errors.New("pre-authorized code already redeemed by this client")
 		}
 	}
 
-	// Record this client as having redeemed the code
+	// Record this client as having redeemed the code.
+	// Use PreviousOrDefaultTTL to preserve the original TTL — repeated redemptions
+	// by different clients must not extend the code's lifetime.
 	doc.RedeemedBy = append(doc.RedeemedBy, dpopThumbprint)
-	c.cache.Set(sessionID, doc, ttlcache.DefaultTTL)
+	c.cache.Set(sessionID, doc, ttlcache.PreviousOrDefaultTTL)
 
 	return doc, nil
 }

--- a/pkg/cache/authcontext.go
+++ b/pkg/cache/authcontext.go
@@ -259,6 +259,11 @@ func (c *MemoryStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThu
 		}
 	}
 
+	// Enforce maximum number of distinct redeemers to prevent unbounded growth
+	if len(doc.RedeemedBy) >= MaxPreAuthRedeemers {
+		return nil, errors.New("pre-authorized code has reached the maximum number of redemptions")
+	}
+
 	// Record this client as having redeemed the code.
 	// Use PreviousOrDefaultTTL to preserve the original TTL — repeated redemptions
 	// by different clients must not extend the code's lifetime.

--- a/pkg/cache/authcontext_test.go
+++ b/pkg/cache/authcontext_test.go
@@ -448,6 +448,39 @@ func TestRedeemPreAuthorizedCode_EmptyCode(t *testing.T) {
 	assert.Contains(t, err.Error(), "code cannot be empty")
 }
 
+func TestRedeemPreAuthorizedCode_EmptyThumbprint(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryStore(5 * time.Minute)
+
+	result, err := cache.RedeemPreAuthorizedCode(ctx, "some-code", "")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "dpop thumbprint is required")
+}
+
+func TestRedeemPreAuthorizedCode_ForfeitedCode(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore(5 * time.Minute)
+
+	doc := &AuthorizationContext{
+		SessionID: "session-forfeited",
+		Code:      "forfeited-code",
+		Forfeited: false,
+	}
+	err := store.Save(ctx, doc)
+	require.NoError(t, err)
+
+	// Forfeit the code
+	err = store.MarkCodeAsForfeited(ctx, "session-forfeited")
+	require.NoError(t, err)
+
+	// Attempt to redeem a forfeited code
+	result, err := store.RedeemPreAuthorizedCode(ctx, "forfeited-code", "thumbprint-1")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "forfeited")
+}
+
 func TestConsent_Success(t *testing.T) {
 	ctx := context.Background()
 	cache := NewMemoryStore(5 * time.Minute)

--- a/pkg/cache/authcontext_test.go
+++ b/pkg/cache/authcontext_test.go
@@ -397,6 +397,57 @@ func TestForfeitAuthorizationCode_AlreadyUsed(t *testing.T) {
 	assert.True(t, retrieved.Forfeited, "Context should remain marked as forfeited")
 }
 
+func TestRedeemPreAuthorizedCode_MultipleClients(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryStore(5 * time.Minute)
+
+	doc := &AuthorizationContext{
+		SessionID: "preauth-session",
+		Code:      "preauth-code-123",
+		Scopes:    []string{"openid"},
+		ExpiresAt: time.Now().Add(5 * time.Minute).Unix(),
+	}
+	require.NoError(t, cache.Save(ctx, doc))
+
+	// First client redeems successfully
+	result, err := cache.RedeemPreAuthorizedCode(ctx, "preauth-code-123", "thumbprint-client-1")
+	require.NoError(t, err)
+	assert.Equal(t, "preauth-session", result.SessionID)
+	assert.Contains(t, result.RedeemedBy, "thumbprint-client-1")
+
+	// Second client also redeems successfully
+	result2, err := cache.RedeemPreAuthorizedCode(ctx, "preauth-code-123", "thumbprint-client-2")
+	require.NoError(t, err)
+	assert.Equal(t, "preauth-session", result2.SessionID)
+	assert.Contains(t, result2.RedeemedBy, "thumbprint-client-1")
+	assert.Contains(t, result2.RedeemedBy, "thumbprint-client-2")
+
+	// Same client trying again is rejected
+	result3, err := cache.RedeemPreAuthorizedCode(ctx, "preauth-code-123", "thumbprint-client-1")
+	assert.Error(t, err)
+	assert.Nil(t, result3)
+	assert.Contains(t, err.Error(), "already redeemed by this client")
+}
+
+func TestRedeemPreAuthorizedCode_NotFound(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryStore(5 * time.Minute)
+
+	result, err := cache.RedeemPreAuthorizedCode(ctx, "nonexistent-code", "thumbprint-1")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestRedeemPreAuthorizedCode_EmptyCode(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryStore(5 * time.Minute)
+
+	result, err := cache.RedeemPreAuthorizedCode(ctx, "", "thumbprint-1")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "code cannot be empty")
+}
+
 func TestConsent_Success(t *testing.T) {
 	ctx := context.Background()
 	cache := NewMemoryStore(5 * time.Minute)

--- a/pkg/cache/authcontext_types.go
+++ b/pkg/cache/authcontext_types.go
@@ -22,6 +22,11 @@ const (
 	SessionStatusCompleted            SessionStatus = "completed"
 	SessionStatusExpired              SessionStatus = "expired"
 	SessionStatusError                SessionStatus = "error"
+
+	// MaxPreAuthRedeemers is the maximum number of distinct clients that can
+	// redeem a single pre-authorized code. This prevents unbounded growth of
+	// the RedeemedBy array and child sessions if a code leaks.
+	MaxPreAuthRedeemers = 10
 )
 
 // Token represents an access token with expiration

--- a/pkg/cache/authcontext_types.go
+++ b/pkg/cache/authcontext_types.go
@@ -101,13 +101,13 @@ type AuthorizationContext struct {
 	PresentationSubmission any            `json:"presentation_submission,omitempty" bson:"presentation_submission,omitempty"`
 
 	// OpenID4VP fields (wallet interaction)
-	EphemeralEncryptionKeyID string          `json:"ephemeral_encryption_key_id,omitempty" bson:"ephemeral_encryption_key_id,omitempty" validate:"omitempty,max=128,printascii"`
-	VerifierResponseCode     string          `json:"verifier_response_code,omitempty" bson:"verifier_response_code,omitempty" validate:"omitempty,max=128,printascii"`
-	RequestObjectID          string          `json:"request_object_id,omitempty" bson:"request_object_id,omitempty" validate:"omitempty,max=128,printascii"`
-	RequestObjectNonce       string          `json:"request_object_nonce,omitempty" bson:"request_object_nonce,omitempty" validate:"omitempty,max=128,printascii"`
-	DCQLQuery                *openid4vp.DCQL                         `json:"dcql_query,omitempty" bson:"dcql_query,omitempty"`
-	Validations              map[string][]openid4vp.ClaimValidation   `json:"validations,omitempty" bson:"validations,omitempty" validate:"omitempty,dive,dive"`
-	WalletID                 string                                  `json:"wallet_id,omitempty" bson:"wallet_id,omitempty" validate:"omitempty,max=128,printascii"`
+	EphemeralEncryptionKeyID string                                 `json:"ephemeral_encryption_key_id,omitempty" bson:"ephemeral_encryption_key_id,omitempty" validate:"omitempty,max=128,printascii"`
+	VerifierResponseCode     string                                 `json:"verifier_response_code,omitempty" bson:"verifier_response_code,omitempty" validate:"omitempty,max=128,printascii"`
+	RequestObjectID          string                                 `json:"request_object_id,omitempty" bson:"request_object_id,omitempty" validate:"omitempty,max=128,printascii"`
+	RequestObjectNonce       string                                 `json:"request_object_nonce,omitempty" bson:"request_object_nonce,omitempty" validate:"omitempty,max=128,printascii"`
+	DCQLQuery                *openid4vp.DCQL                        `json:"dcql_query,omitempty" bson:"dcql_query,omitempty"`
+	Validations              map[string][]openid4vp.ClaimValidation `json:"validations,omitempty" bson:"validations,omitempty" validate:"omitempty,dive,dive"`
+	WalletID                 string                                 `json:"wallet_id,omitempty" bson:"wallet_id,omitempty" validate:"omitempty,max=128,printascii"`
 }
 
 // Validate checks the AuthorizationContext against its struct validation tags.

--- a/pkg/cache/authcontext_types.go
+++ b/pkg/cache/authcontext_types.go
@@ -40,6 +40,12 @@ type AuthorizationContext struct {
 	CreatedAt time.Time     `json:"created_at" bson:"created_at,omitempty"`
 	ExpiresAt int64         `json:"expires_at" bson:"expires_at"`
 
+	// SourceSessionID references the parent session from which this session was
+	// derived. Used in the pre-authorized code flow where each client redemption
+	// creates a new child session that still needs access to the original
+	// session's credential documents.
+	SourceSessionID string `json:"source_session_id,omitempty" bson:"source_session_id,omitempty" validate:"omitempty,max=128,printascii"`
+
 	// Client and authorization fields
 	ClientID            string   `json:"client_id" bson:"client_id" validate:"omitempty,max=128,printascii"`
 	WalletClientID      string   `json:"wallet_client_id,omitempty" bson:"wallet_client_id,omitempty" validate:"omitempty,max=128,printascii"`
@@ -52,6 +58,12 @@ type AuthorizationContext struct {
 	// Authorization code fields
 	Code      string `json:"code,omitempty" bson:"code,omitempty" validate:"omitempty,max=128,printascii"`
 	Forfeited bool   `json:"forfeited,omitempty" bson:"forfeited,omitempty"`
+
+	// RedeemedBy tracks DPoP thumbprints that have redeemed a pre-authorized code.
+	// Pre-authorized codes may be redeemed by multiple distinct clients (each
+	// identified by a unique DPoP key), but a given client must not redeem
+	// the same code twice.
+	RedeemedBy []string `json:"redeemed_by,omitempty" bson:"redeemed_by,omitempty"`
 
 	// Token fields
 	Token       *Token `json:"token,omitempty" bson:"token,omitempty"`

--- a/pkg/cache/interface.go
+++ b/pkg/cache/interface.go
@@ -38,6 +38,11 @@ type AuthContextStore interface {
 	// ForfeitAuthorizationCode marks an authorization code as used and returns the updated context.
 	ForfeitAuthorizationCode(ctx context.Context, query *AuthorizationContext) (*AuthorizationContext, error)
 
+	// RedeemPreAuthorizedCode allows a pre-authorized code to be redeemed by multiple
+	// distinct clients (per DPoP thumbprint). Returns the auth context or an error if
+	// the same client attempts to redeem the code twice.
+	RedeemPreAuthorizedCode(ctx context.Context, code, dpopThumbprint string) (*AuthorizationContext, error)
+
 	// MarkCodeAsForfeited marks an authorization code as forfeited by session ID.
 	MarkCodeAsForfeited(ctx context.Context, id string) error
 

--- a/pkg/cache/mongo_store.go
+++ b/pkg/cache/mongo_store.go
@@ -314,6 +314,9 @@ func (s *MongoStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThum
 	if dpopThumbprint == "" {
 		return nil, errors.New("dpop thumbprint is required for pre-authorized code redemption")
 	}
+	if len(dpopThumbprint) > 128 {
+		return nil, errors.New("dpop thumbprint exceeds maximum length")
+	}
 
 	filter := bson.M{
 		"code":        code,

--- a/pkg/cache/mongo_store.go
+++ b/pkg/cache/mongo_store.go
@@ -309,12 +309,14 @@ func (s *MongoStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThum
 	if code == "" {
 		return nil, errors.New("code cannot be empty")
 	}
+	if dpopThumbprint == "" {
+		return nil, errors.New("dpop thumbprint is required for pre-authorized code redemption")
+	}
 
-	filter := bson.M{"code": code}
-
-	// If a thumbprint is provided, ensure it hasn't already redeemed
-	if dpopThumbprint != "" {
-		filter["redeemed_by"] = bson.M{"$ne": dpopThumbprint}
+	filter := bson.M{
+		"code":        code,
+		"forfeited":   bson.M{"$ne": true},
+		"redeemed_by": bson.M{"$ne": dpopThumbprint},
 	}
 
 	update := bson.M{"$addToSet": bson.M{"redeemed_by": dpopThumbprint}}
@@ -324,10 +326,17 @@ func (s *MongoStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThum
 	err := s.coll.FindOneAndUpdate(ctx, filter, update, opts).Decode(&result)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
-			// Could be code not found or same client replay
+			// Distinguish: code not found, forfeited, or already-redeemed client
 			var existing AuthorizationContext
-			if findErr := s.coll.FindOne(ctx, bson.M{"code": code}).Decode(&existing); findErr != nil {
-				return nil, ErrNoDocuments
+			findErr := s.coll.FindOne(ctx, bson.M{"code": code}).Decode(&existing)
+			if findErr != nil {
+				if errors.Is(findErr, mongo.ErrNoDocuments) {
+					return nil, ErrNoDocuments
+				}
+				return nil, fmt.Errorf("failed to look up pre-authorized code: %w", findErr)
+			}
+			if existing.Forfeited {
+				return nil, errors.New("pre-authorized code has been forfeited")
 			}
 			return nil, errors.New("pre-authorized code already redeemed by this client")
 		}

--- a/pkg/cache/mongo_store.go
+++ b/pkg/cache/mongo_store.go
@@ -303,8 +303,10 @@ func (s *MongoStore) MarkCodeAsForfeited(ctx context.Context, id string) error {
 }
 
 // RedeemPreAuthorizedCode allows a pre-authorized code to be redeemed by multiple
-// distinct clients (identified by DPoP thumbprint). Uses an atomic $addToSet with
-// a condition that the thumbprint is not already present.
+// distinct clients (identified by DPoP thumbprint). Uses an atomic FindOneAndUpdate
+// with $addToSet and a condition that the thumbprint is not already present.
+// The $expr size guard is enforced atomically within the single-document
+// FindOneAndUpdate operation, so the max-redeemer bound is strict.
 func (s *MongoStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThumbprint string) (*AuthorizationContext, error) {
 	if code == "" {
 		return nil, errors.New("code cannot be empty")
@@ -317,6 +319,13 @@ func (s *MongoStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThum
 		"code":        code,
 		"forfeited":   bson.M{"$ne": true},
 		"redeemed_by": bson.M{"$ne": dpopThumbprint},
+		// Enforce max redeemers atomically: reject if already at the cap
+		"$expr": bson.M{
+			"$lt": bson.A{
+				bson.M{"$size": bson.M{"$ifNull": bson.A{"$redeemed_by", bson.A{}}}},
+				MaxPreAuthRedeemers,
+			},
+		},
 	}
 
 	update := bson.M{"$addToSet": bson.M{"redeemed_by": dpopThumbprint}}
@@ -326,7 +335,7 @@ func (s *MongoStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThum
 	err := s.coll.FindOneAndUpdate(ctx, filter, update, opts).Decode(&result)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
-			// Distinguish: code not found, forfeited, or already-redeemed client
+			// Distinguish: code not found, forfeited, already-redeemed, or max reached
 			var existing AuthorizationContext
 			findErr := s.coll.FindOne(ctx, bson.M{"code": code}).Decode(&existing)
 			if findErr != nil {
@@ -338,7 +347,14 @@ func (s *MongoStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThum
 			if existing.Forfeited {
 				return nil, errors.New("pre-authorized code has been forfeited")
 			}
-			return nil, errors.New("pre-authorized code already redeemed by this client")
+			for _, tp := range existing.RedeemedBy {
+				if tp == dpopThumbprint {
+					return nil, errors.New("pre-authorized code already redeemed by this client")
+				}
+			}
+			if len(existing.RedeemedBy) >= MaxPreAuthRedeemers {
+				return nil, errors.New("pre-authorized code has reached the maximum number of redemptions")
+			}
 		}
 		return nil, fmt.Errorf("failed to redeem pre-authorized code: %w", err)
 	}

--- a/pkg/cache/mongo_store.go
+++ b/pkg/cache/mongo_store.go
@@ -302,6 +302,41 @@ func (s *MongoStore) MarkCodeAsForfeited(ctx context.Context, id string) error {
 	return nil
 }
 
+// RedeemPreAuthorizedCode allows a pre-authorized code to be redeemed by multiple
+// distinct clients (identified by DPoP thumbprint). Uses an atomic $addToSet with
+// a condition that the thumbprint is not already present.
+func (s *MongoStore) RedeemPreAuthorizedCode(ctx context.Context, code, dpopThumbprint string) (*AuthorizationContext, error) {
+	if code == "" {
+		return nil, errors.New("code cannot be empty")
+	}
+
+	filter := bson.M{"code": code}
+
+	// If a thumbprint is provided, ensure it hasn't already redeemed
+	if dpopThumbprint != "" {
+		filter["redeemed_by"] = bson.M{"$ne": dpopThumbprint}
+	}
+
+	update := bson.M{"$addToSet": bson.M{"redeemed_by": dpopThumbprint}}
+	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+
+	var result AuthorizationContext
+	err := s.coll.FindOneAndUpdate(ctx, filter, update, opts).Decode(&result)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			// Could be code not found or same client replay
+			var existing AuthorizationContext
+			if findErr := s.coll.FindOne(ctx, bson.M{"code": code}).Decode(&existing); findErr != nil {
+				return nil, ErrNoDocuments
+			}
+			return nil, errors.New("pre-authorized code already redeemed by this client")
+		}
+		return nil, fmt.Errorf("failed to redeem pre-authorized code: %w", err)
+	}
+
+	return &result, nil
+}
+
 // Consent marks an authorization context as consented.
 func (s *MongoStore) Consent(ctx context.Context, query *AuthorizationContext) error {
 	if query == nil || query.RequestURI == "" {

--- a/pkg/cache/store_test.go
+++ b/pkg/cache/store_test.go
@@ -129,6 +129,30 @@ func runAuthContextStoreContractTests(t *testing.T, store AuthContextStore) {
 		assert.True(t, result.Forfeited)
 	})
 
+	t.Run("RedeemPreAuthorizedCode", func(t *testing.T) {
+		doc := &AuthorizationContext{
+			SessionID: "contract-preauth-session",
+			Code:      "contract-preauth-code",
+			Scopes:    []string{"openid"},
+		}
+		require.NoError(t, store.Save(ctx, doc))
+
+		// First client redeems
+		result, err := store.RedeemPreAuthorizedCode(ctx, "contract-preauth-code", "tp-1")
+		require.NoError(t, err)
+		assert.Contains(t, result.RedeemedBy, "tp-1")
+
+		// Second client redeems
+		result, err = store.RedeemPreAuthorizedCode(ctx, "contract-preauth-code", "tp-2")
+		require.NoError(t, err)
+		assert.Contains(t, result.RedeemedBy, "tp-1")
+		assert.Contains(t, result.RedeemedBy, "tp-2")
+
+		// Same client rejected
+		_, err = store.RedeemPreAuthorizedCode(ctx, "contract-preauth-code", "tp-1")
+		assert.Error(t, err)
+	})
+
 	t.Run("Delete", func(t *testing.T) {
 		require.NoError(t, store.Delete(ctx, "contract-session-1"))
 


### PR DESCRIPTION
## Summary

Pre-authorized codes can now be redeemed by multiple distinct wallet clients (each identified by their DPoP thumbprint). This aligns with the OID4VCI conformance suite's `happy-flow-multiple-clients` test where one credential offer is served to multiple wallets simultaneously.

## Problem

The conformance suite submits a single credential offer (containing one pre-authorized code) and then has **two simulated wallet clients** attempt to redeem the same code. Previously, `ForfeitAuthorizationCode()` marked the code as globally single-use after the first redemption, causing the second client to receive a 400 error.

## Solution

For the pre-authorized code flow:

1. **`RedeemPreAuthorizedCode()`** — new method on `AuthContextStore` (both MemoryStore and MongoStore). Tracks which DPoP thumbprints have redeemed the code. A given client cannot redeem the same code twice, but different clients can.

2. **Child sessions** — each client redemption creates an independent `AuthorizationContext` with its own access token and a `SourceSessionID` pointing back to the parent session.

3. **Credential endpoint** — uses `SourceSessionID` for document lookup when set, so child sessions can access the parent's credential data.

The authorization_code flow remains unchanged (strict single-use via `Forfeited` flag).

## Security

- DPoP JTI uniqueness check prevents replay of the same DPoP proof
- Per-client thumbprint tracking prevents same-wallet double-redemption  
- Pre-auth codes remain short-lived (5 min TTL)

Fixes #457