### PR TITLE
fix: do not enumerate all VCTM claims in fallback DCQL query

### DIFF
--- a/internal/verifier/apiv1/client.go
+++ b/internal/verifier/apiv1/client.go
@@ -307,6 +307,12 @@ func (c *Client) createDCQLQuery(ctx context.Context, scopes []string) (*openid4
 // All scopes are considered for matching, including standard OIDC scopes like "openid".
 // Scopes that don't have a corresponding credential configuration are silently skipped,
 // making standard OIDC scopes optional - they can match if configured, but are not required.
+//
+// This is the fallback path used when no presentation request templates are configured
+// or when template loading fails (e.g. invalid presentation_requests_dir).
+// It does NOT enumerate individual claims from the VCTM — instead it omits the Claims
+// field, letting the wallet decide what to disclose. To request specific claims,
+// configure presentation request templates with explicit DCQL claim paths.
 func (c *Client) buildDCQLQueryFromConfig(scopes []string) (*openid4vp.DCQL, error) {
 	var credentials []openid4vp.CredentialQuery
 
@@ -329,19 +335,6 @@ func (c *Client) buildDCQLQueryFromConfig(scopes []string) (*openid4vp.DCQL, err
 			Meta: openid4vp.MetaQuery{
 				VCTValues: []string{vctID},
 			},
-			Claims: make([]openid4vp.ClaimQuery, 0),
-		}
-
-		// Add claims from VCTM claim paths
-		if credInfo.VCTM != nil {
-			for _, claim := range credInfo.VCTM.Claims {
-				if len(claim.Path) == 0 {
-					continue
-				}
-				cred.Claims = append(cred.Claims, openid4vp.ClaimQuery{
-					Path: claim.Path,
-				})
-			}
 		}
 
 		credentials = append(credentials, cred)

--- a/internal/verifier/apiv1/client_test.go
+++ b/internal/verifier/apiv1/client_test.go
@@ -307,6 +307,9 @@ func TestClient_buildDCQLQueryFromConfig(t *testing.T) {
 				// Verify credential format matches config
 				for _, cred := range dcql.Credentials {
 					assert.Equal(t, "dc+sd-jwt", cred.Format)
+					// Claims should not be populated in fallback mode —
+					// let the wallet decide what to disclose
+					assert.Nil(t, cred.Claims, "fallback DCQL should not enumerate individual claims")
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

Fixes #480

When no presentation request templates are configured (`presentation_requests_dir` not set), the verifier falls back to `buildDCQLQueryFromConfig()` which iterated **all claims** from the VCTM and added them to the DCQL query. This caused the verifier to request every possible claim from the wallet, regardless of what the operator intended.

## Changes

- **`internal/verifier/apiv1/client.go`**: Remove VCTM claim enumeration from `buildDCQLQueryFromConfig()`. The fallback DCQL query now omits the `Claims` field entirely, letting the wallet decide what to disclose. To request specific claims, operators should configure presentation request templates with explicit DCQL claim paths.
- **`internal/verifier/apiv1/client_test.go`**: Add assertion that fallback DCQL credentials do not enumerate individual claims.

## Testing

- All existing tests pass (including the `buildDCQLQueryFromConfig` and `createDCQLQuery` test suites)
- The `scope with VCTM containing claims` test case now explicitly verifies that claims are not populated in fallback mode