### PR TITLE
ci: add GitHub Actions workflow for Docker image builds

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -40,18 +40,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.git_ref || github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
+          uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
+          uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+          uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -67,7 +65,7 @@ jobs:
       - name: Extract metadata
         id: meta
         if: inputs.image_tag == ''
-        uses: docker/metadata-action@v6
+          uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ steps.image.outputs.name }}
           tags: |
@@ -93,7 +91,7 @@ jobs:
           echo "tags=${{ steps.image.outputs.name }}:${SAFE_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+          uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./dockerfiles/worker
@@ -108,7 +106,7 @@ jobs:
           cache-to: type=gha,scope=${{ matrix.service }},mode=max
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@v0.36.0
+          uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ steps.image.outputs.name }}:${{ inputs.image_tag || steps.meta.outputs.version }}
           format: sarif
@@ -117,7 +115,7 @@ jobs:
 
       - name: Upload Trivy results to Security tab
         if: ${{ !cancelled() }}
-        uses: github/codeql-action/upload-sarif@v4
+          uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         continue-on-error: true
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -11,7 +11,7 @@ name: Build and Publish Docker Images
 
 on:
   push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+    tags: ['v[0-9]*.[0-9]*.[0-9]*']
   workflow_dispatch:
     inputs:
       git_ref:
@@ -40,16 +40,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.git_ref || github.ref }}
 
       - name: Set up QEMU
-          uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+
       - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
       - name: Log in to GHCR
-          uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -64,8 +66,8 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        if: inputs.image_tag == ''
-          uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        if: github.event_name != 'workflow_dispatch' || inputs.image_tag == ''
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ steps.image.outputs.name }}
           tags: |
@@ -77,7 +79,7 @@ jobs:
 
       - name: Compute custom tag
         id: custom-tag
-        if: inputs.image_tag != ''
+        if: github.event_name == 'workflow_dispatch' && inputs.image_tag != ''
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
@@ -89,9 +91,10 @@ jobs:
             | cut -c1-128 \
           )
           echo "tags=${{ steps.image.outputs.name }}:${SAFE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${SAFE_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-          uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./dockerfiles/worker
@@ -101,21 +104,21 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SERVICE_NAME=${{ matrix.service }}
-            BUILDTAG=${{ inputs.image_tag || github.ref_name }}
+            BUILDTAG=${{ steps.custom-tag.outputs.version || github.ref_name }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,scope=${{ matrix.service }},mode=max
 
       - name: Run Trivy vulnerability scan
-          uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ steps.image.outputs.name }}:${{ inputs.image_tag || steps.meta.outputs.version }}
+          image-ref: ${{ steps.image.outputs.name }}:${{ steps.custom-tag.outputs.version || steps.meta.outputs.version }}
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy results to Security tab
         if: ${{ !cancelled() }}
-          uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         continue-on-error: true
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -91,6 +91,10 @@ jobs:
             | sed 's/^[-._]\+//; s/[-._]\+$//' \
             | cut -c1-128 \
           )
+          if [[ -z "${SAFE_TAG}" ]]; then
+            echo "::error::image_tag '${IMAGE_TAG}' produced an empty tag after sanitization"
+            exit 1
+          fi
           echo "tags=${{ steps.image.outputs.name }}:${SAFE_TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${SAFE_TAG}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -69,6 +69,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch' || inputs.image_tag == ''
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
+          context: git
           images: ${{ steps.image.outputs.name }}
           tags: |
             type=semver,pattern={{version}}
