### PR TITLE
fix: fail startup when presentation request templates cannot be loaded

### DIFF
--- a/internal/verifier/apiv1/client.go
+++ b/internal/verifier/apiv1/client.go
@@ -95,7 +95,7 @@ func New(ctx context.Context, db *db.Service, notify *notify.Service, cacheServi
 
 	// Load presentation request templates if configured
 	if err := c.loadPresentationTemplates(ctx); err != nil {
-		c.log.Info("Failed to load presentation templates", "error", err)
+		return nil, fmt.Errorf("failed to load presentation request templates: %w", err)
 	}
 
 	// Initialize claims extractor
@@ -148,8 +148,7 @@ func (c *Client) loadPresentationTemplates(ctx context.Context) error {
 	// Load templates from directory
 	config, err := configuration.LoadPresentationRequests(ctx, templatesDir)
 	if err != nil {
-		c.log.Info("Failed to load presentation request templates, falling back to credential config scope mapping", "error", err, "dir", templatesDir)
-		return nil
+		return fmt.Errorf("loading templates from %s: %w", templatesDir, err)
 	}
 
 	// Create presentation builder


### PR DESCRIPTION
## Summary

Fail verifier startup when `presentation_requests_dir` is configured but template loading fails (e.g. duplicate scopes across templates).

## Problem

When template loading failed, the verifier silently fell back to the `buildDCQLQueryFromConfig()` path, which requests **all** VCTM claims instead of the configured subset. This made configuration errors invisible — the verifier appeared to work but requested far more claims than intended.

See #480 for the full analysis and reproduction.

## Changes

- `loadPresentationTemplates()`: return the error instead of logging and returning nil
- `New()`: propagate the error, preventing startup with broken template configuration

When no `presentation_requests_dir` is configured, the behavior is unchanged — the fallback path is used as before.

## Testing

All existing tests pass. The scope uniqueness validation in `validateNoDuplicateScopes()` already catches the duplicate-scope case; this PR ensures that error actually prevents startup instead of being silently swallowed.

Fixes #480