### PR TITLE
feat: support DID-based verifier identity (did:web)

### DIFF
--- a/internal/verifier/apiv1/handler_oidc.go
+++ b/internal/verifier/apiv1/handler_oidc.go
@@ -15,7 +15,6 @@ import (
 	"github.com/SUNET/vc/internal/verifier/db"
 	"github.com/SUNET/vc/pkg/cache"
 	"github.com/SUNET/vc/pkg/crypto"
-	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/jose"
 	"github.com/SUNET/vc/pkg/oauth2"
 
@@ -158,7 +157,12 @@ func (c *Client) Authorize(ctx context.Context, req *AuthorizeRequest) (*Authori
 	}
 
 	// Generate OpenID4VP authorization request
-	authzReqURL, authzParams, err := buildOpenID4VPAuthzRequest(c.cfg.Verifier.PublicURL, sessionID)
+	clientID, err := c.cfg.Verifier.VerifierClientID()
+	if err != nil {
+		c.log.Error(err, "Failed to determine verifier client_id")
+		return nil, ErrServerError
+	}
+	authzReqURL, authzParams, err := buildOpenID4VPAuthzRequest(c.cfg.Verifier.PublicURL, sessionID, clientID)
 	if err != nil {
 		c.log.Error(err, "Failed to build OpenID4VP authorization request")
 		return nil, ErrServerError
@@ -858,20 +862,20 @@ func (c *Client) GetQRCode(ctx context.Context, req *GetQRCodeRequest) (*GetQRCo
 			return nil, fmt.Errorf("failed to construct request object path: %w", err)
 		}
 
-		host, err := helpers.HostFromURL(c.cfg.Verifier.PublicURL)
+		qrClientID, err := c.cfg.Verifier.VerifierClientID()
 		if err != nil {
-			return nil, fmt.Errorf("failed to extract host from PublicURL: %w", err)
+			return nil, fmt.Errorf("failed to determine verifier client_id: %w", err)
 		}
 
 		q := url.Values{}
-		q.Set("client_id", fmt.Sprintf("x509_san_dns:%s", host))
+		q.Set("client_id", qrClientID)
 		q.Set("request_uri", requestObjectPath)
 		qrData = walletBaseURL + "?" + q.Encode()
 	} else {
 		// Standard flow: generate QR for openid4vp:// URI (native wallet)
-		host, err := helpers.HostFromURL(c.cfg.Verifier.PublicURL)
+		qrClientID, err := c.cfg.Verifier.VerifierClientID()
 		if err != nil {
-			return nil, fmt.Errorf("failed to extract host from PublicURL: %w", err)
+			return nil, fmt.Errorf("failed to determine verifier client_id: %w", err)
 		}
 
 		// Construct request_uri with path parameter (matching the OIDC
@@ -882,9 +886,8 @@ func (c *Client) GetQRCode(ctx context.Context, req *GetQRCodeRequest) (*GetQRCo
 			return nil, fmt.Errorf("failed to construct request object path: %w", err)
 		}
 
-		oidc4vpClientID := fmt.Sprintf("x509_san_dns:%s", host)
 		q := url.Values{}
-		q.Set("client_id", oidc4vpClientID)
+		q.Set("client_id", qrClientID)
 		q.Set("request_uri", requestObjectPath)
 		qrData = "openid4vp://cb?" + q.Encode()
 	}
@@ -1031,19 +1034,14 @@ func (c *Client) matchRedirectURI(registered []string, reqURI string) bool {
 // buildOpenID4VPAuthzRequest constructs an OpenID4VP authorization request URL
 // with a request_uri pointing to the request-object endpoint as a path parameter.
 // It returns the full authorization request URL and the query parameters used.
-func buildOpenID4VPAuthzRequest(publicURL, sessionID string) (string, url.Values, error) {
+func buildOpenID4VPAuthzRequest(publicURL, sessionID, clientID string) (string, url.Values, error) {
 	requestObjectPath, err := url.JoinPath(publicURL, "verification", "request-object", sessionID)
 	if err != nil {
 		return "", nil, fmt.Errorf("construct request object path: %w", err)
 	}
 
-	host, err := helpers.HostFromURL(publicURL)
-	if err != nil {
-		return "", nil, fmt.Errorf("extract host from PublicURL: %w", err)
-	}
-
 	q := url.Values{}
-	q.Set("client_id", fmt.Sprintf("x509_san_dns:%s", host))
+	q.Set("client_id", clientID)
 	q.Set("request_uri", requestObjectPath)
 	return "openid4vp://cb?" + q.Encode(), q, nil
 }

--- a/internal/verifier/apiv1/handler_oidc_test.go
+++ b/internal/verifier/apiv1/handler_oidc_test.go
@@ -2863,7 +2863,7 @@ func TestBuildOpenID4VPAuthzRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, _, err := buildOpenID4VPAuthzRequest(tt.publicURL, tt.sessionID)
+			result, _, err := buildOpenID4VPAuthzRequest(tt.publicURL, tt.sessionID, "x509_san_dns:verifier.example.com")
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/internal/verifier/apiv1/handler_openid4vp.go
+++ b/internal/verifier/apiv1/handler_openid4vp.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/SUNET/vc/pkg/crypto"
-	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/openid4vp"
 )
 
@@ -34,12 +33,11 @@ func (c *Client) CreateRequestObject(ctx context.Context, sessionID string, dcql
 		c.log.Error(err, "Failed to construct response URI")
 		return "", err
 	}
-	// Build x509_san_dns client_id: strip scheme to get the DNS name (+ optional port)
-	host, err := helpers.HostFromURL(c.cfg.Verifier.PublicURL)
+	// Determine client_id based on configured scheme (x509_san_dns or did)
+	clientID, err := c.cfg.Verifier.VerifierClientID()
 	if err != nil {
-		return "", fmt.Errorf("failed to extract host from PublicURL: %w", err)
+		return "", fmt.Errorf("failed to determine verifier client_id: %w", err)
 	}
-	clientID := fmt.Sprintf("x509_san_dns:%s", host)
 
 	requestObject := &openid4vp.RequestObject{
 		ISS:          c.cfg.Verifier.Outbound.OIDCProvider.Issuer,

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/SUNET/vc/pkg/cache"
-	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/openid4vp"
 
@@ -213,9 +212,9 @@ func (c *Client) UIInteraction(ctx context.Context, req *UIInteractionRequest) (
 	// them using the VCTM so wallets disclose nested content correctly.
 	c.augmentDCQLFromVCTM(req.DCQLQuery)
 
-	host, err := helpers.HostFromURL(c.cfg.Verifier.PublicURL)
+	uiClientID, err := c.cfg.Verifier.VerifierClientID()
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract host from PublicURL: %w", err)
+		return nil, fmt.Errorf("failed to determine verifier client_id: %w", err)
 	}
 
 	authorizationContext := &cache.AuthorizationContext{
@@ -226,7 +225,7 @@ func (c *Client) UIInteraction(ctx context.Context, req *UIInteractionRequest) (
 		WalletURI:           "",
 		Forfeited:           false,
 		State:               state,
-		ClientID:            fmt.Sprintf("x509_san_dns:%s", host),
+		ClientID:            uiClientID,
 		ExpiresAt:           0,
 		CodeChallenge:       "",
 		CodeChallengeMethod: "",
@@ -253,7 +252,7 @@ func (c *Client) UIInteraction(ctx context.Context, req *UIInteractionRequest) (
 	requestObject := &openid4vp.RequestObject{
 		ResponseURI:  responseURI,
 		AUD:          "https://self-issued.me/v2",
-		ISS:          host,
+		ISS:          uiClientID,
 		ClientID:     authorizationContext.ClientID,
 		ResponseType: "vp_token",
 		ResponseMode: "direct_post.jwt",

--- a/internal/verifier/httpserver/endpoints_did.go
+++ b/internal/verifier/httpserver/endpoints_did.go
@@ -73,8 +73,8 @@ func (s *Service) endpointDIDDocument(ctx context.Context, c *gin.Context) (any,
 
 	// Derive linked domains if PublicURL is set
 	if s.cfg.Verifier.PublicURL != "" {
-		u, _ := url.Parse(s.cfg.Verifier.PublicURL)
-		if u != nil {
+		u, parseErr := url.Parse(s.cfg.Verifier.PublicURL)
+		if parseErr == nil && u.Scheme != "" && u.Host != "" {
 			didDoc["alsoKnownAs"] = []string{u.Scheme + "://" + u.Host}
 		}
 	}

--- a/internal/verifier/httpserver/endpoints_did.go
+++ b/internal/verifier/httpserver/endpoints_did.go
@@ -1,0 +1,84 @@
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/SUNET/vc/pkg/pki"
+	"github.com/gin-gonic/gin"
+)
+
+// endpointDIDDocument serves the DID Document at /.well-known/did.json
+// per the did:web method specification (https://w3c-ccg.github.io/did-method-web/).
+func (s *Service) endpointDIDDocument(ctx context.Context, c *gin.Context) (any, error) {
+	if s.cfg.Verifier.ClientIDScheme != "did" || s.cfg.Verifier.DID == "" {
+		c.Status(http.StatusNotFound)
+		return nil, nil
+	}
+
+	signerConfig := pki.NewSignerConfig(s.cfg.Verifier.KeyConfig)
+	jwk, err := signerConfig.GetJWK()
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the DID Document
+	verificationMethodID := s.cfg.Verifier.DID + "#key-1"
+
+	// Use the JWK's JSON serialization for the actual key data
+	pubJWK := jwk.Public()
+	pubJWKBytes, err := pubJWK.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	// Parse back to get proper structure
+	var pubJWKParsed map[string]any
+	if err := json.Unmarshal(pubJWKBytes, &pubJWKParsed); err != nil {
+		return nil, err
+	}
+	// Remove non-JWK fields that jose adds (certificates are separate from DID)
+	delete(pubJWKParsed, "x5c")
+	delete(pubJWKParsed, "x5t")
+	delete(pubJWKParsed, "x5t#S256")
+	delete(pubJWKParsed, "x5u")
+
+	serviceEndpoint := s.cfg.Verifier.PublicURL
+
+	didDoc := map[string]any{
+		"@context": []string{
+			"https://www.w3.org/ns/did/v1",
+			"https://w3id.org/security/suites/jws-2020/v1",
+		},
+		"id": s.cfg.Verifier.DID,
+		"verificationMethod": []map[string]any{
+			{
+				"id":           verificationMethodID,
+				"type":         "JsonWebKey2020",
+				"controller":   s.cfg.Verifier.DID,
+				"publicKeyJwk": pubJWKParsed,
+			},
+		},
+		"authentication":  []string{verificationMethodID},
+		"assertionMethod": []string{verificationMethodID},
+		"service": []map[string]any{
+			{
+				"id":              s.cfg.Verifier.DID + "#verifier",
+				"type":            "OpenID4VP",
+				"serviceEndpoint": serviceEndpoint,
+			},
+		},
+	}
+
+	// Derive linked domains if PublicURL is set
+	if s.cfg.Verifier.PublicURL != "" {
+		u, _ := url.Parse(s.cfg.Verifier.PublicURL)
+		if u != nil {
+			didDoc["alsoKnownAs"] = []string{u.Scheme + "://" + u.Host}
+		}
+	}
+
+	c.JSON(http.StatusOK, didDoc)
+	return nil, nil
+}

--- a/internal/verifier/httpserver/endpoints_did.go
+++ b/internal/verifier/httpserver/endpoints_did.go
@@ -15,7 +15,7 @@ import (
 // per the did:web method specification (https://w3c-ccg.github.io/did-method-web/).
 func (s *Service) endpointDIDDocument(ctx context.Context, c *gin.Context) (any, error) {
 	if s.cfg.Verifier.ClientIDScheme != "did" || s.cfg.Verifier.DID == "" {
-		c.Status(http.StatusNotFound)
+		c.AbortWithStatus(http.StatusNotFound)
 		return nil, nil
 	}
 
@@ -86,6 +86,5 @@ func (s *Service) endpointDIDDocument(ctx context.Context, c *gin.Context) (any,
 		}
 	}
 
-	c.JSON(http.StatusOK, didDoc)
-	return nil, nil
+	return didDoc, nil
 }

--- a/internal/verifier/httpserver/endpoints_did.go
+++ b/internal/verifier/httpserver/endpoints_did.go
@@ -3,6 +3,7 @@ package httpserver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -24,8 +25,14 @@ func (s *Service) endpointDIDDocument(ctx context.Context, c *gin.Context) (any,
 		return nil, err
 	}
 
-	// Build the DID Document
-	verificationMethodID := s.cfg.Verifier.DID + "#key-1"
+	// Build the DID Document.
+	// The verification method ID uses the JWK's kid to ensure consistency
+	// with the kid in signed JWTs (derived by determineKeyID in pki package).
+	kid := jwk.KeyID
+	if kid == "" {
+		return nil, fmt.Errorf("JWK has no key ID; cannot construct DID Document verification method")
+	}
+	verificationMethodID := s.cfg.Verifier.DID + "#" + kid
 
 	// Use the JWK's JSON serialization for the actual key data
 	pubJWK := jwk.Public()

--- a/internal/verifier/httpserver/endpoints_did_test.go
+++ b/internal/verifier/httpserver/endpoints_did_test.go
@@ -1,0 +1,148 @@
+package httpserver
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SUNET/vc/pkg/httphelpers"
+	"github.com/SUNET/vc/pkg/logger"
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/pki"
+	"github.com/SUNET/vc/pkg/trace"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestSigningKey generates a fresh EC private key and writes it as a PEM
+// file under t.TempDir(), returning the file path. Mirrors the pattern used
+// in pkg/pki/signer_config_test.go.
+func writeTestSigningKey(t *testing.T) string {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	keyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	require.NoError(t, err)
+
+	keyPath := filepath.Join(t.TempDir(), "test-key.pem")
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+
+	return keyPath
+}
+
+// testSetupDID builds a minimal gin engine that registers only the DID
+// document endpoint, matching how it's wired in service.go.
+func testSetupDID(t *testing.T, verifierCfg *model.Verifier) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	log, err := logger.New("test", "", false)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tracer, err := trace.NewForTesting(ctx, "test", log)
+	require.NoError(t, err)
+
+	cfg := &model.Cfg{
+		Common:   &model.Common{},
+		Verifier: verifierCfg,
+	}
+
+	helpers, err := httphelpers.New(ctx, tracer, cfg, log)
+	require.NoError(t, err)
+
+	s := &Service{
+		cfg:         cfg,
+		log:         log.New("httpserver"),
+		tracer:      tracer,
+		httpHelpers: helpers,
+	}
+
+	engine := gin.New()
+	rg := engine.Group("/")
+	helpers.Server.RegEndpoint(ctx, rg, http.MethodGet, ".well-known/did.json", http.StatusOK, s.endpointDIDDocument)
+
+	return engine
+}
+
+// TestEndpointDIDDocument_Disabled verifies that when DID mode is not enabled
+// (ClientIDScheme != "did" or DID unset), the endpoint responds with a real
+// 404 that is not overwritten by RegEndpoint's default-status fallback.
+func TestEndpointDIDDocument_Disabled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *model.Verifier
+	}{
+		{
+			name: "client_id_scheme not did",
+			cfg: &model.Verifier{
+				ClientIDScheme: "x509_san_dns",
+				DID:            "",
+			},
+		},
+		{
+			name: "did scheme but empty DID",
+			cfg: &model.Verifier{
+				ClientIDScheme: "did",
+				DID:            "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := testSetupDID(t, tt.cfg)
+
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/did.json", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+			assert.Empty(t, w.Body.Bytes())
+		})
+	}
+}
+
+// TestEndpointDIDDocument_Enabled verifies that when DID mode is enabled the
+// endpoint renders the DID Document via RegEndpoint (i.e. the handler returns
+// the document instead of writing the response itself), with the expected
+// status code and JSON content-type.
+func TestEndpointDIDDocument_Enabled(t *testing.T) {
+	keyPath := writeTestSigningKey(t)
+
+	verifierCfg := &model.Verifier{
+		ClientIDScheme: "did",
+		DID:            "did:web:verifier.example.com",
+		PublicURL:      "https://verifier.example.com",
+		KeyConfig: &pki.KeyConfig{
+			PrivateKeyPath: keyPath,
+		},
+	}
+
+	engine := testSetupDID(t, verifierCfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/did.json", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	assert.Contains(t, w.Body.String(), `"id":"did:web:verifier.example.com"`)
+	assert.Contains(t, w.Body.String(), "verificationMethod")
+	assert.Contains(t, w.Body.String(), "alsoKnownAs")
+}

--- a/internal/verifier/httpserver/service.go
+++ b/internal/verifier/httpserver/service.go
@@ -142,6 +142,9 @@ func New(ctx context.Context, cfg *model.Cfg, apiv1 *apiv1.Client, notify *notif
 	// JWKS
 	s.httpHelpers.Server.RegEndpoint(ctx, rgRoot, http.MethodGet, "jwks", http.StatusOK, s.endpointJWKS)
 
+	// DID Document (did:web)
+	s.httpHelpers.Server.RegEndpoint(ctx, rgRoot, http.MethodGet, ".well-known/did.json", http.StatusOK, s.endpointDIDDocument)
+
 	// UserInfo endpoint
 	s.httpHelpers.Server.RegEndpoint(ctx, rgRoot, http.MethodGet, "userinfo", http.StatusOK, s.endpointUserInfo)
 

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -581,12 +581,18 @@ type Verifier struct {
 func (v *Verifier) VerifierClientID() (string, error) {
 	switch v.ClientIDScheme {
 	case "did":
+		if v.DID == "" {
+			return "", fmt.Errorf("client_id_scheme is \"did\" but no DID is configured")
+		}
 		return v.DID, nil
 	default:
 		// x509_san_dns (default)
 		u, err := url.Parse(v.PublicURL)
 		if err != nil {
 			return "", fmt.Errorf("failed to parse PublicURL: %w", err)
+		}
+		if u.Host == "" {
+			return "", fmt.Errorf("PublicURL %q has no host component", v.PublicURL)
 		}
 		return "x509_san_dns:" + u.Host, nil
 	}

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -545,6 +545,13 @@ type Verifier struct {
 	PublicURL string `yaml:"public_url" validate:"required,httpurl" doc_example:"\"https://verifier.sunet.se\""`
 	// KeyConfig is the signing key configuration
 	KeyConfig *pki.KeyConfig `yaml:"key_config" validate:"required"`
+	// ClientIDScheme determines how the verifier identifies itself to wallets.
+	// Supported values: "x509_san_dns" (default), "did".
+	// When "did", the DID field must be set and /.well-known/did.json is served.
+	ClientIDScheme string `yaml:"client_id_scheme,omitempty" default:"x509_san_dns" validate:"omitempty,oneof=x509_san_dns did"`
+	// DID is the verifier's DID identity (e.g., "did:web:verifier.example.com").
+	// Required when ClientIDScheme is "did".
+	DID string `yaml:"did,omitempty" validate:"required_if=ClientIDScheme did"`
 	// PreferredVPFormats specifies informational VP formats and algorithms supported by wallets
 	PreferredVPFormats *openid4vp.VPFormatsSupported `yaml:"preferred_vp_formats,omitempty"`
 	// SupportedWallets holds supported wallet configurations
@@ -566,6 +573,23 @@ type Verifier struct {
 	// Each preset maps credential_metadata scopes to optional claim overrides.
 	// A nil scope value requests all VCTM claims; use claims/exclude_claims to narrow.
 	Presets map[string]VerificationPreset `yaml:"presets,omitempty" validate:"omitempty,dive,dive" doc_key:"preset label" doc_value_key:"scope" doc_example:"\"PID\":{\"pid\":null},\"PID + EHIC\":{\"pid\":null,\"ehic\":null}"`
+}
+
+// VerifierClientID returns the client_id value the verifier uses in OID4VP requests.
+// For "x509_san_dns" (default): returns "x509_san_dns:{hostname}".
+// For "did": returns the configured DID value directly.
+func (v *Verifier) VerifierClientID() (string, error) {
+	switch v.ClientIDScheme {
+	case "did":
+		return v.DID, nil
+	default:
+		// x509_san_dns (default)
+		u, err := url.Parse(v.PublicURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse PublicURL: %w", err)
+		}
+		return "x509_san_dns:" + u.Host, nil
+	}
 }
 
 // TrustConfig holds configuration for key resolution and trust evaluation via go-trust.


### PR DESCRIPTION
## Summary

Add configurable `client_id_scheme` for the verifier service. Previously, the verifier always used `x509_san_dns:{hostname}` as its client_id in OID4VP requests. Now it can optionally identify as a DID.

## Changes

- Add `Verifier.ClientIDScheme` ("x509_san_dns" | "did") and `Verifier.DID` config fields
- Add `Verifier.VerifierClientID()` helper method
- Replace all hard-coded x509_san_dns construction with VerifierClientID()
- Add `/.well-known/did.json` endpoint serving a DID Document derived from the verifier's signing key (JsonWebKey2020)
- DID Document includes authentication, assertionMethod, and OpenID4VP service endpoint

## Configuration Example

```yaml
verifier:
  client_id_scheme: "did"
  did: "did:web:verifier.example.com"
```

When `client_id_scheme` is "x509_san_dns" (default), behavior is unchanged.

## Context

Phase 3b of the client-id-strategy plan — enables SUNET/vc verifier to use DID-based identity for wallets that resolve trust via DID Documents.