### PR TITLE
fix: don't DNS-resolve redirect_uris during client registration

### DIFF
--- a/internal/verifier/apiv1/handler_client_registration_test.go
+++ b/internal/verifier/apiv1/handler_client_registration_test.go
@@ -187,6 +187,20 @@ func TestClientRegistrationRequest_Validation(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "valid redirect URI with ccTLD",
+			req: ClientRegistrationRequest{
+				RedirectURIs: []string{"https://example.se/callback"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid redirect URI with non-resolving hostname",
+			req: ClientRegistrationRequest{
+				RedirectURIs: []string{"https://nonexistent.test/callback"},
+			},
+			wantErr: false,
+		},
+		{
 			name: "valid token endpoint auth method - client_secret_basic",
 			req: ClientRegistrationRequest{
 				RedirectURIs:            []string{"https://example.com/callback"},

--- a/pkg/helpers/validate.go
+++ b/pkg/helpers/validate.go
@@ -149,9 +149,17 @@ func NewValidator() (*validator.Validate, error) {
 			return false
 		}
 
-		hostname := parsedURL.Hostname()
-		if hostname == "" {
-			return false
+		// For http/https, require a hostname. For custom schemes (native apps
+		// per RFC 8252 §7.1), only require that the URI has content beyond the scheme.
+		if parsedURL.Scheme == "http" || parsedURL.Scheme == "https" {
+			if parsedURL.Hostname() == "" {
+				return false
+			}
+		} else {
+			// Custom scheme: must have an opaque part or path (e.g. com.example.app:/callback)
+			if parsedURL.Host == "" && parsedURL.Path == "" && parsedURL.Opaque == "" {
+				return false
+			}
 		}
 
 		return true

--- a/pkg/helpers/validate.go
+++ b/pkg/helpers/validate.go
@@ -126,7 +126,10 @@ func NewValidator() (*validator.Validate, error) {
 	// Used by OIDC dynamic client registration (RFC 7591) for redirect_uris.
 	// Per RFC 6749: must have a scheme and must not contain a fragment.
 	// Per RFC 8252 §7.3: loopback redirect URIs MUST be allowed for native clients.
-	// Non-loopback private IPs are blocked to prevent SSRF.
+	// No DNS resolution or SSRF check: redirect URIs are never fetched
+	// server-side — the browser follows them. Blocking unresolvable
+	// hostnames would reject valid registrations (e.g. any TLD not in the
+	// verifier's DNS).
 	err = validate.RegisterValidation("redirect_uri", func(fl validator.FieldLevel) bool {
 		urlStr := fl.Field().String()
 		if urlStr == "" {
@@ -149,27 +152,6 @@ func NewValidator() (*validator.Validate, error) {
 		hostname := parsedURL.Hostname()
 		if hostname == "" {
 			return false
-		}
-
-		// Per RFC 8252 §7.3: loopback redirect URIs (localhost, 127.0.0.1, [::1])
-		// MUST be allowed for native OAuth 2.0 clients.
-		lowerHost := strings.ToLower(hostname)
-		if lowerHost == "localhost" || lowerHost == "127.0.0.1" || lowerHost == "::1" {
-			return true
-		}
-
-		// Resolve hostname and block private/loopback IPs
-		ips, err := net.LookupIP(hostname)
-		if err != nil {
-			// If we can't resolve, allow — it may be a custom scheme (e.g. eudi-wallet://)
-			// Custom schemes won't have a resolvable hostname
-			return parsedURL.Scheme != "http" && parsedURL.Scheme != "https"
-		}
-
-		for _, ip := range ips {
-			if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() {
-				return false
-			}
 		}
 
 		return true


### PR DESCRIPTION
Fixes #487

## Problem

The `redirect_uri` validator resolved hostnames via `net.LookupIP()` and rejected URIs whose hostnames didn't resolve (for http/https). This caused ccTLD domains like `example.se` to fail registration while `example.org` (which resolves to an IANA-reserved IP) succeeded.

## Fix

Remove DNS resolution and private-IP blocking from the `redirect_uri` validator. Redirect URIs are never fetched server-side — they're URLs the browser is redirected to. The SSRF concern that motivated the DNS check doesn't apply.

Keep only the syntactic checks required by RFC 6749 (scheme present, no fragment).

The `safe_uri` validator (used for server-side fetches like `logo_uri`) retains its DNS/SSRF checks.

## Tests

Added test cases for ccTLD (`example.se`) and non-resolving hostnames (`nonexistent.test`).