### PR TITLE
feat: add POST /api/v1/datastore/preauth_offer endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ swagger-verifier: ## Generate verifier Swagger docs
 	swag init -d internal/verifier/apiv1/ -g client.go --output docs/verifier $(SWAGGER_OPTS)
 
 swagger-apigw: ## Generate apigw Swagger docs
-	swag init -d internal/apigw/apiv1/,pkg/helpers,pkg/model,pkg/vcclient,pkg/openid4vci,pkg/oauth2,internal/gen/issuer/apiv1_issuer -g client.go --output docs/apigw $(SWAGGER_OPTS)
+	swag init -d internal/apigw/apiv1/,pkg/helpers,pkg/model,pkg/vcclient,pkg/openid4vci,pkg/openid4vp,pkg/oauth2,internal/gen/issuer/apiv1_issuer -g client.go --output docs/apigw $(SWAGGER_OPTS)
 
 swagger-issuer: ## Generate issuer Swagger docs
 	swag init -d internal/issuer/apiv1/ -g client.go --output docs/issuer $(SWAGGER_OPTS)

--- a/docs/apigw/docs.go
+++ b/docs/apigw/docs.go
@@ -1170,9 +1170,6 @@ const docTemplate = `{
                 },
                 "credential_offer_url": {
                     "type": "string"
-                },
-                "qr": {
-                    "$ref": "#/definitions/openid4vp.QRReply"
                 }
             }
         },
@@ -2288,21 +2285,6 @@ const docTemplate = `{
                 },
                 "token_type": {
                     "description": "TokenType REQUIRED.  The type of the token issued as described in Section 7.1.  Value is case insensitive.",
-                    "type": "string"
-                }
-            }
-        },
-        "openid4vp.QRReply": {
-            "type": "object",
-            "required": [
-                "base64_image",
-                "uri"
-            ],
-            "properties": {
-                "base64_image": {
-                    "type": "string"
-                },
-                "uri": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/docs.go
+++ b/docs/apigw/docs.go
@@ -336,6 +336,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datastore/preauth_offer": {
+            "post": {
+                "description": "Generate a pre-authorized credential offer for a datastore document",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "vc-platform"
+                ],
+                "summary": "DatastorePreAuthOffer",
+                "operationId": "datastore-preauth-offer",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiv1.DatastorePreAuthOfferRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/apiv1.DatastorePreAuthOfferReply"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/helpers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Document not found",
+                        "schema": {
+                            "$ref": "#/definitions/helpers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datastore/resolve": {
             "post": {
                 "description": "Resolve identity attributes to documents",
@@ -1112,6 +1159,45 @@ const docTemplate = `{
                 },
                 "valid_to": {
                     "type": "integer"
+                }
+            }
+        },
+        "apiv1.DatastorePreAuthOfferReply": {
+            "type": "object",
+            "properties": {
+                "credential_offer": {
+                    "$ref": "#/definitions/openid4vci.CredentialOfferResult"
+                },
+                "credential_offer_url": {
+                    "type": "string"
+                },
+                "qr": {
+                    "$ref": "#/definitions/openid4vp.QRReply"
+                }
+            }
+        },
+        "apiv1.DatastorePreAuthOfferRequest": {
+            "type": "object",
+            "required": [
+                "authentic_source",
+                "document_id",
+                "scope"
+            ],
+            "properties": {
+                "authentic_source": {
+                    "description": "required: true\nexample: SUNET",
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "document_id": {
+                    "description": "required: true\nexample: 7a00fe1a-3e1a-11ef-9272-fb906803d1b8",
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "scope": {
+                    "description": "required: true\nexample: pid",
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -2202,6 +2288,21 @@ const docTemplate = `{
                 },
                 "token_type": {
                     "description": "TokenType REQUIRED.  The type of the token issued as described in Section 7.1.  Value is case insensitive.",
+                    "type": "string"
+                }
+            }
+        },
+        "openid4vp.QRReply": {
+            "type": "object",
+            "required": [
+                "base64_image",
+                "uri"
+            ],
+            "properties": {
+                "base64_image": {
+                    "type": "string"
+                },
+                "uri": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.json
+++ b/docs/apigw/swagger.json
@@ -1162,9 +1162,6 @@
                 },
                 "credential_offer_url": {
                     "type": "string"
-                },
-                "qr": {
-                    "$ref": "#/definitions/openid4vp.QRReply"
                 }
             }
         },
@@ -2280,21 +2277,6 @@
                 },
                 "token_type": {
                     "description": "TokenType REQUIRED.  The type of the token issued as described in Section 7.1.  Value is case insensitive.",
-                    "type": "string"
-                }
-            }
-        },
-        "openid4vp.QRReply": {
-            "type": "object",
-            "required": [
-                "base64_image",
-                "uri"
-            ],
-            "properties": {
-                "base64_image": {
-                    "type": "string"
-                },
-                "uri": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.json
+++ b/docs/apigw/swagger.json
@@ -328,6 +328,53 @@
                 }
             }
         },
