### PR TITLE
fix(verifier): use path-param request_uri in GetQRCode for native wallets

### DIFF
--- a/internal/verifier/apiv1/handler_oidc.go
+++ b/internal/verifier/apiv1/handler_oidc.go
@@ -18,7 +18,6 @@ import (
 	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/jose"
 	"github.com/SUNET/vc/pkg/oauth2"
-	"github.com/SUNET/vc/pkg/openid4vp"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/skip2/go-qrcode"
@@ -159,24 +158,11 @@ func (c *Client) Authorize(ctx context.Context, req *AuthorizeRequest) (*Authori
 	}
 
 	// Generate OpenID4VP authorization request
-	requestObjectPath, err := url.JoinPath(c.cfg.Verifier.PublicURL, "/verification/request-object", sessionID)
+	authzReqURL, authzParams, err := buildOpenID4VPAuthzRequest(c.cfg.Verifier.PublicURL, sessionID)
 	if err != nil {
-		c.log.Error(err, "Failed to construct request object path")
+		c.log.Error(err, "Failed to build OpenID4VP authorization request")
 		return nil, ErrServerError
 	}
-
-	// Construct OpenID4VP authorization request URL with query parameters
-	// Use x509_san_dns: prefix so wallets know how to verify the client identity
-	host, err := helpers.HostFromURL(c.cfg.Verifier.PublicURL)
-	if err != nil {
-		c.log.Error(err, "Failed to extract host from PublicURL")
-		return nil, ErrServerError
-	}
-	oidc4vpClientID := fmt.Sprintf("x509_san_dns:%s", host)
-	q := url.Values{}
-	q.Set("client_id", oidc4vpClientID)
-	q.Set("request_uri", requestObjectPath)
-	authzReqURL := "openid4vp://cb?" + q.Encode()
 
 	qrCodeImageURL, err := url.JoinPath("/qr", sessionID)
 	if err != nil {
@@ -202,7 +188,7 @@ func (c *Client) Authorize(ctx context.Context, req *AuthorizeRequest) (*Authori
 	// Build wallet links from supported_wallets config
 	// Each wallet URL gets the same client_id + request_uri params appended
 	for name, walletBaseURL := range c.cfg.Verifier.SupportedWallets {
-		walletLink := walletBaseURL + "?" + q.Encode()
+		walletLink := walletBaseURL + "?" + authzParams.Encode()
 
 		// Build QR code image URL for cross-device flow
 		walletQRURL, err := url.JoinPath("/qr", sessionID)
@@ -876,7 +862,7 @@ func (c *Client) GetQRCode(ctx context.Context, req *GetQRCodeRequest) (*GetQRCo
 		}
 
 		// Build the web wallet URL with the same authorization params
-		requestObjectPath, err := url.JoinPath(c.cfg.Verifier.PublicURL, "/verification/request-object", req.SessionID)
+		requestObjectPath, err := url.JoinPath(c.cfg.Verifier.PublicURL, "verification", "request-object", req.SessionID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct request object path: %w", err)
 		}
@@ -897,13 +883,19 @@ func (c *Client) GetQRCode(ctx context.Context, req *GetQRCodeRequest) (*GetQRCo
 			return nil, fmt.Errorf("failed to extract host from PublicURL: %w", err)
 		}
 
-		requestObject := &openid4vp.RequestObject{
-			ClientID: fmt.Sprintf("x509_san_dns:%s", host),
-		}
-		qrData, err = requestObject.CreateAuthorizationRequestURI(ctx, c.cfg.Verifier.PublicURL, req.SessionID)
+		// Construct request_uri with path parameter (matching the OIDC
+		// request-object/:session_id endpoint), not the query-param format
+		// used by the UI flow.
+		requestObjectPath, err := url.JoinPath(c.cfg.Verifier.PublicURL, "verification", "request-object", req.SessionID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create authorization request URI: %w", err)
+			return nil, fmt.Errorf("failed to construct request object path: %w", err)
 		}
+
+		oidc4vpClientID := fmt.Sprintf("x509_san_dns:%s", host)
+		q := url.Values{}
+		q.Set("client_id", oidc4vpClientID)
+		q.Set("request_uri", requestObjectPath)
+		qrData = "openid4vp://cb?" + q.Encode()
 	}
 
 	// Generate QR code
@@ -1043,4 +1035,24 @@ func (c *Client) matchRedirectURI(registered []string, reqURI string) bool {
 		}
 	}
 	return false
+}
+
+// buildOpenID4VPAuthzRequest constructs an OpenID4VP authorization request URL
+// with a request_uri pointing to the request-object endpoint as a path parameter.
+// It returns the full authorization request URL and the query parameters used.
+func buildOpenID4VPAuthzRequest(publicURL, sessionID string) (string, url.Values, error) {
+	requestObjectPath, err := url.JoinPath(publicURL, "verification", "request-object", sessionID)
+	if err != nil {
+		return "", nil, fmt.Errorf("construct request object path: %w", err)
+	}
+
+	host, err := helpers.HostFromURL(publicURL)
+	if err != nil {
+		return "", nil, fmt.Errorf("extract host from PublicURL: %w", err)
+	}
+
+	q := url.Values{}
+	q.Set("client_id", fmt.Sprintf("x509_san_dns:%s", host))
+	q.Set("request_uri", requestObjectPath)
+	return "openid4vp://cb?" + q.Encode(), q, nil
 }

--- a/internal/verifier/apiv1/handler_oidc_test.go
+++ b/internal/verifier/apiv1/handler_oidc_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -2809,6 +2810,54 @@ func TestMatchRedirectURI(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := client.matchRedirectURI(tt.registered, tt.reqURI)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildOpenID4VPAuthzRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		publicURL string
+		sessionID string
+		wantErr   bool
+	}{
+		{
+			name:      "standard URL",
+			publicURL: "https://verifier.example.com",
+			sessionID: "session-abc-123",
+		},
+		{
+			name:      "URL with trailing slash",
+			publicURL: "https://verifier.example.com/",
+			sessionID: "session-xyz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _, err := buildOpenID4VPAuthzRequest(tt.publicURL, tt.sessionID)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.True(t, strings.HasPrefix(result, "openid4vp://cb?"),
+				"must use openid4vp:// scheme")
+
+			parsed, err := url.Parse(result)
+			require.NoError(t, err)
+
+			requestURI := parsed.Query().Get("request_uri")
+			assert.True(t, strings.HasSuffix(requestURI,
+				"/verification/request-object/"+tt.sessionID),
+				"request_uri must use path-param format, got: %s", requestURI)
+			assert.NotContains(t, requestURI, "?id=",
+				"request_uri must not use query-param format")
+
+			clientID := parsed.Query().Get("client_id")
+			assert.True(t, strings.HasPrefix(clientID, "x509_san_dns:"),
+				"client_id must use x509_san_dns prefix")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #466

`GetQRCode`'s standard flow (native wallet, no `WalletName` set) was calling `CreateAuthorizationRequestURI`, which builds the `request_uri` with a **query parameter** (`?id=<sessionID>`). This URL matches the UI-flow handler (`endpointVerificationRequestObject` at `GET /verification/request-object`), which looks up the session by `RequestObjectID` — but `GetQRCode` passes a `SessionID`, causing a cache miss and a 404 response to the wallet.

## Fix

Construct the `request_uri` inline using `url.JoinPath` with the session ID as a **path parameter**, matching the OIDC endpoint at `GET /verification/request-object/:session_id`. This is the same pattern already used by `OIDCAuthorize` (line 162 in the same file).

## What is NOT changed

- `CreateAuthorizationRequestURI` / `createRequestURI` in `pkg/openid4vp/context.go` — still uses query params, which is correct for the `UIInteraction` flow (passes `requestObjectID`, not `sessionID`)
- The UI-flow handler (`handlers_verification.go`) — unchanged
- The apigw verification endpoints — completely separate package

## Testing

- All existing verifier tests pass
- Bug was discovered during interoperability testing with the SPRIND German national EUDI wallet
