### PR TITLE
fix: switch runtime image from Debian to Alpine to eliminate 103 OS CVEs

### DIFF
--- a/dockerfiles/worker
+++ b/dockerfiles/worker
@@ -31,15 +31,14 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -X vc/pkg/model.BuildVersion=$(echo $BUILDTAG) \
     -w -s --extldflags '-static'" ./cmd/$SERVICE_NAME
 
-# Deploy
-FROM debian:13-slim
+# Deploy — Alpine for minimal CVE surface (binary is statically linked)
+FROM alpine:3.23
 
 ARG SERVICE_NAME
 
 WORKDIR /
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl procps iputils-ping less netcat-openbsd \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates curl
 
 COPY --from=builder /go/src/app/bin/vc_${SERVICE_NAME} /vc_service
 COPY --from=builder /go/src/app/docs /docs


### PR DESCRIPTION
## What

Switches the worker Dockerfile runtime stage from `debian:13-slim` to `alpine:3.23`.

## Why

A Trivy scan of the current `v0.5.0-sirosid.4` images shows **132 CVEs** (5 CRITICAL, 37 HIGH, 90 MEDIUM). 103 of these are from Debian OS packages that the statically-linked Go binary never uses.

### CVE breakdown (before → after)

| Category | Before | After |
|---|---|---|
| OS packages (Debian) | 103 (2C, 14H, 87M) | **0** |
| Go stdlib (1.26.0) | 21 (15H, 6M) | 21 (need Go 1.26.4 rebuild) |
| Go modules | 8 (1C, 5H, 2M) | 8 (need dep bumps) |
| **Total** | **132** | **~29** |

### Notable eliminated CVEs

- **CVE-2026-42496** (CRITICAL): perl-archive-tar path traversal — no fix in Debian
- **CVE-2026-8376** (CRITICAL): perl heap buffer overflow — no fix in Debian
- **CVE-2026-33845** (CRITICAL): gnutls DTLS DoS
- **CVE-2026-42010** (CRITICAL): gnutls authentication bypass via NUL character
- 14 HIGH CVEs in curl, ncurses, libssh2, perl, gnutls, nghttp2

## What changed

```diff
-FROM debian:13-slim
+FROM alpine:3.23

-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-    curl procps iputils-ping less netcat-openbsd \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates curl
```

## Why it works

The Go binary is built with `--extldflags '-static'` — it's fully statically linked and has zero dependency on glibc or any Debian runtime library. The removed packages (`procps`, `iputils-ping`, `less`, `netcat-openbsd`) are debug tools not needed in production. `curl` is retained for the HEALTHCHECK.

## Remaining CVEs (separate PRs)

The remaining ~29 CVEs require:
1. **Go 1.26.4 rebuild** — go.mod and gobuild already at 1.26.4, just needs a fresh image build
2. **Module bumps** — grpc (1.79.3), otel (1.43.0), go-jose (4.1.4), goxmldsig (1.6.0)

## Image size impact

Alpine base is ~8MB vs ~80MB for Debian slim — approximately 10x smaller runtime image.