### PR TITLE
fix: copyDCQL drops DoctypeValue and TypeValues from MetaQuery

### DIFF
--- a/pkg/configuration/testdata/mdoc_template.yaml
+++ b/pkg/configuration/testdata/mdoc_template.yaml
@@ -1,0 +1,24 @@
+# mdoc template for testing mso_mdoc format support in DCQL
+
+templates:
+  - id: "mdoc_mdl"
+    name: "mDL via mdoc"
+    description: "Mobile driving licence using ISO mdoc"
+    version: "1.0"
+    oidc_scopes:
+      - "mdl"
+    dcql:
+      credentials:
+        - id: "mdl_credential"
+          format: "mso_mdoc"
+          meta:
+            doctype_value: "org.iso.18013.5.1.mDL"
+          claims:
+            - path: ["org.iso.18013.5.1", "family_name"]
+            - path: ["org.iso.18013.5.1", "given_name"]
+    claim_mappings:
+      family_name: "family_name"
+      given_name: "given_name"
+    enabled: true
+
+default_template: "mdoc_mdl"

--- a/pkg/configuration/testdata/w3c_vc_template.yaml
+++ b/pkg/configuration/testdata/w3c_vc_template.yaml
@@ -1,0 +1,25 @@
+# W3C VC Data Integrity template for testing type_values in DCQL
+
+templates:
+  - id: "w3c_vc_diploma"
+    name: "University Diploma (W3C VC)"
+    description: "University diploma using W3C VC Data Integrity"
+    version: "1.0"
+    oidc_scopes:
+      - "diploma"
+    dcql:
+      credentials:
+        - id: "diploma_credential"
+          format: "ldp_vc"
+          meta:
+            type_values:
+              - ["https://www.w3.org/2018/credentials#VerifiableCredential", "https://example.org/credentials#UniversityDiploma"]
+          claims:
+            - path: ["credentialSubject", "degree"]
+            - path: ["credentialSubject", "name"]
+    claim_mappings:
+      degree: "degree"
+      name: "name"
+    enabled: true
+
+default_template: "w3c_vc_diploma"

