### PR TITLE
fix(openid4vci): allow clock skew when validating proof JWT iat

### DIFF
--- a/pkg/openid4vci/proof_jwt.go
+++ b/pkg/openid4vci/proof_jwt.go
@@ -15,6 +15,12 @@ import (
 	jwtv5 "github.com/golang-jwt/jwt/v5"
 )
 
+// proofIatClockSkew is the tolerance applied when checking that a proof JWT's
+// iat isn't in the future. Without it, any wallet clock even fractionally
+// ahead of this server's (routine NTP jitter, not misconfiguration) fails
+// every credential request outright.
+const proofIatClockSkew = 30 * time.Second
+
 // ProofJWTToken represents a JWT proof token as defined in OpenID4VCI 1.0 Appendix F.1
 // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-jwt-proof-type
 type ProofJWTToken string
@@ -283,12 +289,14 @@ func (p ProofJWTToken) Verify(publicKey crypto.PublicKey, opts *VerifyProofOptio
 			}
 		}
 
-		// iat: validate not in the future
+		// iat: validate not in the future, allowing for clock skew between the
+		// wallet and this server (matches pkg/oauth2/client_assertion_verifier.go's
+		// clockSkew tolerance for the same kind of client-supplied iat check).
 		t, err := claims.GetIssuedAt()
 		if err != nil {
 			return nil, &Error{Err: ErrInvalidCredentialRequest, ErrorDescription: "failed to parse iat claim"}
 		}
