### PR TITLE
fix: nil pointer dereference in IssuerMetadata.Generate when VCTM rendering has no logo

### DIFF
--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -1260,7 +1260,7 @@ func (cfg *IssuerMetadata) Generate(ctx context.Context, publicURL string, crede
 				}
 
 				// Map rendering information from VCTM to OpenID4VCI format
-				if vctmDisplay.Rendering != nil {
+				if vctmDisplay.Rendering != nil && vctmDisplay.Rendering.Simple != nil {
 					simple := vctmDisplay.Rendering.Simple
 					if simple.BackgroundColor != "" {
 						display.BackgroundColor = simple.BackgroundColor
@@ -1268,7 +1268,7 @@ func (cfg *IssuerMetadata) Generate(ctx context.Context, publicURL string, crede
 					if simple.TextColor != "" {
 						display.TextColor = simple.TextColor
 					}
-					if simple.Logo.URI != "" {
+					if simple.Logo != nil && simple.Logo.URI != "" {
 						display.Logo = &openid4vci.MetadataLogo{
 							URI:     simple.Logo.URI,
 							AltText: simple.Logo.AltText,

--- a/pkg/model/issuer_metadata_test.go
+++ b/pkg/model/issuer_metadata_test.go
@@ -95,6 +95,74 @@ func TestIssuerMetadata_Generate_VCTMDisplay(t *testing.T) {
 	assert.Equal(t, "VCTM Description", credConfig.CredentialMetadata.Display[0].Description)
 }
 
+func TestIssuerMetadata_Generate_VCTMDisplay_PartialRendering(t *testing.T) {
+	tests := []struct {
+		name            string
+		rendering       *sdjwtvc.Rendering
+		wantBgColor     string
+		wantTextColor   string
+		wantLogoNil     bool
+	}{
+		{
+			name: "simple rendering without logo",
+			rendering: &sdjwtvc.Rendering{
+				Simple: &sdjwtvc.SimpleRendering{
+					BackgroundColor: "#1a365d",
+					TextColor:       "#ffffff",
+				},
+			},
+			wantBgColor:   "#1a365d",
+			wantTextColor: "#ffffff",
+			wantLogoNil:   true,
+		},
+		{
+			name: "nil simple with svg_templates only",
+			rendering: &sdjwtvc.Rendering{
+				SVGTemplates: []sdjwtvc.SVGTemplates{
+					{URI: "data:image/svg+xml;base64,abc"},
+				},
+			},
+			wantBgColor:   "",
+			wantTextColor: "",
+			wantLogoNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &IssuerMetadata{}
+			mockVCTM := &sdjwtvc.VCTM{
+				VCT:  "urn:demo:1",
+				Name: "Demo",
+				Display: []sdjwtvc.VCTMDisplay{
+					{
+						Locale:    "en-US",
+						Name:      "Demo",
+						Rendering: tt.rendering,
+					},
+				},
+			}
+			credMeta := map[string]*CredentialMetadata{
+				"demo": {VCTM: mockVCTM},
+			}
+			ctx := context.Background()
+			metadata, err := cfg.Generate(ctx, "https://issuer.example.com", credMeta)
+			require.NoError(t, err)
+			require.NotNil(t, metadata)
+
+			credConfig, exists := metadata.CredentialConfigurationsSupported["demo"]
+			require.True(t, exists)
+			require.NotNil(t, credConfig.CredentialMetadata)
+			require.Len(t, credConfig.CredentialMetadata.Display, 1)
+			assert.Equal(t, tt.wantBgColor, credConfig.CredentialMetadata.Display[0].BackgroundColor)
+			assert.Equal(t, tt.wantTextColor, credConfig.CredentialMetadata.Display[0].TextColor)
+			if tt.wantLogoNil {
+				assert.Nil(t, credConfig.CredentialMetadata.Display[0].Logo)
+			}
+		})
+	}
+}
+
 func TestIssuerMetadata_Generate_CustomCryptoBindingMethods(t *testing.T) {
 	cfg := &IssuerMetadata{
 		CryptographicBindingMethodsSupported: []string{"jwk", "did:key"},


### PR DESCRIPTION
Fixes #461

## Problem

`IssuerMetadata.Generate` panics with a nil pointer dereference (SIGSEGV) when a VCTM has a `rendering` block but either:
- `rendering.simple` is nil (the VCTM only has `svg_templates`)
- `rendering.simple.logo` is nil (the simple rendering has colors but no logo)

Both `Rendering.Simple` and `SimpleRendering.Logo` are pointer types (`*SimpleRendering` and `*Logo`), but the code was dereferencing them without nil checks.

## Fix

- Add nil check for `Rendering.Simple` before accessing its fields
- Add nil check for `Simple.Logo` before accessing `.URI`

## Tests

Added a table-driven regression test `TestIssuerMetadata_Generate_VCTMDisplay_PartialRendering` with subcases:
- `RenderingWithoutLogo` — rendering with colors but no logo
- `RenderingNilSimple` — rendering with only svg_templates (nil simple)