--- a/pkg/openid4vp/presentation_builder.go
+++ b/pkg/openid4vp/presentation_builder.go
@@ -154,13 +154,23 @@ func copyDCQL(src *DCQL) *DCQL {
 
 	// Copy credentials
 	for i, cred := range src.Credentials {
+		meta := MetaQuery{
+			DoctypeValue: cred.Meta.DoctypeValue,
+		}
+		if len(cred.Meta.VCTValues) > 0 {
+			meta.VCTValues = append([]string{}, cred.Meta.VCTValues...)
+		}
+		if len(cred.Meta.TypeValues) > 0 {
+			meta.TypeValues = make([][]string, len(cred.Meta.TypeValues))
+			for j, tv := range cred.Meta.TypeValues {
+				meta.TypeValues[j] = append([]string{}, tv...)
+			}
+		}
 		dst.Credentials[i] = CredentialQuery{
-			ID:       cred.ID,
-			Format:   cred.Format,
-			Multiple: cred.Multiple,
-			Meta: MetaQuery{
-				VCTValues: append([]string{}, cred.Meta.VCTValues...),
-			},
+			ID:                                cred.ID,
+			Format:                            cred.Format,
+			Multiple:                          cred.Multiple,
+			Meta:                              meta,
 			RequireCryptographicHolderBinding: cred.RequireCryptographicHolderBinding,
 		}
 

--- a/pkg/openid4vp/presentation_builder_test.go
+++ b/pkg/openid4vp/presentation_builder_test.go
@@ -398,46 +398,79 @@ func TestPresentationBuilder_ScopePriority(t *testing.T) {
 	}
 }
 
-// TestPresentationBuilder_MdocDoctypeValue verifies that copyDCQL preserves
-// DoctypeValue for mso_mdoc format templates (and TypeValues for W3C VC).
-// This is a regression test for the bug where copyDCQL only copied VCTValues,
-// producing an empty/invalid meta object for non-SD-JWT formats.
-func TestPresentationBuilder_MdocDoctypeValue(t *testing.T) {
-	ctx := t.Context()
-
-	config, err := configuration.LoadPresentationRequestsFromFile(ctx, "../configuration/testdata/mdoc_template.yaml")
-	if err != nil {
-		t.Fatalf("Failed to load mdoc test config: %v", err)
+// TestPresentationBuilder_CopyDCQLMetaQuery verifies that copyDCQL preserves
+// all MetaQuery fields (DoctypeValue, TypeValues) for non-SD-JWT formats.
+// This is a regression test for the bug where copyDCQL only copied VCTValues.
+func TestPresentationBuilder_CopyDCQLMetaQuery(t *testing.T) {
+	tests := []struct {
+		name           string
+		fixture        string
+		scopes         []string
+		expectedFormat string
+		checkMeta      func(t *testing.T, cred openid4vp.CredentialQuery)
+	}{
+		{
+			name:           "mso_mdoc preserves DoctypeValue",
+			fixture:        "../configuration/testdata/mdoc_template.yaml",
+			scopes:         []string{"openid", "mdl"},
+			expectedFormat: "mso_mdoc",
+			checkMeta: func(t *testing.T, cred openid4vp.CredentialQuery) {
+				if cred.Meta.DoctypeValue != "org.iso.18013.5.1.mDL" {
+					t.Errorf("Expected DoctypeValue 'org.iso.18013.5.1.mDL', got %q", cred.Meta.DoctypeValue)
+				}
+			},
+		},
+		{
+			name:           "ldp_vc preserves TypeValues",
+			fixture:        "../configuration/testdata/w3c_vc_template.yaml",
+			scopes:         []string{"openid", "diploma"},
+			expectedFormat: "ldp_vc",
+			checkMeta: func(t *testing.T, cred openid4vp.CredentialQuery) {
+				if len(cred.Meta.TypeValues) == 0 {
+					t.Fatal("Expected TypeValues to be preserved, got empty")
+				}
+				expected := []string{
+					"https://www.w3.org/2018/credentials#VerifiableCredential",
+					"https://example.org/credentials#UniversityDiploma",
+				}
+				if len(cred.Meta.TypeValues[0]) != len(expected) {
+					t.Fatalf("Expected %d types, got %d", len(expected), len(cred.Meta.TypeValues[0]))
+				}
+				for i, want := range expected {
+					if cred.Meta.TypeValues[0][i] != want {
+						t.Errorf("TypeValues[0][%d] = %q, want %q", i, cred.Meta.TypeValues[0][i], want)
+					}
+				}
+			},
+		},
 	}
 
-	builder := openid4vp.NewPresentationBuilder(config.GetEnabledTemplates())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			config, err := configuration.LoadPresentationRequestsFromFile(ctx, tt.fixture)
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
 
-	// Build DCQL from the mdl scope
-	dcql, err := builder.BuildDCQLQuery(ctx, []string{"openid", "mdl"})
-	if err != nil {
-		t.Fatalf("BuildDCQLQuery failed: %v", err)
-	}
+			builder := openid4vp.NewPresentationBuilder(config.GetEnabledTemplates())
+			dcql, err := builder.BuildDCQLQuery(ctx, tt.scopes)
+			if err != nil {
+				t.Fatalf("BuildDCQLQuery failed: %v", err)
+			}
+			if dcql == nil || len(dcql.Credentials) == 0 {
+				t.Fatal("Expected at least one credential in DCQL")
+			}
 
-	if dcql == nil {
-		t.Fatal("Expected DCQL but got nil")
-	}
+			cred := dcql.Credentials[0]
+			if cred.Format != tt.expectedFormat {
+				t.Errorf("Expected format %s, got %s", tt.expectedFormat, cred.Format)
+			}
+			tt.checkMeta(t, cred)
 
-	if len(dcql.Credentials) == 0 {
-		t.Fatal("Expected at least one credential")
-	}
-
-	cred := dcql.Credentials[0]
-
-	if cred.Format != "mso_mdoc" {
-		t.Errorf("Expected format mso_mdoc, got %s", cred.Format)
-	}
-
-	if cred.Meta.DoctypeValue != "org.iso.18013.5.1.mDL" {
-		t.Errorf("Expected DoctypeValue 'org.iso.18013.5.1.mDL', got %q", cred.Meta.DoctypeValue)
-	}
-
-	// Validate the copied DCQL passes format-specific validation
-	if err := openid4vp.ValidateCredentialQuery(cred); err != nil {
-		t.Errorf("Copied mdoc credential query failed validation: %v", err)
+			if err := openid4vp.ValidateCredentialQuery(cred); err != nil {
+				t.Errorf("Credential query failed validation: %v", err)
+			}
+		})
 	}
 }

--- a/pkg/openid4vp/presentation_builder_test.go
+++ b/pkg/openid4vp/presentation_builder_test.go
@@ -397,3 +397,47 @@ func TestPresentationBuilder_ScopePriority(t *testing.T) {
 			dcql.Credentials[0].ID)
 	}
 }
