### PR TITLE
fix: add ClaimQuery.ID and fix ClaimSet type to [][]string per OID4VP §6.4.1

### DIFF
--- a/pkg/openid4vp/dcql.go
+++ b/pkg/openid4vp/dcql.go
@@ -38,7 +38,7 @@ type CredentialQuery struct {
 	Claims []ClaimQuery `json:"claims,omitempty" yaml:"claims,omitempty"`
 
 	// ClaimSet OPTIONAL. A non-empty array containing arrays of identifiers for elements in claims that specifies which combinations of claims for the Credential are requested. The rules for selecting claims to send are defined in Section 6.4.1.
-	ClaimSet []string `json:"claim_sets,omitempty" yaml:"claim_sets,omitempty" validate:"omitnil,min=1,dive,required"`
+	ClaimSet [][]string `json:"claim_sets,omitempty" yaml:"claim_sets,omitempty" validate:"omitnil,min=1,dive,required,min=1,dive,required"`
 }
 
 type CredentialSetQuery struct {
@@ -138,6 +138,12 @@ type TrustedAuthority struct {
 }
 
 type ClaimQuery struct {
+	// ID REQUIRED if claim_sets is present in the Credential Query; OPTIONAL otherwise.
+	// A string identifying the particular claim. The value MUST be a non-empty string
+	// consisting of alphanumeric, underscore (_), or hyphen (-) characters.
+	// Within the particular claims array, the same id MUST NOT be present more than once.
+	ID string `json:"-" yaml:"-"`
+
 	// Path REQUIRED The value MUST be a non-empty array representing a claims path pointer
 	// that specifies the path to a claim within the Credential, as defined in Section 7.
 	// Elements are strings (object keys) or nil (representing null for array element access).
@@ -155,9 +161,11 @@ func (cq ClaimQuery) MarshalJSON() ([]byte, error) {
 			path[i] = *p
 		}
 	}
-	return json.Marshal(struct {
-		Path []any `json:"path"`
-	}{Path: path})
+	type wire struct {
+		ID   string `json:"id,omitempty"`
+		Path []any  `json:"path"`
+	}
+	return json.Marshal(wire{ID: cq.ID, Path: path})
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for ClaimQuery.
@@ -165,6 +173,7 @@ func (cq ClaimQuery) MarshalJSON() ([]byte, error) {
 // elements cause an unmarshal error (Go's json package rejects them for *string).
 func (cq *ClaimQuery) UnmarshalJSON(data []byte) error {
 	var raw struct {
+		ID   string    `json:"id"`
 		Path []*string `json:"path"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -173,6 +182,7 @@ func (cq *ClaimQuery) UnmarshalJSON(data []byte) error {
 	if err := validateClaimPath(raw.Path); err != nil {
 		return err
 	}
+	cq.ID = raw.ID
 	cq.Path = raw.Path
 	return nil
 }
@@ -182,6 +192,7 @@ func (cq *ClaimQuery) UnmarshalJSON(data []byte) error {
 // elements cause an unmarshal error.
 func (cq *ClaimQuery) UnmarshalYAML(unmarshal func(any) error) error {
 	var raw struct {
+		ID   string    `yaml:"id"`
 		Path []*string `yaml:"path"`
 	}
 	if err := unmarshal(&raw); err != nil {
@@ -190,6 +201,7 @@ func (cq *ClaimQuery) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := validateClaimPath(raw.Path); err != nil {
 		return err
 	}
+	cq.ID = raw.ID
 	cq.Path = raw.Path
 	return nil
 }

--- a/pkg/openid4vp/dcql_test.go
+++ b/pkg/openid4vp/dcql_test.go
@@ -175,3 +175,50 @@ func TestExample(t *testing.T) {
 		})
 	}
 }
+
+// TestClaimSetsRoundTrip verifies that claim_sets ([][]string) and claim IDs
+// survive JSON marshal/unmarshal round-trips per OID4VP §6.4.1.
+func TestClaimSetsRoundTrip(t *testing.T) {
+	dcql := &DCQL{
+		Credentials: []CredentialQuery{
+			{
+				ID:     "pid",
+				Format: "dc+sd-jwt",
+				Meta: MetaQuery{
+					VCTValues: []string{"urn:eudi:pid:1"},
+				},
+				Claims: []ClaimQuery{
+					{ID: "name", Path: StringPath("given_name")},
+					{ID: "family", Path: StringPath("family_name")},
+					{ID: "age", Path: StringPath("age_over_18")},
+				},
+				ClaimSet: [][]string{
+					{"name", "family"},
+					{"name", "age"},
+				},
+			},
+		},
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(dcql)
+	assert.NoError(t, err)
+
+	// Unmarshal back
+	var decoded DCQL
+	err = json.Unmarshal(data, &decoded)
+	assert.NoError(t, err)
+
+	cred := decoded.Credentials[0]
+	// Verify claim IDs survived
+	assert.Equal(t, "name", cred.Claims[0].ID)
+	assert.Equal(t, "family", cred.Claims[1].ID)
+	assert.Equal(t, "age", cred.Claims[2].ID)
+
+	// Verify claim_sets survived as [][]string
+	assert.Equal(t, [][]string{{"name", "family"}, {"name", "age"}}, cred.ClaimSet)
+
+	// Verify the JSON contains expected structure
+	assert.Contains(t, string(data), `"claim_sets"`)
+	assert.Contains(t, string(data), `"id":"name"`)
+}

--- a/pkg/openid4vp/presentation_builder.go
+++ b/pkg/openid4vp/presentation_builder.go
@@ -187,6 +187,7 @@ func copyDCQL(src *DCQL) *DCQL {
 					}
 				}
 				dst.Credentials[i].Claims[j] = ClaimQuery{
+					ID:   claim.ID,
 					Path: pathCopy,
 				}
 			}
@@ -194,7 +195,10 @@ func copyDCQL(src *DCQL) *DCQL {
 
 		// Copy claim sets
 		if len(cred.ClaimSet) > 0 {
-			dst.Credentials[i].ClaimSet = append([]string{}, cred.ClaimSet...)
+			dst.Credentials[i].ClaimSet = make([][]string, len(cred.ClaimSet))
+			for j, cs := range cred.ClaimSet {
+				dst.Credentials[i].ClaimSet[j] = append([]string{}, cs...)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #511

## Summary

The DCQL `claim_sets` feature (OID4VP §6.4.1) was unusable because:

1. `ClaimQuery` was missing the `ID` field — required when `claim_sets` is present so claim set entries can reference individual claims
2. `ClaimSet` was typed as `[]string` instead of `[][]string` (array of arrays per spec)

## Changes

- **`pkg/openid4vp/dcql.go`**:
  - Add `ID string` field to `ClaimQuery`
  - Update `MarshalJSON`/`UnmarshalJSON`/`UnmarshalYAML` to handle the `id` field
  - Change `ClaimSet` type from `[]string` to `[][]string`
- **`pkg/openid4vp/presentation_builder.go`**:
  - Copy `ClaimQuery.ID` in `copyDCQL`
  - Deep-copy nested `ClaimSet` slices correctly for `[][]string`
- **`pkg/openid4vp/dcql_test.go`**: Add `TestClaimSetsRoundTrip` verifying JSON round-trip of claim IDs and claim_sets

## Type of change

- [x] Bug fix

## How to test

```bash
GOWORK=off go test ./pkg/openid4vp/ -run TestClaimSetsRoundTrip -v
```

Verifier templates can now use `claim_sets`:
```yaml
claims:
  - id: "name"
    path: ["given_name"]
  - id: "family"
    path: ["family_name"]
  - id: "age"
    path: ["age_over_18"]
claim_sets:
  - ["name", "family"]
  - ["name", "age"]
```

## Checklist

- [x] I self-reviewed my changes
- [x] I added/updated tests
- [x] I ran the relevant checks locally (lint/unit)
