### PR TITLE
fix: don't return redirect_uri in OIDC direct_post response

### DIFF
--- a/internal/verifier/apiv1/handler_oidc.go
+++ b/internal/verifier/apiv1/handler_oidc.go
@@ -749,24 +749,11 @@ func (c *Client) ProcessDirectPost(ctx context.Context, req *DirectPostRequest) 
 
 	c.log.Info("VP processed successfully", "session_id", session.SessionID, "claims_count", len(oidcClaims))
 
-	// Return redirect URI if present
-	redirectURI := ""
-	if session.RedirectURI != "" {
-		u, err := url.Parse(session.RedirectURI)
-		if err != nil {
-			c.log.Error(err, "Failed to parse redirect URI")
-			return nil, ErrServerError
-		}
-		q := u.Query()
-		q.Set("code", code)
-		q.Set("state", session.State)
-		u.RawQuery = q.Encode()
-		redirectURI = u.String()
-	}
-
-	return &DirectPostResponse{
-		RedirectURI: redirectURI,
-	}, nil
+	// Do NOT return redirect_uri here. The browser's /authorize page polls
+	// for session status and handles the redirect to the RP. Returning
+	// redirect_uri would cause the wallet to also redirect, consuming the
+	// authorization code before the browser can use it.
+	return &DirectPostResponse{}, nil
 }
 
 // CallbackRequest represents a callback request

--- a/internal/verifier/apiv1/handler_oidc_test.go
+++ b/internal/verifier/apiv1/handler_oidc_test.go
@@ -2318,10 +2318,10 @@ func TestProcessDirectPost(t *testing.T) {
 				if tt.expectShowCredentials {
 					// Should redirect to display page
 					assert.Contains(t, resp.RedirectURI, "/verification/display/")
-				} else if authCtx.RedirectURI != "" {
-					// Should have authorization code in redirect
-					assert.Contains(t, resp.RedirectURI, "code=")
-					assert.Contains(t, resp.RedirectURI, "state=")
+				} else {
+					// Direct post must NOT return redirect_uri; the browser
+					// picks up the redirect via the poll endpoint instead.
+					assert.Empty(t, resp.RedirectURI)
 				}
 			}
 		})


### PR DESCRIPTION
Fixes #484

## Problem

`ProcessDirectPost()` returned `redirect_uri` (with authorization code) in the direct_post 200 JSON response. The wallet followed this redirect, but the browser's `/authorize` page also polled for `code_issued` status and redirected to the same URL. Both raced to consume the authorization code — the second arrival got an error.

## Fix

Remove `redirect_uri` from the standard code-issuance path in `ProcessDirectPost()`. The browser exclusively handles the redirect to the RP via its polling mechanism (`/poll/<session_id>`).

The credential display path (`ShowCredentialDetails`) still returns its internal `/verification/display/` redirect, which is a verifier-internal page — not the RP callback.

## Spec Reference

Per OpenID4VP spec Section 7.2, `redirect_uri` in the direct_post response is optional. The existing comment at `endpoints_openid4vp.go:77-86` already documented that the browser should pick up the redirect via polling.

## Testing

- Updated `TestProcessDirectPost` to assert `redirect_uri` is empty in the standard flow
- All 8 test cases pass