+        "/api/v1/datastore/preauth_offer": {
+            "post": {
+                "description": "Generate a pre-authorized credential offer for a datastore document",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "vc-platform"
+                ],
+                "summary": "DatastorePreAuthOffer",
+                "operationId": "datastore-preauth-offer",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiv1.DatastorePreAuthOfferRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/apiv1.DatastorePreAuthOfferReply"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/helpers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Document not found",
+                        "schema": {
+                            "$ref": "#/definitions/helpers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datastore/resolve": {
             "post": {
                 "description": "Resolve identity attributes to documents",
@@ -1104,6 +1151,45 @@
                 },
                 "valid_to": {
                     "type": "integer"
+                }
+            }
+        },
+        "apiv1.DatastorePreAuthOfferReply": {
+            "type": "object",
+            "properties": {
+                "credential_offer": {
+                    "$ref": "#/definitions/openid4vci.CredentialOfferResult"
+                },
+                "credential_offer_url": {
+                    "type": "string"
+                },
+                "qr": {
+                    "$ref": "#/definitions/openid4vp.QRReply"
+                }
+            }
+        },
+        "apiv1.DatastorePreAuthOfferRequest": {
+            "type": "object",
+            "required": [
+                "authentic_source",
+                "document_id",
+                "scope"
+            ],
+            "properties": {
+                "authentic_source": {
+                    "description": "required: true\nexample: SUNET",
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "document_id": {
+                    "description": "required: true\nexample: 7a00fe1a-3e1a-11ef-9272-fb906803d1b8",
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "scope": {
+                    "description": "required: true\nexample: pid",
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -2194,6 +2280,21 @@
                 },
                 "token_type": {
                     "description": "TokenType REQUIRED.  The type of the token issued as described in Section 7.1.  Value is case insensitive.",
+                    "type": "string"
+                }
+            }
+        },
+        "openid4vp.QRReply": {
+            "type": "object",
+            "required": [
+                "base64_image",
+                "uri"
+            ],
+            "properties": {
+                "base64_image": {
+                    "type": "string"
+                },
+                "uri": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.yaml
+++ b/docs/apigw/swagger.yaml
@@ -145,8 +145,6 @@ definitions:
         $ref: '#/definitions/openid4vci.CredentialOfferResult'
       credential_offer_url:
         type: string
-      qr:
-        $ref: '#/definitions/openid4vp.QRReply'
     type: object
   apiv1.DatastorePreAuthOfferRequest:
     properties:
@@ -1130,16 +1128,6 @@ definitions:
     - access_token
     - expires_in
     - token_type
-    type: object
-  openid4vp.QRReply:
-    properties:
-      base64_image:
-        type: string
-      uri:
-        type: string
-    required:
-    - base64_image
-    - uri
     type: object
   vcclient.UploadRequest:
     properties:

--- a/docs/apigw/swagger.yaml
+++ b/docs/apigw/swagger.yaml
@@ -139,6 +139,40 @@ definitions:
     required:
     - identity_mapping_id
     type: object
+  apiv1.DatastorePreAuthOfferReply:
+    properties:
+      credential_offer:
+        $ref: '#/definitions/openid4vci.CredentialOfferResult'
+      credential_offer_url:
+        type: string
+      qr:
+        $ref: '#/definitions/openid4vp.QRReply'
+    type: object
+  apiv1.DatastorePreAuthOfferRequest:
+    properties:
+      authentic_source:
+        description: |-
+          required: true
+          example: SUNET
+        maxLength: 128
+        type: string
+      document_id:
+        description: |-
+          required: true
+          example: 7a00fe1a-3e1a-11ef-9272-fb906803d1b8
+        maxLength: 128
+        type: string
+      scope:
+        description: |-
+          required: true
+          example: pid
+        maxLength: 128
+        type: string
+    required:
+    - authentic_source
+    - document_id
+    - scope
+    type: object
   apiv1.DatastoreResolveReply:
     properties:
       authentic_source_person_id:
@@ -1097,6 +1131,16 @@ definitions:
     - expires_in
     - token_type
     type: object
+  openid4vp.QRReply:
+    properties:
+      base64_image:
+        type: string
+      uri:
+        type: string
+    required:
+    - base64_image
+    - uri
+    type: object
   vcclient.UploadRequest:
     properties:
       document_data:
@@ -1331,6 +1375,37 @@ paths:
           schema:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: DatastoreList
+      tags:
+      - vc-platform
+  /api/v1/datastore/preauth_offer:
+    post:
+      consumes:
+      - application/json
+      description: Generate a pre-authorized credential offer for a datastore document
+      operationId: datastore-preauth-offer
+      parameters:
+      - description: ' '
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/apiv1.DatastorePreAuthOfferRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: '#/definitions/apiv1.DatastorePreAuthOfferReply'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/helpers.ErrorResponse'
+        "404":
+          description: Document not found
+          schema:
+            $ref: '#/definitions/helpers.ErrorResponse'
+      summary: DatastorePreAuthOffer
       tags:
       - vc-platform
   /api/v1/datastore/resolve:

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -619,8 +619,9 @@ func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAut
 		CreatedAt:  time.Now(),
 		ExpiresAt:  time.Now().Add(5 * time.Minute).Unix(),
 		Scopes:     []string{req.Scope},
-		Nonce:      nonce,
-		DataSource: string(model.DataSourceDatastore),
+		Nonce:        nonce,
+		DataSource:   string(model.DataSourceDatastore),
+		AuthProvider: model.AuthProviderDatastore,
 	}
 	if err := c.cacheService.AuthContext.Save(ctx, authCtx); err != nil {
 		return nil, fmt.Errorf("failed to store pre-auth code: %w", err)

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -3,7 +3,6 @@ package apiv1
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/SUNET/vc/internal/apigw/db"
@@ -12,11 +11,9 @@ import (
 	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/openid4vci"
-	"github.com/SUNET/vc/pkg/openid4vp"
 	"github.com/SUNET/vc/pkg/vcclient"
 
 	"github.com/google/uuid"
-	"github.com/skip2/go-qrcode"
 )
 
 // DatastoreUploadReply is the reply for a document upload
@@ -562,11 +559,10 @@ type DatastorePreAuthOfferRequest struct {
 	DocumentID string `json:"document_id" validate:"required,max=128,printascii"`
 }
 
-// DatastorePreAuthOfferReply is the reply containing a credential offer and QR code
+// DatastorePreAuthOfferReply is the reply containing a credential offer
 type DatastorePreAuthOfferReply struct {
 	CredentialOffer    *openid4vci.CredentialOfferResult `json:"credential_offer"`
 	CredentialOfferURL string                            `json:"credential_offer_url"`
-	QR                 *openid4vp.QRReply                `json:"qr,omitempty"`
 }
 
 // DatastorePreAuthOffer generates a pre-authorized credential offer for a specific
@@ -645,21 +641,9 @@ func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAut
 	}
 	credentialOfferURL := fmt.Sprintf("openid-credential-offer://?%s", string(credentialOfferEncoded))
 
-	// Generate QR code for the offer URL
-	u, err := url.Parse(credentialOfferURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse credential offer URL: %w", err)
-	}
-	qr, err := openid4vp.GenerateQR(u, qrcode.Medium, 256)
-	if err != nil {
-		c.log.Debug("failed to generate QR code", "error", err)
-		// QR generation failure is non-fatal; return the offer without the QR
-	}
-
 	reply := &DatastorePreAuthOfferReply{
 		CredentialOffer:    credentialOffer,
 		CredentialOfferURL: credentialOfferURL,
-		QR:                 qr,
 	}
 
 	c.log.Info("Pre-authorized credential offer created for datastore document",

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -3,13 +3,20 @@ package apiv1
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"time"
 
 	"github.com/SUNET/vc/internal/apigw/db"
+	"github.com/SUNET/vc/pkg/cache"
+	"github.com/SUNET/vc/pkg/crypto"
 	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/openid4vci"
+	"github.com/SUNET/vc/pkg/openid4vp"
 	"github.com/SUNET/vc/pkg/vcclient"
 
 	"github.com/google/uuid"
+	"github.com/skip2/go-qrcode"
 )
 
 // DatastoreUploadReply is the reply for a document upload
@@ -535,6 +542,131 @@ func (c *Client) DatastoreSearch(ctx context.Context, req *DatastoreSearchReques
 	reply := &DatastoreSearchReply{
 		Data: docs,
 	}
+
+	return reply, nil
+}
+
+// DatastorePreAuthOfferRequest is the request for generating a pre-authorized credential offer
+// for a specific document in the datastore.
+type DatastorePreAuthOfferRequest struct {
+	// required: true
+	// example: SUNET
+	AuthenticSource string `json:"authentic_source" validate:"required,max=128,printascii"`
+
+	// required: true
+	// example: pid
+	Scope string `json:"scope" validate:"required,max=128,printascii"`
+
+	// required: true
+	// example: 7a00fe1a-3e1a-11ef-9272-fb906803d1b8
+	DocumentID string `json:"document_id" validate:"required,max=128,printascii"`
+}
+
+// DatastorePreAuthOfferReply is the reply containing a credential offer and QR code
+type DatastorePreAuthOfferReply struct {
+	CredentialOffer    *openid4vci.CredentialOfferResult `json:"credential_offer"`
+	CredentialOfferURL string                            `json:"credential_offer_url"`
+	QR                 *openid4vp.QRReply                `json:"qr,omitempty"`
+}
+
+// DatastorePreAuthOffer generates a pre-authorized credential offer for a specific
+// document in the datastore. This allows an admin or authentic source to create
+// a credential offer that a wallet can redeem without user authentication.
+//
+//	@Summary		DatastorePreAuthOffer
+//	@ID				datastore-preauth-offer
+//	@Description	Generate a pre-authorized credential offer for a datastore document
+//	@Tags			vc-platform
+//	@Accept			json
+//	@Produce		json
+//	@Success		200	{object}	DatastorePreAuthOfferReply	"Success"
+//	@Failure		400	{object}	helpers.ErrorResponse		"Bad Request"
+//	@Failure		404	{object}	helpers.ErrorResponse		"Document not found"
+//	@Param			req	body		DatastorePreAuthOfferRequest	true	" "
+//	@Router			/api/v1/datastore/preauth_offer [post]
+func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAuthOfferRequest) (*DatastorePreAuthOfferReply, error) {
+	// Look up the document from the datastore
+	doc, err := c.datastoreStore.GetByKey(ctx, req.AuthenticSource, req.Scope, req.DocumentID)
+	if err != nil {
+		return nil, fmt.Errorf("document not found: %w", err)
+	}
+
+	// Generate credential offer with pre-authorized code
+	credentialOffer, err := openid4vci.NewCredentialOffer(
+		c.cfg.APIGW.Delivery.CredentialOffers.IssuerURL,
+		req.Scope,
+		openid4vci.GrantTypePreAuthorizedCode,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate credential offer: %w", err)
+	}
+
+	preAuthCode := credentialOffer.ID
+
+	// Generate nonce for the authorization context
+	nonce, err := crypto.GenerateSecureToken(0, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	// Create and persist the authorization context so the wallet can redeem
+	// the offer via the token endpoint.
+	authCtx := &cache.AuthorizationContext{
+		SessionID:  preAuthCode,
+		Code:       preAuthCode,
+		Status:     "code_issued",
+		CreatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(5 * time.Minute).Unix(),
+		Scopes:     []string{req.Scope},
+		Nonce:      nonce,
+		DataSource: string(model.DataSourceDatastore),
+		AuthorizationDetails: []openid4vci.AuthorizationDetailsParameter{
+			{
+				Type:                      "openid_credential",
+				CredentialConfigurationID: req.Scope,
+			},
+		},
+	}
+	if err := c.cacheService.AuthContext.Save(ctx, authCtx); err != nil {
+		return nil, fmt.Errorf("failed to store pre-auth code: %w", err)
+	}
+
+	// Store the document data so the credential endpoint can issue the
+	// credential when the wallet redeems the offer.
+	if err := c.StoreVCIDocuments(ctx, preAuthCode, map[string]*model.CompleteDocument{req.AuthenticSource: doc}); err != nil {
+		return nil, fmt.Errorf("failed to store VCI documents: %w", err)
+	}
+
+	// Build the credential offer URL (inline offer, not by-reference)
+	offerParams := credentialOffer.CredentialOfferParameters
+	credentialOfferEncoded, err := offerParams.CredentialOffer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode credential offer: %w", err)
+	}
+	credentialOfferURL := fmt.Sprintf("openid-credential-offer://?%s", string(credentialOfferEncoded))
+
+	// Generate QR code for the offer URL
+	u, err := url.Parse(credentialOfferURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse credential offer URL: %w", err)
+	}
+	qr, err := openid4vp.GenerateQR(u, qrcode.Medium, 256)
+	if err != nil {
+		c.log.Debug("failed to generate QR code", "error", err)
+		// QR generation failure is non-fatal; return the offer without the QR
+	}
+
+	reply := &DatastorePreAuthOfferReply{
+		CredentialOffer:    credentialOffer,
+		CredentialOfferURL: credentialOfferURL,
+		QR:                 qr,
+	}
+
+	c.log.Info("Pre-authorized credential offer created for datastore document",
+		"authentic_source", req.AuthenticSource,
+		"scope", req.Scope,
+		"document_id", req.DocumentID,
+		"offer_id", credentialOffer.ID)
 
 	return reply, nil
 }

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -607,6 +607,11 @@ func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAut
 
 	// Create and persist the authorization context so the wallet can redeem
 	// the offer via the token endpoint.
+	// Note: AuthorizationDetails is intentionally left empty. If set, the token
+	// endpoint would return authorization_details with credential_identifiers,
+	// which per OID4VCI spec forces the wallet to use credential_identifier
+	// (not credential_configuration_id) in the credential request. Most wallets
+	// use credential_configuration_id for pre-auth flows, so we keep it simple.
 	authCtx := &cache.AuthorizationContext{
 		SessionID:  preAuthCode,
 		Code:       preAuthCode,
@@ -616,12 +621,6 @@ func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAut
 		Scopes:     []string{req.Scope},
 		Nonce:      nonce,
 		DataSource: string(model.DataSourceDatastore),
-		AuthorizationDetails: []openid4vci.AuthorizationDetailsParameter{
-			{
-				Type:                      "openid_credential",
-				CredentialConfigurationID: req.Scope,
-			},
-		},
 	}
 	if err := c.cacheService.AuthContext.Save(ctx, authCtx); err != nil {
 		return nil, fmt.Errorf("failed to store pre-auth code: %w", err)

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -2,6 +2,7 @@ package apiv1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -584,7 +585,10 @@ func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAut
 	// Look up the document from the datastore
 	doc, err := c.datastoreStore.GetByKey(ctx, req.AuthenticSource, req.Scope, req.DocumentID)
 	if err != nil {
-		return nil, fmt.Errorf("document not found: %w", err)
+		if errors.Is(err, helpers.ErrNoDocumentFound) {
+			return nil, helpers.ErrNoDocumentFound
+		}
+		return nil, fmt.Errorf("failed to retrieve document: %w", err)
 	}
 
 	// Generate credential offer with pre-authorized code

--- a/internal/apigw/apiv1/handlers_datastore_test.go
+++ b/internal/apigw/apiv1/handlers_datastore_test.go
@@ -981,10 +981,6 @@ func TestDatastorePreAuthOffer_Success(t *testing.T) {
 	assert.Contains(t, reply.CredentialOfferURL, "openid-credential-offer://")
 	assert.Contains(t, reply.CredentialOfferURL, "credential_offer")
 
-	// Verify QR code was generated
-	require.NotNil(t, reply.QR)
-	assert.NotEmpty(t, reply.QR.Base64Image)
-	assert.NotEmpty(t, reply.QR.URI)
 }
 
 func TestDatastorePreAuthOffer_DocumentNotFound(t *testing.T) {

--- a/internal/apigw/apiv1/handlers_datastore_test.go
+++ b/internal/apigw/apiv1/handlers_datastore_test.go
@@ -994,7 +994,7 @@ func TestDatastorePreAuthOffer_DocumentNotFound(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, reply)
-	assert.Contains(t, err.Error(), "document not found")
+	assert.ErrorIs(t, err, helpers.ErrNoDocumentFound)
 }
 
 func TestDatastorePreAuthOffer_AuthContextPersisted(t *testing.T) {

--- a/internal/apigw/apiv1/handlers_datastore_test.go
+++ b/internal/apigw/apiv1/handlers_datastore_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SUNET/vc/internal/apigw/cache"
 	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/openid4vci"
 	"github.com/SUNET/vc/pkg/vcclient"
 
 	"github.com/stretchr/testify/assert"
@@ -914,4 +916,138 @@ func TestDatastoreDeleteNotFound(t *testing.T) {
 		AuthenticSource: "SUNET", Scope: "ehic", DocumentID: "no-such",
 	})
 	assert.Error(t, err)
+}
+
+// --- DatastorePreAuthOffer ---
+
+func newPreAuthOfferTestClient(t *testing.T) (*Client, *memoryDatastoreStore) {
+	t.Helper()
+	log, err := logger.New("test", "", false)
+	require.NoError(t, err)
+
+	datastore := newMemoryDatastoreStore()
+	authContextStore := cache.NewTestMemoryStore(10 * time.Minute)
+	docCache := cache.NewTestMemoryCache[map[string]*model.CompleteDocument](10 * time.Minute)
+
+	client := &Client{
+		log:            log,
+		datastoreStore: datastore,
+		cfg: &model.Cfg{
+			APIGW: &model.APIGW{
+				Delivery: model.APIGWDelivery{
+					CredentialOffers: model.CredentialOffers{
+						IssuerURL: "https://issuer.example.com",
+						Wallets:   map[string]model.CredentialOfferWallets{},
+					},
+				},
+			},
+		},
+		cacheService: &cache.Service{
+			AuthContext: authContextStore,
+			Document:    docCache,
+		},
+	}
+	return client, datastore
+}
+
+func TestDatastorePreAuthOffer_Success(t *testing.T) {
+	client, datastore := newPreAuthOfferTestClient(t)
+
+	seedDoc(t, datastore, "SUNET", "pid", "doc-1", []string{"person-1"}, map[string]any{
+		"family_name": "Doe",
+		"given_name":  "John",
+	})
+
+	reply, err := client.DatastorePreAuthOffer(t.Context(), &DatastorePreAuthOfferRequest{
+		AuthenticSource: "SUNET",
+		Scope:           "pid",
+		DocumentID:      "doc-1",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, reply)
+
+	// Verify credential offer fields
+	assert.Equal(t, "https://issuer.example.com", reply.CredentialOffer.CredentialIssuer)
+	assert.Equal(t, []string{"pid"}, reply.CredentialOffer.CredentialConfigurationIDs)
+	assert.NotEmpty(t, reply.CredentialOffer.ID)
+
+	// Verify the offer contains a pre-authorized code grant
+	grant, ok := reply.CredentialOffer.Grants[openid4vci.GrantTypePreAuthorizedCode]
+	require.True(t, ok, "offer should contain pre-authorized_code grant")
+	require.NotNil(t, grant)
+
+	// Verify credential offer URL
+	assert.Contains(t, reply.CredentialOfferURL, "openid-credential-offer://")
+	assert.Contains(t, reply.CredentialOfferURL, "credential_offer")
+
+	// Verify QR code was generated
+	require.NotNil(t, reply.QR)
+	assert.NotEmpty(t, reply.QR.Base64Image)
+	assert.NotEmpty(t, reply.QR.URI)
+}
+
+func TestDatastorePreAuthOffer_DocumentNotFound(t *testing.T) {
+	client, _ := newPreAuthOfferTestClient(t)
+
+	reply, err := client.DatastorePreAuthOffer(t.Context(), &DatastorePreAuthOfferRequest{
+		AuthenticSource: "SUNET",
+		Scope:           "pid",
+		DocumentID:      "nonexistent",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, reply)
+	assert.Contains(t, err.Error(), "document not found")
+}
+
+func TestDatastorePreAuthOffer_AuthContextPersisted(t *testing.T) {
+	client, datastore := newPreAuthOfferTestClient(t)
+
+	seedDoc(t, datastore, "SUNET", "ehic", "doc-2", []string{"person-2"}, map[string]any{
+		"card_number": "SE123456",
+	})
+
+	reply, err := client.DatastorePreAuthOffer(t.Context(), &DatastorePreAuthOfferRequest{
+		AuthenticSource: "SUNET",
+		Scope:           "ehic",
+		DocumentID:      "doc-2",
+	})
+	require.NoError(t, err)
+
+	// Verify the auth context was saved by retrieving it
+	preAuthCode := reply.CredentialOffer.ID
+	authCtx, err := client.cacheService.AuthContext.GetByID(t.Context(), preAuthCode)
+	require.NoError(t, err)
+	require.NotNil(t, authCtx)
+
+	assert.Equal(t, preAuthCode, authCtx.SessionID)
+	assert.Equal(t, preAuthCode, authCtx.Code)
+	assert.Equal(t, "code_issued", string(authCtx.Status))
+	assert.Equal(t, []string{"ehic"}, authCtx.Scopes)
+	assert.Equal(t, "datastore", authCtx.DataSource)
+	assert.NotEmpty(t, authCtx.Nonce)
+	assert.True(t, authCtx.ExpiresAt > time.Now().Unix())
+}
+
+func TestDatastorePreAuthOffer_DocumentDataCached(t *testing.T) {
+	client, datastore := newPreAuthOfferTestClient(t)
+
+	docData := map[string]any{
+		"family_name": "Smith",
+		"given_name":  "Jane",
+		"birth_date":  "1990-05-15",
+	}
+	seedDoc(t, datastore, "SUNET", "pid", "doc-3", []string{"person-3"}, docData)
+
+	reply, err := client.DatastorePreAuthOffer(t.Context(), &DatastorePreAuthOfferRequest{
+		AuthenticSource: "SUNET",
+		Scope:           "pid",
+		DocumentID:      "doc-3",
+	})
+	require.NoError(t, err)
+
+	// Verify the document data was cached for the credential endpoint
+	preAuthCode := reply.CredentialOffer.ID
+	assert.True(t, client.HasVCIDocuments(t.Context(), preAuthCode))
 }

--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -56,10 +56,11 @@ func (c *Client) ResolveIdentifier(ctx context.Context, authenticSource string, 
 }
 
 // requireIdentifier validates that a non-empty identifier exists for data sources
-// that require it. Assertion-based issuance allows an empty identifier because
-// all data comes from the trusted IdP claims.
+// that require it. Assertion-based and datastore-based issuance allow an empty
+// identifier because the data comes from trusted sources (IdP claims or
+// pre-uploaded documents) rather than identity-mapped lookups.
 func requireIdentifier(identifier string, dataSource model.DataSourceType) (string, error) {
-	if identifier == "" && dataSource != model.DataSourceAssertion {
+	if identifier == "" && dataSource != model.DataSourceAssertion && dataSource != model.DataSourceDatastore {
 		return "", errors.New("no identifier in auth context")
 	}
 	return identifier, nil

--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -281,7 +281,7 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 	c.log.Debug("VCICredential: retrieving credential data", "auth_provider", authContext.AuthProvider, "scope", scope, "session_id", authContext.SessionID, "doc_session_id", docSessionID)
 	// Retrieve credential data based on the auth provider used during authorization
 	switch authContext.AuthProvider {
-	case model.AuthProviderOpenID4VP, model.AuthProviderSAML, model.AuthProviderOIDC:
+	case model.AuthProviderOpenID4VP, model.AuthProviderSAML, model.AuthProviderOIDC, model.AuthProviderDatastore:
 		// Session-based auth providers: retrieve from session cache
 		docs, ok := c.cacheService.Document.Get(ctx, docSessionID)
 		if !ok || len(docs) == 0 {

--- a/internal/apigw/apiv1/handlers_issuer_assertion_test.go
+++ b/internal/apigw/apiv1/handlers_issuer_assertion_test.go
@@ -175,10 +175,10 @@ func TestAssertionDataSource_CredentialIssuance_AllowsEmptyIdentifier(t *testing
 			wantErr:    false,
 		},
 		{
-			name:       "datastore_empty_identifier_rejected",
+			name:       "datastore_empty_identifier_allowed",
 			dataSource: model.DataSourceDatastore,
 			identifier: "",
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name:       "external_api_empty_identifier_rejected",

--- a/internal/apigw/httpserver/api.go
+++ b/internal/apigw/httpserver/api.go
@@ -29,6 +29,7 @@ type Apiv1 interface {
 	DatastoreReplace(ctx context.Context, req *vcclient.UploadRequest) error
 	DatastoreSearch(ctx context.Context, req *apiv1.DatastoreSearchRequest) (*apiv1.DatastoreSearchReply, error)
 	DatastoreBulkUpload(ctx context.Context, req *apiv1.DatastoreBulkUploadRequest) (*apiv1.DatastoreBulkUploadReply, error)
+	DatastorePreAuthOffer(ctx context.Context, req *apiv1.DatastorePreAuthOfferRequest) (*apiv1.DatastorePreAuthOfferReply, error)
 
 	// identity mapping endpoints
 	IdentityMappingCreate(ctx context.Context, req *apiv1.IdentityMappingCreateRequest) (*apiv1.IdentityMappingCreateReply, error)

--- a/internal/apigw/httpserver/endpoints_datastore.go
+++ b/internal/apigw/httpserver/endpoints_datastore.go
@@ -214,3 +214,22 @@ func (s *Service) endpointDatastoreBulkUpload(ctx context.Context, c *gin.Contex
 
 	return reply, nil
 }
+
+func (s *Service) endpointDatastorePreAuthOffer(ctx context.Context, c *gin.Context) (any, error) {
+	ctx, span := s.tracer.Start(ctx, "httpserver:endpointDatastorePreAuthOffer")
+	defer span.End()
+
+	request := &apiv1.DatastorePreAuthOfferRequest{}
+	if err := s.httpHelpers.Binding.Request(ctx, c, request); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	reply, err := s.apiv1.DatastorePreAuthOffer(ctx, request)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	return reply, nil
+}

--- a/internal/apigw/httpserver/endpoints_datastore_test.go
+++ b/internal/apigw/httpserver/endpoints_datastore_test.go
@@ -394,6 +394,10 @@ func (u unimplementedApiv1) ListAuthenticSources(context.Context) ([]string, err
 	return nil, nil
 }
 
+func (u unimplementedApiv1) DatastorePreAuthOffer(context.Context, *apiv1.DatastorePreAuthOfferRequest) (*apiv1.DatastorePreAuthOfferReply, error) {
+	panic("not implemented")
+}
+
 func (u unimplementedApiv1) Health(context.Context, *apiv1_status.StatusRequest) (*apiv1_status.StatusReply, error) {
 	panic("not implemented")
 }

--- a/internal/apigw/httpserver/service.go
+++ b/internal/apigw/httpserver/service.go
@@ -262,6 +262,7 @@ func New(ctx context.Context, cfg *model.Cfg, apiv1 *apiv1.Client, tracer *trace
 	s.httpHelpers.Server.RegEndpoint(ctx, rgDatastore, http.MethodDelete, "/identity", http.StatusNoContent, s.endpointDatastoreDeleteIdentity)
 	s.httpHelpers.Server.RegEndpoint(ctx, rgDatastore, http.MethodGet, "/search", http.StatusOK, s.endpointDatastoreSearch)
 	s.httpHelpers.Server.RegEndpoint(ctx, rgDatastore, http.MethodPost, "/bulk", http.StatusOK, s.endpointDatastoreBulkUpload)
+	s.httpHelpers.Server.RegEndpoint(ctx, rgDatastore, http.MethodPost, "/preauth_offer", http.StatusOK, s.endpointDatastorePreAuthOffer)
 
 	s.httpHelpers.Server.RegEndpoint(ctx, rgOAuthSession, http.MethodGet, "/user/lookup", http.StatusOK, s.endpointUserLookup)
 	s.httpHelpers.Server.RegEndpoint(ctx, rgOAuthSession, http.MethodPost, "/user/cancel", http.StatusSeeOther, s.endpointUserCancel)

--- a/pkg/model/auth_providers.go
+++ b/pkg/model/auth_providers.go
@@ -4,4 +4,5 @@ const (
 	AuthProviderSAML      = "saml"
 	AuthProviderOIDC      = "oidc"
 	AuthProviderOpenID4VP = "openid4vp"
+	AuthProviderDatastore = "datastore"
 )


### PR DESCRIPTION
## Summary

Add a new endpoint `POST /api/v1/datastore/preauth_offer` that generates a pre-authorized credential offer for a specific document in the datastore.

This restores the capability that was lost when PR #375 removed the old `/api/v1/notification` endpoint and the `QR` field from the `CompleteDocument` model.

Closes #492

## What it does

The endpoint accepts `{authentic_source, scope, document_id}` and:

1. Looks up the document from the datastore
2. Generates a credential offer with a pre-authorized code (via `openid4vci.NewCredentialOffer`)
3. Creates and persists an authorization context in the cache (5-minute expiry)
4. Caches the document data for the credential endpoint (keyed by pre-auth code)
5. Returns the credential offer, a `credential_offer_url`, and a QR code

## Design

This follows the same pre-authorized code flow pattern used by the OIDC (`handlers_oidcrp.go`) and SAML (`endpoints_saml.go`) standalone authentication flows, but sources the document data from the datastore instead of from authentication claims.

The wallet can redeem the offer via the standard token + credential endpoints, just as it would for an OIDC/SAML-initiated offer.

## Files changed

- `internal/apigw/apiv1/handlers_datastore.go` — new handler + request/reply types
- `internal/apigw/httpserver/endpoints_datastore.go` — HTTP endpoint wrapper
- `internal/apigw/httpserver/service.go` — route registration
- `internal/apigw/httpserver/api.go` — interface method
- `internal/apigw/apiv1/handlers_datastore_test.go` — unit tests (4 test cases)