-		if t.After(time.Now()) {
+		if t.After(time.Now().Add(proofIatClockSkew)) {
 			return nil, &Error{Err: ErrInvalidCredentialRequest, ErrorDescription: "iat claim value is in the future"}
 		}
 

--- a/pkg/openid4vci/verify_proof_test.go
+++ b/pkg/openid4vci/verify_proof_test.go
@@ -62,7 +62,10 @@ func createJWTProofWithIat(t *testing.T, privateKey *ecdsa.PrivateKey, aud strin
 	token := jwtv5.NewWithClaims(jwtv5.SigningMethodES256, claims)
 	token.Header["typ"] = "openid4vci-proof+jwt"
 	token.Header["jwk"] = map[string]any{
-		"kty": "EC", "crv": "P-256", "x": "test-x", "y": "test-y",
+		"kty": "EC",
+		"crv": "P-256",
+		"x":   "test-x",
+		"y":   "test-y",
 	}
 	signedToken, err := token.SignedString(privateKey)
 	require.NoError(t, err)

--- a/pkg/openid4vci/verify_proof_test.go
+++ b/pkg/openid4vci/verify_proof_test.go
@@ -56,7 +56,7 @@ func createJWTProofWithIat(t *testing.T, privateKey *ecdsa.PrivateKey, aud strin
 
 	claims := jwtv5.MapClaims{
 		"aud":   aud,
-		"iat":   iat.Unix(),
+		"iat":   jwtv5.NewNumericDate(iat),
 		"nonce": "test-nonce",
 	}
 	token := jwtv5.NewWithClaims(jwtv5.SigningMethodES256, claims)
@@ -288,7 +288,7 @@ func TestVerifyJWTProof(t *testing.T) {
 		// A wallet's clock running a few seconds ahead of the server (routine
 		// NTP jitter between two independent systems) must not fail every
 		// credential request outright - see proofIatClockSkew.
-		jwtStr := createJWTProofWithIat(t, privateKey, "https://issuer.example.com", time.Now().Add(10*time.Second))
+		jwtStr := createJWTProofWithIat(t, privateKey, "https://issuer.example.com", time.Now().Add(proofIatClockSkew/3))
 		jwt := ProofJWTToken(jwtStr)
 		opts := &VerifyProofOptions{Audience: "https://issuer.example.com", CNonce: "test-nonce"}
 		err := jwt.Verify(&privateKey.PublicKey, opts)
@@ -296,7 +296,7 @@ func TestVerifyJWTProof(t *testing.T) {
 	})
 
 	t.Run("iat far in the future is rejected", func(t *testing.T) {
-		jwtStr := createJWTProofWithIat(t, privateKey, "https://issuer.example.com", time.Now().Add(5*time.Minute))
+		jwtStr := createJWTProofWithIat(t, privateKey, "https://issuer.example.com", time.Now().Add(proofIatClockSkew+5*time.Minute))
 		jwt := ProofJWTToken(jwtStr)
 		opts := &VerifyProofOptions{Audience: "https://issuer.example.com", CNonce: "test-nonce"}
 		err := jwt.Verify(&privateKey.PublicKey, opts)

--- a/pkg/openid4vci/verify_proof_test.go
+++ b/pkg/openid4vci/verify_proof_test.go
@@ -50,6 +50,25 @@ func createValidJWTProof(t *testing.T, privateKey *ecdsa.PrivateKey, aud string)
 	return signedToken
 }
 
+// createJWTProofWithIat creates a JWT proof with an explicit iat, to test clock-skew tolerance.
+func createJWTProofWithIat(t *testing.T, privateKey *ecdsa.PrivateKey, aud string, iat time.Time) string {
+	t.Helper()
+
+	claims := jwtv5.MapClaims{
+		"aud":   aud,
+		"iat":   iat.Unix(),
+		"nonce": "test-nonce",
+	}
+	token := jwtv5.NewWithClaims(jwtv5.SigningMethodES256, claims)
+	token.Header["typ"] = "openid4vci-proof+jwt"
+	token.Header["jwk"] = map[string]any{
+		"kty": "EC", "crv": "P-256", "x": "test-x", "y": "test-y",
+	}
+	signedToken, err := token.SignedString(privateKey)
+	require.NoError(t, err)
+	return signedToken
+}
+
 func TestProofTypes(t *testing.T) {
 	tts := []struct {
 		name   string
@@ -260,6 +279,26 @@ func TestVerifyJWTProof(t *testing.T) {
 		err := jwt.Verify(&privateKey.PublicKey, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid_credential_request")
+	})
+
+	t.Run("iat slightly ahead of server clock is tolerated", func(t *testing.T) {
+		// A wallet's clock running a few seconds ahead of the server (routine
+		// NTP jitter between two independent systems) must not fail every
+		// credential request outright - see proofIatClockSkew.
+		jwtStr := createJWTProofWithIat(t, privateKey, "https://issuer.example.com", time.Now().Add(10*time.Second))
+		jwt := ProofJWTToken(jwtStr)
+		opts := &VerifyProofOptions{Audience: "https://issuer.example.com", CNonce: "test-nonce"}
+		err := jwt.Verify(&privateKey.PublicKey, opts)
+		assert.NoError(t, err)
+	})
+
+	t.Run("iat far in the future is rejected", func(t *testing.T) {
+		jwtStr := createJWTProofWithIat(t, privateKey, "https://issuer.example.com", time.Now().Add(5*time.Minute))
+		jwt := ProofJWTToken(jwtStr)
+		opts := &VerifyProofOptions{Audience: "https://issuer.example.com", CNonce: "test-nonce"}
+		err := jwt.Verify(&privateKey.PublicKey, opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "iat claim value is in the future")
 	})
 
 	t.Run("nonce validation", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `VerifyProof` rejected any credential request proof JWT whose `iat` was even a fraction of a second ahead of the server's own clock (`t.After(time.Now())`, zero tolerance).
- Two independent, correctly NTP-synced systems routinely differ by a second or two — this made issuance fail intermittently for legitimate wallets. Reproduced live end-to-end against a real wallet whose clock was within ~2 seconds of the server's.
- Adds a 30-second leeway, matching the identical tolerance already used for client_assertion `iat` validation in `pkg/oauth2/client_assertion_verifier.go`.

## Test plan
- [x] `go test ./pkg/openid4vci/...` passes, including two new cases: `iat slightly ahead of server clock is tolerated` and `iat far in the future is rejected`
- [x] `go build ./...` passes
- [x] Verified live against a deployed apigw instance that the same failure mode (`invalid_credential_request: iat claim value is in the future`) reproduces without this fix and resolves with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)