@@ -104,7 +105,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SERVICE_NAME=${{ matrix.service }}
-            BUILDTAG=${{ steps.custom-tag.outputs.version || github.ref_name }}
+            BUILDTAG=${{ steps.custom-tag.outputs.version || steps.meta.outputs.version }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,scope=${{ matrix.service }},mode=max
 

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,122 @@
+name: Build and Publish Docker Images
+
+# Builds multi-arch container images for all services and pushes to GHCR.
+# Includes Trivy CVE scanning with SARIF upload to the Security tab.
+#
+# Triggers:
+#   - Semver tags (v*.*.*): automatic build and push
+#   - workflow_dispatch: manual build from any git ref
+#
+# Images: ghcr.io/<owner>/vc/{verifier,registry,apigw,issuer}
+
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build (tag, branch, or SHA)'
+        required: true
+        default: 'main'
+      image_tag:
+        description: 'Custom image tag (auto-derived from ref if empty)'
+        required: false
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [verifier, registry, apigw, issuer]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.git_ref || github.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image name
+        id: image
+        run: |
+          # Lowercase the full repository path for GHCR compatibility
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "name=${{ env.REGISTRY }}/${REPO}/${{ matrix.service }}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract metadata
+        id: meta
+        if: inputs.image_tag == ''
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+
+      - name: Compute custom tag
+        id: custom-tag
+        if: inputs.image_tag != ''
+        run: |
+          SAFE_TAG=$(echo "${{ inputs.image_tag }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9._-]/-/g' \
+            | sed 's/[-._]\{2,\}/-/g' \
+            | sed 's/^[-._]\+//; s/[-._]\+$//' \
+            | cut -c1-128 \
+          )
+          echo "tags=${{ steps.image.outputs.name }}:${SAFE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./dockerfiles/worker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.custom-tag.outputs.tags || steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SERVICE_NAME=${{ matrix.service }}
+            BUILDTAG=${{ inputs.image_tag || github.ref_name }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,scope=${{ matrix.service }},mode=max
+
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ steps.image.outputs.name }}:${{ inputs.image_tag || steps.meta.outputs.version }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy results to Security tab
+        if: ${{ !cancelled() }}
+        uses: github/codeql-action/upload-sarif@v4
+        continue-on-error: true
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-${{ matrix.service }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -80,8 +80,10 @@ jobs:
       - name: Compute custom tag
         id: custom-tag
         if: inputs.image_tag != ''
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          SAFE_TAG=$(echo "${{ inputs.image_tag }}" \
+          SAFE_TAG=$(echo "${IMAGE_TAG}" \
             | tr '[:upper:]' '[:lower:]' \
             | sed 's/[^a-z0-9._-]/-/g' \
             | sed 's/[-._]\{2,\}/-/g' \

--- a/dockerfiles/worker
+++ b/dockerfiles/worker
@@ -36,10 +36,13 @@ RUN make proto-${SERVICE_NAME}
 # GO_BUILD_TAGS is optional - if set, adds -tags flag
 # CGO defaults to disabled for static builds. Pass --build-arg CGO_ENABLED=1
 # for features that require CGO (e.g. pkcs11 HSM support).
+# TARGETARCH is automatically set by Docker buildx for multi-platform builds;
+# defaults to amd64 for plain docker build.
 ARG CGO_ENABLED=0
+ARG TARGETARCH=amd64
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=amd64 go build -v ${GO_BUILD_TAGS:+-tags "$GO_BUILD_TAGS"} -o bin/vc_$SERVICE_NAME -ldflags \
+    CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH} go build -v ${GO_BUILD_TAGS:+-tags "$GO_BUILD_TAGS"} -o bin/vc_$SERVICE_NAME -ldflags \
     "-X vc/pkg/model.BuildVariableGitCommit=$(git rev-list -1 HEAD) \
     -X vc/pkg/model.BuildVariableGitBranch=$(git rev-parse --abbrev-ref HEAD) \
     -X vc/pkg/model.BuildVariableTimestamp=$(date +'%F:T%TZ') \


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that builds and pushes multi-arch container images for all services to GHCR.

## Depends on

- #473 (TARGETARCH support for multi-arch builds)
- #474 (inline gobuild for self-contained Dockerfile)

## Features

- **Multi-arch**: linux/amd64 + linux/arm64 via QEMU + buildx
- **Matrix strategy**: 4 parallel jobs (verifier, registry, apigw, issuer)
- **Trivy CVE scanning**: per-service SARIF upload to the Security tab
- **Semver tags**: via docker/metadata-action (version, major.minor, major, sha, latest)
- **GHA build cache**: per-service scope for fast rebuilds
- **Manual dispatch**: build any git ref on demand via workflow_dispatch

## Triggers

- `push.tags`: `v*.*.*` — automatic on semver tags
- `workflow_dispatch`: manual build from any ref

## Image naming

`ghcr.io/<owner>/vc/{verifier,registry,apigw,issuer}:<tag>`

The owner is derived from the repository at runtime, so this works for both SUNET/vc and forks.