### PR TITLE
fix(verifier): use credential format from metadata for custom presentation requests

### DIFF
--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -19,6 +19,7 @@ import (
 
 // UICredentialInfo is a sanitized view of a credential for the UI.
 type UICredentialInfo struct {
+	Format     string                          `json:"format"`
 	VCT        string                          `json:"vct"`
 	Attributes map[string]map[string][]*string `json:"attributes"`
 }
@@ -62,6 +63,7 @@ func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
 
 	for scope, constructor := range c.cfg.Common.CredentialMetadata {
 		info := &UICredentialInfo{
+			Format:     constructor.Format,
 			Attributes: constructor.GetAttributes(),
 		}
 		if v := constructor.GetVCTURL(); v != "" {

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -93,8 +93,11 @@ func TestUIMetadata(t *testing.T) {
 				assert.Len(t, reply.Credentials, tt.expectCredentials)
 				for scope, cred := range reply.Credentials {
 					srcCred := tt.credentials[scope]
-					if srcCred != nil && srcCred.VCTM != nil {
-						assert.Equal(t, srcCred.VCTM.VCT, cred.VCT, "VCT should be populated from VCTM")
+					if srcCred != nil {
+						assert.Equal(t, srcCred.Format, cred.Format, "Format should be populated from credential metadata")
+						if srcCred.VCTM != nil {
+							assert.Equal(t, srcCred.VCTM.VCT, cred.VCT, "VCT should be populated from VCTM")
+						}
 					}
 				}
 			}
@@ -289,6 +292,40 @@ func TestUIMetadataPresetFormatFromMetadata(t *testing.T) {
 	require.NotNil(t, preset)
 	require.Len(t, preset.Credentials, 1)
 	assert.Equal(t, openid4vp.FormatSDJWTVC, preset.Credentials[0].Format)
+}
+
+// TestUIMetadataCredentialFormatFromMetadata verifies that each credential
+// advertised to the UI carries the format from credential_metadata, so custom
+// presentation requests can use the correct DCQL format (e.g. mso_mdoc).
+func TestUIMetadataCredentialFormatFromMetadata(t *testing.T) {
+	ctx := t.Context()
+
+	cfg := &model.Cfg{
+		Common: &model.Common{
+			CredentialMetadata: map[string]*model.CredentialMetadata{
+				"pid": {
+					Format: openid4vp.FormatSDJWTVC,
+					VCTM:   &sdjwtvc.VCTM{VCT: "urn:eudi:pid:1"},
+				},
+				"mdl": {
+					Format: openid4vp.FormatMsoMdoc,
+					VCTM:   &sdjwtvc.VCTM{VCT: "org.iso.18013.5.1.mDL"},
+				},
+			},
+		},
+		Verifier: &model.Verifier{},
+	}
+
+	client, _ := CreateTestClientWithMock(cfg)
+	client.cfg = cfg
+
+	reply, err := client.UIMetadata(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, reply)
+
+	require.Len(t, reply.Credentials, 2)
+	assert.Equal(t, openid4vp.FormatSDJWTVC, reply.Credentials["pid"].Format)
+	assert.Equal(t, openid4vp.FormatMsoMdoc, reply.Credentials["mdl"].Format)
 }
 
 // TestAugmentDCQLFromVCTM_ArraySelectiveDisclosure verifies that augmentDCQLFromVCTM

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -3,6 +3,7 @@ import * as v from "valibot";
 
 /** @typedef {v.InferOutput<typeof credentialAttributesSchema>} CredentialAttributes */
 const credentialAttributesSchema = v.object({
+    format: v.string(),
     vct: v.string(),
     attributes: v.record(
         v.string(),
@@ -201,7 +202,7 @@ Alpine.data("app", () => ({
     /** @type {Record<string, string> | null} */
     walletInstances: null,
 
-     /** @type {{ id: string; vct: string; claims: Record<string, (string|null)[]>; claimTree: ClaimNode[]; } | null} */
+     /** @type {{ id: string; format: string; vct: string; claims: Record<string, (string|null)[]>; claimTree: ClaimNode[]; } | null} */
     credentialAttributes: null,
 
     /** 
@@ -336,6 +337,7 @@ Alpine.data("app", () => ({
 
         this.credentialAttributes = {
             id: credential,
+            format: chosenCredential.format,
             vct: chosenCredential.vct,
             claims,
             claimTree: buildClaimTree(claims),
@@ -409,7 +411,7 @@ Alpine.data("app", () => ({
         /** @satisfies {DCQLQueryCredential} */
         const credential = {
             id: this.credentialAttributes.id,
-            format: "dc+sd-jwt",
+            format: this.credentialAttributes.format,
             meta: {
                 vct_values: [this.credentialAttributes.vct]
             },


### PR DESCRIPTION
Custom presentation requests in the verifier UI always hard-coded the DCQL credential format to "dc+sd-jwt". This broke mDoc credentials (e.g. `org.iso.18013.5.1.mDL`), which must use `mso_mdoc`.

- Include `Format` in `UICredentialInfo` returned by `/ui/metadata`.
- Propagate the format through the UI credential selection state.
- Build the custom DCQL credential using the selected credential's actual format instead of the hard-coded default.

Fixes #521