+
+// TestPresentationBuilder_MdocDoctypeValue verifies that copyDCQL preserves
+// DoctypeValue for mso_mdoc format templates (and TypeValues for W3C VC).
+// This is a regression test for the bug where copyDCQL only copied VCTValues,
+// producing an empty/invalid meta object for non-SD-JWT formats.
+func TestPresentationBuilder_MdocDoctypeValue(t *testing.T) {
+	ctx := t.Context()
+
+	config, err := configuration.LoadPresentationRequestsFromFile(ctx, "../configuration/testdata/mdoc_template.yaml")
+	if err != nil {
+		t.Fatalf("Failed to load mdoc test config: %v", err)
+	}
+
+	builder := openid4vp.NewPresentationBuilder(config.GetEnabledTemplates())
+
+	// Build DCQL from the mdl scope
+	dcql, err := builder.BuildDCQLQuery(ctx, []string{"openid", "mdl"})
+	if err != nil {
+		t.Fatalf("BuildDCQLQuery failed: %v", err)
+	}
+
+	if dcql == nil {
+		t.Fatal("Expected DCQL but got nil")
+	}
+
+	if len(dcql.Credentials) == 0 {
+		t.Fatal("Expected at least one credential")
+	}
+
+	cred := dcql.Credentials[0]
+
+	if cred.Format != "mso_mdoc" {
+		t.Errorf("Expected format mso_mdoc, got %s", cred.Format)
+	}
+
+	if cred.Meta.DoctypeValue != "org.iso.18013.5.1.mDL" {
+		t.Errorf("Expected DoctypeValue 'org.iso.18013.5.1.mDL', got %q", cred.Meta.DoctypeValue)
+	}
+
+	// Validate the copied DCQL passes format-specific validation
+	if err := openid4vp.ValidateCredentialQuery(cred); err != nil {
+		t.Errorf("Copied mdoc credential query failed validation: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #509

`copyDCQL` only copied `VCTValues` when deep-copying a DCQL query from a presentation request template. For `mso_mdoc` format templates that use `DoctypeValue` (and W3C VC templates that use `TypeValues`), the copy produced an empty `meta` object which fails validation.

## Changes

- **`pkg/openid4vp/presentation_builder.go`**: Copy all three `MetaQuery` fields (`VCTValues`, `TypeValues`, `DoctypeValue`) in `copyDCQL`
- **`pkg/openid4vp/presentation_builder_test.go`**: Add `TestPresentationBuilder_MdocDoctypeValue` regression test
- **`pkg/configuration/testdata/mdoc_template.yaml`**: Add `mso_mdoc` test fixture

## Type of change

- [x] Bug fix

## How to test

```bash
GOWORK=off go test ./pkg/openid4vp/ -run TestPresentationBuilder_MdocDoctypeValue -v
```

## Checklist

- [x] I self-reviewed my changes
- [x] I added/updated tests
- [x] I ran the relevant checks locally (lint/unit)
