### PR TITLE
fix(mdoc): correct COSE_Sign1 and MSO structural bugs

### DIFF
--- a/pkg/mdoc/cose.go
+++ b/pkg/mdoc/cose.go
@@ -586,6 +586,13 @@ func Mac0(
 	algorithm int64,
 	externalAAD []byte,
 ) (*COSEMac0, error) {
+	// Must match Sign1's own nil-vs-empty normalization - see its doc
+	// comment. MAC_structure's external_aad element has the same h'' vs.
+	// CBOR-null requirement as Sig_structure's.
+	if externalAAD == nil {
+		externalAAD = []byte{}
+	}
+
 	headers := map[int64]any{
 		HeaderAlgorithm: algorithm,
 	}
@@ -653,6 +660,11 @@ func computeMAC(data, key []byte, algorithm int64) ([]byte, error) {
 
 // VerifyCOSEMac0 verifies a COSE_Mac0 message.
 func VerifyCOSEMac0(mac0 *COSEMac0, key []byte, externalAAD []byte) error {
+	// Must match Mac0's own nil-vs-empty normalization - see its comment.
+	if externalAAD == nil {
+		externalAAD = []byte{}
+	}
+
 	var headers map[int64]any
 	if err := cbor.Unmarshal(mac0.Protected, &headers); err != nil {
 		return fmt.Errorf("failed to decode protected headers: %w", err)

--- a/pkg/mdoc/cose.go
+++ b/pkg/mdoc/cose.go
@@ -275,6 +275,18 @@ func NewCOSEHeaders() *COSEHeaders {
 }
 
 // Sign creates a COSE_Sign1 signature.
+//
+// x5chain (when present) goes in the UNPROTECTED header, not protected - per
+// RFC 9360 and the ISO 18013-5 mdoc convention followed by real-world
+// verifiers (e.g. Google's isomdoc), the protected header for an mdoc
+// issuerAuth/deviceAuth COSE_Sign1 contains only the algorithm (label 1);
+// the certificate chain isn't itself integrity-critical (trust comes from
+// the signature verifying against the chain's leaf key, not from the
+// chain's placement) and strict verifiers reject a protected header with
+// any additional element. Putting it in protected was a real, confirmed bug
+// (caught by Google's public https://digital-credentials.dev/ demo, which
+// rejected our issued mdocs with "issuerAuth COSE_Sign1 protected contains
+// too many elements").
 func Sign1(
 	payload []byte,
 	signer crypto.Signer,
@@ -282,12 +294,22 @@ func Sign1(
 	x5chain [][]byte,
 	externalAAD []byte,
 ) (*COSESign1, error) {
+	// A nil Go []byte and an empty (len-0, non-nil) one both mean "no AAD",
+	// but cbor.Marshal encodes them differently - nil as CBOR null (0xf6),
+	// empty as an empty byte string (0x40, i.e. h''). Sig_structure's
+	// external_aad element MUST be h'' per RFC 8152/9052 - a verifier
+	// reconstructing it as an empty byte string (as every real one does,
+	// including Google's isomdoc, which is what caught this) computes
+	// different bytes-to-be-signed than what a nil-produced signature was
+	// actually computed over, so the signature fails to verify even though
+	// nothing else about it is wrong. Normalizing here means no caller has
+	// to remember this footgun.
+	if externalAAD == nil {
+		externalAAD = []byte{}
+	}
+
 	headers := NewCOSEHeaders()
 	headers.Protected[HeaderAlgorithm] = algorithm
-
-	if len(x5chain) > 0 {
-		headers.Protected[HeaderX5Chain] = x5chain
-	}
 
 	protectedBytes, err := cbor.Marshal(headers.Protected)
 	if err != nil {
@@ -313,9 +335,14 @@ func Sign1(
 		return nil, fmt.Errorf("signing failed: %w", err)
 	}
 
+	unprotected := make(map[any]any)
+	if len(x5chain) > 0 {
+		unprotected[HeaderX5Chain] = x5chain
+	}
+
 	sign1 := &COSESign1{
 		Protected:   protectedBytes,
-		Unprotected: make(map[any]any),
+		Unprotected: unprotected,
 		Payload:     payload,
 		Signature:   signature,
 	}
@@ -409,6 +436,11 @@ func parseASN1Signature(data []byte) (*big.Int, *big.Int, error) {
 
 // Verify1 verifies a COSE_Sign1 signature.
 func Verify1(sign1 *COSESign1, payload []byte, pubKey crypto.PublicKey, externalAAD []byte) error {
+	// Must match Sign1's own nil-vs-empty normalization - see its doc comment.
+	if externalAAD == nil {
+		externalAAD = []byte{}
+	}
+
 	var headers map[int64]any
 	if err := cbor.Unmarshal(sign1.Protected, &headers); err != nil {
 		return fmt.Errorf("failed to decode protected headers: %w", err)
@@ -670,20 +702,49 @@ func VerifyCOSEMac0(mac0 *COSEMac0, key []byte, externalAAD []byte) error {
 	return nil
 }
 
+// lookupUnprotectedHeader looks up a COSE header label in an already-decoded
+// unprotected-header map. cbor.Unmarshal into an `any`-typed map decodes a
+// CBOR positive integer key as uint64 (not int64), so a plain `m[label]`
+// lookup with an int64 label constant would silently never match - this
+// checks both representations (plus plain int, for maps built directly in
+// Go code rather than decoded from CBOR).
+func lookupUnprotectedHeader(m map[any]any, label int64) (any, bool) {
+	if v, ok := m[label]; ok {
+		return v, true
+	}
+	if v, ok := m[uint64(label)]; ok {
+		return v, true
+	}
+	if v, ok := m[int(label)]; ok {
+		return v, true
+	}
+	return nil, false
+}
+
 // GetCertificateChainFromSign1 extracts the x5chain from a COSE_Sign1.
 // If ext is provided, certificates are parsed using extension-aware parsing
 // (e.g. to support brainpool curves).
+//
+// Checks the unprotected header first (the correct location per RFC 9360 -
+// see Sign1's doc comment) and falls back to protected for compatibility
+// with mdocs issued before that fix.
 func GetCertificateChainFromSign1(sign1 *COSESign1, ext ...*cryptoutil.Extensions) ([]*x509.Certificate, error) {
-	var headers map[int64]any
-	if err := cbor.Unmarshal(sign1.Protected, &headers); err != nil {
-		return nil, fmt.Errorf("failed to decode protected headers: %w", err)
+	x5chainRaw, ok := lookupUnprotectedHeader(sign1.Unprotected, HeaderX5Chain)
+	if !ok {
+		x5chainRaw, ok = lookupUnprotectedHeader(sign1.Unprotected, HeaderX5ChainAlt)
 	}
 
-	x5chainRaw, ok := headers[HeaderX5Chain]
 	if !ok {
-		x5chainRaw, ok = headers[HeaderX5ChainAlt]
+		var headers map[int64]any
+		if err := cbor.Unmarshal(sign1.Protected, &headers); err != nil {
+			return nil, fmt.Errorf("failed to decode protected headers: %w", err)
+		}
+		x5chainRaw, ok = headers[HeaderX5Chain]
 		if !ok {
-			return nil, fmt.Errorf("no x5chain in headers")
+			x5chainRaw, ok = headers[HeaderX5ChainAlt]
+			if !ok {
+				return nil, fmt.Errorf("no x5chain in headers")
+			}
 		}
 	}
 
@@ -692,8 +753,12 @@ func GetCertificateChainFromSign1(sign1 *COSESign1, ext ...*cryptoutil.Extension
 	case []byte:
 		// Single certificate
 		certBytes = [][]byte{v}
+	case [][]byte:
+		// Array of certificates, built directly in Go (not yet round-tripped
+		// through CBOR encode/decode - see Sign1).
+		certBytes = v
 	case []any:
-		// Array of certificates
+		// Array of certificates, as decoded generically from CBOR.
 		for _, c := range v {
 			b, ok := c.([]byte)
 			if !ok {

--- a/pkg/mdoc/device_auth.go
+++ b/pkg/mdoc/device_auth.go
@@ -352,11 +352,19 @@ func ExtractDeviceKeyFromMSO(mso *MobileSecurityObject) (crypto.PublicKey, error
 		return nil, errors.New("MSO is nil")
 	}
 
-	if len(mso.DeviceKeyInfo.DeviceKey.X) == 0 {
+	key := mso.DeviceKeyInfo.DeviceKey
+	if len(key.X) == 0 {
 		return nil, errors.New("device key not present in MSO")
 	}
+	// EC2 keys require both coordinates. Without this check, a missing Y
+	// silently produces an ECDSA public key with Y=0 (big.Int.SetBytes(nil)
+	// == 0) instead of a clear error, and any failure surfaces later as a
+	// confusing signature-verification error instead of "key missing".
+	if key.Kty == KeyTypeEC2 && len(key.Y) == 0 {
+		return nil, errors.New("device key not present in MSO: EC2 key missing Y coordinate")
+	}
 
-	return mso.DeviceKeyInfo.DeviceKey.ToPublicKey()
+	return key.ToPublicKey()
 }
 
 // VerifyDeviceAuth verifies device authentication as part of document verification.

--- a/pkg/mdoc/device_auth.go
+++ b/pkg/mdoc/device_auth.go
@@ -352,22 +352,11 @@ func ExtractDeviceKeyFromMSO(mso *MobileSecurityObject) (crypto.PublicKey, error
 		return nil, errors.New("MSO is nil")
 	}
 
-	if len(mso.DeviceKeyInfo.DeviceKey) == 0 {
+	if len(mso.DeviceKeyInfo.DeviceKey.X) == 0 {
 		return nil, errors.New("device key not present in MSO")
 	}
 
-	encoder, err := NewCBOREncoder()
-	if err != nil {
-		return nil, err
-	}
-
-	// Parse the COSE_Key
-	var coseKey COSEKey
-	if err := encoder.Unmarshal(mso.DeviceKeyInfo.DeviceKey, &coseKey); err != nil {
-		return nil, fmt.Errorf("failed to parse device COSE key: %w", err)
-	}
-
-	return coseKey.ToPublicKey()
+	return mso.DeviceKeyInfo.DeviceKey.ToPublicKey()
 }
 
 // VerifyDeviceAuth verifies device authentication as part of document verification.

--- a/pkg/mdoc/device_auth_test.go
+++ b/pkg/mdoc/device_auth_test.go
@@ -519,6 +519,30 @@ func TestExtractDeviceKeyFromMSO_NoDeviceKey(t *testing.T) {
 	}
 }
 
+// TestExtractDeviceKeyFromMSO_EC2MissingY guards against a partially-present
+// EC2 device key (X set, Y empty) slipping through as "present". Without the
+// Kty-aware check, toECDSAPublicKey would happily produce a public key with
+// Y=0 (big.Int.SetBytes(nil) == 0), and the caller wouldn't see a clear
+// "key missing" error until signature verification failed downstream for an
+// unrelated-looking reason.
+func TestExtractDeviceKeyFromMSO_EC2MissingY(t *testing.T) {
+	mso := &MobileSecurityObject{
+		Version: "1.0",
+		DeviceKeyInfo: DeviceKeyInfo{
+			DeviceKey: COSEKey{
+				Kty: KeyTypeEC2,
+				Crv: CurveP256,
+				X:   []byte{0x01, 0x02, 0x03},
+			},
+		},
+	}
+
+	_, err := ExtractDeviceKeyFromMSO(mso)
+	if err == nil {
+		t.Error("ExtractDeviceKeyFromMSO() should fail when EC2 key is missing Y")
+	}
+}
+
 func TestDeriveDeviceAuthenticationKey(t *testing.T) {
 	// Create session encryption
 	deviceKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/pkg/mdoc/device_auth_test.go
+++ b/pkg/mdoc/device_auth_test.go
@@ -473,18 +473,13 @@ func TestExtractDeviceKeyFromMSO(t *testing.T) {
 		t.Fatalf("failed to create COSE key: %v", err)
 	}
 
-	keyBytes, err := coseKey.Bytes()
-	if err != nil {
-		t.Fatalf("failed to encode COSE key: %v", err)
-	}
-
 	// Create MSO with device key
 	mso := &MobileSecurityObject{
 		Version:         "1.0",
 		DigestAlgorithm: "SHA-256",
 		DocType:         DocType,
 		DeviceKeyInfo: DeviceKeyInfo{
-			DeviceKey: keyBytes,
+			DeviceKey: *coseKey,
 		},
 	}
 
@@ -642,7 +637,6 @@ func TestVerifier_VerifyDeviceAuth_Signature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create device COSE key: %v", err)
 	}
-	deviceKeyBytes, _ := deviceCOSEKey.Bytes()
 
 	// Create MSO
 	mso := &MobileSecurityObject{
@@ -650,7 +644,7 @@ func TestVerifier_VerifyDeviceAuth_Signature(t *testing.T) {
 		DigestAlgorithm: "SHA-256",
 		DocType:         DocType,
 		DeviceKeyInfo: DeviceKeyInfo{
-			DeviceKey: deviceKeyBytes,
+			DeviceKey: *deviceCOSEKey,
 		},
 		ValidityInfo: ValidityInfo{
 			Signed:         time.Now(),
@@ -717,11 +711,10 @@ func TestVerifier_VerifyDeviceAuth_NoDeviceAuth(t *testing.T) {
 	// Create minimal MSO
 	deviceKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	deviceCOSEKey, _ := NewCOSEKeyFromECDSA(&deviceKey.PublicKey)
-	deviceKeyBytes, _ := deviceCOSEKey.Bytes()
 
 	mso := &MobileSecurityObject{
 		DeviceKeyInfo: DeviceKeyInfo{
-			DeviceKey: deviceKeyBytes,
+			DeviceKey: *deviceCOSEKey,
 		},
 	}
 
@@ -748,11 +741,10 @@ func TestVerifier_VerifyDeviceAuth_WrongKey(t *testing.T) {
 
 	// Create MSO with WRONG key (not the one used to sign)
 	wrongCOSEKey, _ := NewCOSEKeyFromECDSA(&wrongKey.PublicKey)
-	wrongKeyBytes, _ := wrongCOSEKey.Bytes()
 
 	mso := &MobileSecurityObject{
 		DeviceKeyInfo: DeviceKeyInfo{
-			DeviceKey: wrongKeyBytes,
+			DeviceKey: *wrongCOSEKey,
 		},
 	}
 
@@ -807,11 +799,10 @@ func TestVerifier_VerifyDeviceAuth_MACRequiresSessionKey(t *testing.T) {
 	// Create MSO
 	deviceKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	deviceCOSEKey, _ := NewCOSEKeyFromECDSA(&deviceKey.PublicKey)
-	deviceKeyBytes, _ := deviceCOSEKey.Bytes()
 
 	mso := &MobileSecurityObject{
 		DeviceKeyInfo: DeviceKeyInfo{
-			DeviceKey: deviceKeyBytes,
+			DeviceKey: *deviceCOSEKey,
 		},
 	}
 
@@ -963,10 +954,11 @@ func TestVerifier_VerifyDeviceAuth_InvalidDeviceKey(t *testing.T) {
 		nil,
 	)
 
-	// Create MSO with invalid device key bytes
+	// Create MSO with an absent device key (zero-value COSEKey - no X
+	// coordinate) - ExtractDeviceKeyFromMSO's "not present" check catches this.
 	mso := &MobileSecurityObject{
 		DeviceKeyInfo: DeviceKeyInfo{
-			DeviceKey: []byte{0x01, 0x02, 0x03}, // Invalid CBOR
+			DeviceKey: COSEKey{},
 		},
 	}
 

--- a/pkg/mdoc/mdoc.go
+++ b/pkg/mdoc/mdoc.go
@@ -182,8 +182,12 @@ type AgeOver struct {
 
 // DeviceKeyInfo contains information about the device key used for mdoc authentication.
 type DeviceKeyInfo struct {
-	// DeviceKey is the public key of the device (COSE_Key format).
-	DeviceKey []byte `json:"deviceKey" cbor:"deviceKey" validate:"required"`
+	// DeviceKey is the public key of the device, embedded directly as a
+	// COSE_Key structure (a CBOR map) per ISO 18013-5 - not pre-serialized
+	// to bytes and wrapped in a byte string (a real bug caught by Google's
+	// https://digital-credentials.dev/ demo, see MSOBuilder.Build's doc
+	// comment).
+	DeviceKey COSEKey `json:"deviceKey" cbor:"deviceKey" validate:"required"`
 
 	// KeyAuthorizations contains authorized namespaces and data elements.
 	KeyAuthorizations *KeyAuthorizations `json:"keyAuthorizations,omitempty" cbor:"keyAuthorizations,omitempty"`

--- a/pkg/mdoc/mdoc_test.go
+++ b/pkg/mdoc/mdoc_test.go
@@ -217,7 +217,7 @@ func TestDrivingPrivilege_AllCategories(t *testing.T) {
 }
 
 func TestDeviceKeyInfo(t *testing.T) {
-	deviceKey := []byte{0xA1, 0x01, 0x02} // Sample COSE_Key
+	deviceKey := COSEKey{Kty: 2, Crv: CurveP256, X: []byte{0x01, 0x02, 0x03}, Y: []byte{0x04, 0x05, 0x06}}
 
 	info := DeviceKeyInfo{
 		DeviceKey: deviceKey,
@@ -232,8 +232,8 @@ func TestDeviceKeyInfo(t *testing.T) {
 		},
 	}
 
-	if len(info.DeviceKey) != 3 {
-		t.Errorf("DeviceKey length = %d, want 3", len(info.DeviceKey))
+	if len(info.DeviceKey.X) != 3 {
+		t.Errorf("DeviceKey.X length = %d, want 3", len(info.DeviceKey.X))
 	}
 	if len(info.KeyAuthorizations.NameSpaces) != 1 {
 		t.Errorf("NameSpaces length = %d, want 1", len(info.KeyAuthorizations.NameSpaces))
@@ -277,7 +277,7 @@ func TestMobileSecurityObject(t *testing.T) {
 			},
 		},
 		DeviceKeyInfo: DeviceKeyInfo{
-			DeviceKey: []byte{0xA1, 0x01, 0x02},
+			DeviceKey: COSEKey{Kty: 2, Crv: CurveP256, X: []byte{0xA1, 0x01, 0x02}},
 		},
 		DocType: DocType,
 		ValidityInfo: ValidityInfo{

--- a/pkg/mdoc/mso.go
+++ b/pkg/mdoc/mso.go
@@ -206,19 +206,22 @@ func (b *MSOBuilder) Build() (*COSESign1, map[string][]cbor.Tag, error) {
 	validFromStr := b.validFrom.UTC().Format(time.RFC3339)
 	validUntilStr := b.validUntil.UTC().Format(time.RFC3339)
 
-	// Get device key bytes
-	deviceKeyBytes, err := b.deviceKey.Bytes()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to encode device key: %w", err)
-	}
-
 	mso := map[string]any{
 		"version":         "1.0",
 		"digestAlgorithm": string(b.digestAlgorithm),
 		"docType":         b.docType,
 		"valueDigests":    valueDigests,
+		// DeviceKeyInfo.deviceKey is the COSE_Key structure embedded
+		// directly (a CBOR map, per ISO 18013-5), not pre-serialized to
+		// bytes and wrapped in a byte string - b.deviceKey's own `cbor:"..."`
+		// struct tags (see COSEKey) produce the correct map encoding when
+		// this whole mso value is marshaled below. The previous
+		// double-encoding was a real bug caught by Google's own
+		// https://digital-credentials.dev/ demo, which rejected our issued
+		// mdocs with "'bytes' object has no attribute 'get'" trying to read
+		// deviceKey as a dict.
 		"deviceKeyInfo": map[string]any{
-			"deviceKey": deviceKeyBytes,
+			"deviceKey": b.deviceKey,
 		},
 		"validityInfo": map[string]any{
 			"signed":     cbor.Tag{Number: 0, Content: signedTime},


### PR DESCRIPTION
## Summary

Three real, spec-conformance bugs in mdoc issuance/verification, all caught
by cross-checking our issued mdocs against Google's own reference verifier
(https://digital-credentials.dev/, backed by the `isomdoc` Python library)
while validating a native Digital Credentials API (DC API) presentation
flow. Our own verifier never caught these, since it happened to agree with
itself on the same (incorrect) conventions on both the issuing and
verifying side.

- **`issuerAuth`'s x5chain was in the COSE_Sign1 protected header.** Per RFC
  9360 and the mdoc convention, it belongs in the unprotected header - the
  certificate chain isn't itself integrity-critical (trust comes from the
  signature verifying against the chain's leaf key, not from where the
  chain is placed), and a strict verifier rejects any protected header with
  more than the algorithm element (isomdoc's exact error: `"issuerAuth
  COSE_Sign1 protected contains too many elements"`).
  `GetCertificateChainFromSign1` now checks the unprotected header first
  (handling the uint64-vs-int64 CBOR key-decode ambiguity for maps decoded
  generically from the wire), falling back to protected for mdocs issued
  before this fix.

- **`Sign1`'s `external_aad` was left as Go's `nil` `[]byte`.**
  `cbor.Marshal` encodes a nil slice as CBOR null (`0xf6`), but a compliant
  verifier reconstructs the Sig_structure with an empty byte string (`0x40`,
  `h''`) - so the bytes actually signed diverged from what any verifier
  reconstructs to check the signature, invalidating every issuerAuth
  signature produced by this code (isomdoc's error:
  `cryptography.exceptions.InvalidSignature`). Both `Sign1` and `Verify1`
  now normalize `nil` to an explicit empty slice.

- **`MSOBuilder.Build()` pre-serialized `DeviceKeyInfo.deviceKey` to bytes**
  and wrapped those bytes in a byte string, when ISO 18013-5 embeds the
  COSE_Key directly as a CBOR map (isomdoc's error: `'bytes' object has no
  attribute 'get'` trying to read it as a dict). `DeviceKeyInfo.DeviceKey`
  is now typed `COSEKey` (not `[]byte`), so the struct's own `cbor` tags
  produce the correct encoding when the whole MSO is marshaled.

All three were reproducible independent of DC API specifically - any mdoc
presentation (redirect flow included) built with this code would fail
against a spec-strict verifier.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/mdoc/...` (all pass, including updated fixtures for the
      `DeviceKeyInfo.DeviceKey` type change)
- [x] `go test ./internal/verifier/...`, `./internal/issuer/...`
- [x] End-to-end on-device verification: issued a real mDL, presented it via
      the W3C Digital Credentials API, and confirmed successful verification
      against both Google's reference verifier (digital-credentials.dev)
      and this fork's own verifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhWrEC7D4b3vxZ4wm3gDML