### PR TITLE
fix: use @sirosfoundation/dc-api v0.5.0's authorization-request bridge

### DIFF
--- a/internal/verifier/staticembed/dc-api-polyfill.js
+++ b/internal/verifier/staticembed/dc-api-polyfill.js
@@ -29,6 +29,7 @@ export {
     isUserCancel,
     isProtocolUnsupported,
     ERROR_MESSAGES,
+    requestCredentialFromAuthorizationRequestURI,
 } from '@sirosfoundation/dc-api';
 
 import {

--- a/internal/verifier/staticembed/dc-api.js
+++ b/internal/verifier/staticembed/dc-api.js
@@ -79,14 +79,21 @@ function normalizeCredential(credential, fallbackProtocol) {
 }
 
 // src/authorization-request.ts
+// PATCHED (not upstream @sirosfoundation/dc-api v0.5.0): options.signal was
+// accepted by requestCredentialFromAuthorizationRequestURI but dropped
+// before reaching the request_uri fetch, so an AbortController passed by
+// the caller couldn't cancel a slow/hung request_uri fetch. Threaded
+// `signal` through buildRequestData/_fetchJwt below. File an upstream fix
+// too so the next dc-api bump doesn't reintroduce this.
 async function buildRequestData(protocol, authorizationRequestUri, options) {
   const fetchImpl = options?.fetchFn ?? fetch;
+  const signal = options?.signal;
   const url = new URL(authorizationRequestUri);
   const params = url.searchParams;
   const inlineRequest = params.get("request");
   const requestUri = params.get("request_uri");
   if (protocol === OID4VP_PROTOCOLS.SIGNED || protocol === OID4VP_PROTOCOLS.MULTISIGNED) {
-    const jwt = inlineRequest ?? (requestUri ? await _fetchJwt(requestUri, fetchImpl) : null);
+    const jwt = inlineRequest ?? (requestUri ? await _fetchJwt(requestUri, fetchImpl, signal) : null);
     if (!jwt) {
       throw new Error(
         `Cannot build ${protocol} request data: authorization request has neither 'request' nor 'request_uri'`
@@ -98,7 +105,7 @@ async function buildRequestData(protocol, authorizationRequestUri, options) {
     return _decodeJwtPayload(inlineRequest);
   }
   if (requestUri) {
-    const jwt = await _fetchJwt(requestUri, fetchImpl);
+    const jwt = await _fetchJwt(requestUri, fetchImpl, signal);
     return _decodeJwtPayload(jwt);
   }
   const data = {};
@@ -112,8 +119,8 @@ async function buildRequestData(protocol, authorizationRequestUri, options) {
   }
   return data;
 }
-async function _fetchJwt(requestUri, fetchImpl) {
-  const res = await fetchImpl(requestUri);
+async function _fetchJwt(requestUri, fetchImpl, signal) {
+  const res = await fetchImpl(requestUri, signal ? { signal } : void 0);
   if (!res.ok) {
     throw new Error(`Failed to fetch request_uri ${requestUri}: HTTP ${res.status}`);
   }
@@ -137,7 +144,7 @@ function _decodeJwtPayload(jwt) {
 async function requestCredentialFromAuthorizationRequestURI(authorizationRequestUri, options) {
   const protocol = getBestProtocol(options?.protocolPreference);
   if (!protocol) return null;
-  const data = await buildRequestData(protocol, authorizationRequestUri, { fetchFn: options?.fetchFn });
+  const data = await buildRequestData(protocol, authorizationRequestUri, { fetchFn: options?.fetchFn, signal: options?.signal });
   return requestCredential(protocol, data, options);
 }
 

--- a/internal/verifier/staticembed/dc-api.js
+++ b/internal/verifier/staticembed/dc-api.js
@@ -21,6 +21,13 @@ const OID4VP_ALL_PROTOCOLS = [
 function isOID4VPProtocol(value) {
   return OID4VP_ALL_PROTOCOLS.includes(value);
 }
+const OID4VCI_PROTOCOLS = {
+  /** OpenID4VCI 1.0 */
+  V1: "openid4vci-v1"
+};
+function isOID4VCIProtocol(value) {
+  return value === OID4VCI_PROTOCOLS.V1;
+}
 
 // src/detect.ts
 function isDCAPIAvailable() {
@@ -71,6 +78,69 @@ function normalizeCredential(credential, fallbackProtocol) {
   };
 }
 
+// src/authorization-request.ts
+async function buildRequestData(protocol, authorizationRequestUri, options) {
+  const fetchImpl = options?.fetchFn ?? fetch;
+  const url = new URL(authorizationRequestUri);
+  const params = url.searchParams;
+  const inlineRequest = params.get("request");
+  const requestUri = params.get("request_uri");
+  if (protocol === OID4VP_PROTOCOLS.SIGNED || protocol === OID4VP_PROTOCOLS.MULTISIGNED) {
+    const jwt = inlineRequest ?? (requestUri ? await _fetchJwt(requestUri, fetchImpl) : null);
+    if (!jwt) {
+      throw new Error(
+        `Cannot build ${protocol} request data: authorization request has neither 'request' nor 'request_uri'`
+      );
+    }
+    return { request: jwt };
+  }
+  if (inlineRequest) {
+    return _decodeJwtPayload(inlineRequest);
+  }
+  if (requestUri) {
+    const jwt = await _fetchJwt(requestUri, fetchImpl);
+    return _decodeJwtPayload(jwt);
+  }
+  const data = {};
+  for (const [key, value] of params.entries()) {
+    if (key === "client_id") continue;
+    try {
+      data[key] = JSON.parse(value);
+    } catch {
+      data[key] = value;
+    }
+  }
+  return data;
+}
+async function _fetchJwt(requestUri, fetchImpl) {
+  const res = await fetchImpl(requestUri);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch request_uri ${requestUri}: HTTP ${res.status}`);
+  }
+  const text = await res.text();
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed === "string") return parsed;
+  } catch {
+  }
+  return text;
+}
+function _decodeJwtPayload(jwt) {
+  const parts = jwt.split(".");
+  if (parts.length < 2) {
+    throw new Error("Not a valid JWT: expected at least 2 dot-separated parts");
+  }
+  let base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+  while (base64.length % 4) base64 += "=";
+  return JSON.parse(atob(base64));
+}
+async function requestCredentialFromAuthorizationRequestURI(authorizationRequestUri, options) {
+  const protocol = getBestProtocol(options?.protocolPreference);
+  if (!protocol) return null;
+  const data = await buildRequestData(protocol, authorizationRequestUri, { fetchFn: options?.fetchFn });
+  return requestCredential(protocol, data, options);
+}
+
 // src/errors.ts
 const ERROR_MESSAGES = {
   NotAllowedError: "You denied the credential request or no wallet is available.",
@@ -98,15 +168,19 @@ function isProtocolUnsupported(error) {
 }
 export {
   ERROR_MESSAGES,
+  OID4VCI_PROTOCOLS,
   OID4VP_ALL_PROTOCOLS,
   OID4VP_PROTOCOLS,
   OID4VP_SPEC_PROTOCOLS,
+  buildRequestData,
   getBestProtocol,
   getUserFriendlyErrorMessage,
   isDCAPIAvailable,
+  isOID4VCIProtocol,
   isOID4VPProtocol,
   isProtocolAllowed,
   isProtocolUnsupported,
   isUserCancel,
-  requestCredential
+  requestCredential,
+  requestCredentialFromAuthorizationRequestURI
 };

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -2,9 +2,9 @@ import Alpine from "alpinejs";
 import * as v from "valibot";
 import {
     configure as configureDCAPI,
-    requestCredential,
     isNativeDCAPIAvailable,
     getBestSupportedProtocol,
+    requestCredentialFromAuthorizationRequestURI,
 } from "./dc-api-polyfill.js";
 
 /** @typedef {v.InferOutput<typeof credentialAttributesSchema>} CredentialAttributes */
@@ -84,7 +84,11 @@ const credentialsList = v.record(
 /** @typedef {v.InferOutput<typeof metadataResponseSchema>} MetadataResponse */
 const metadataResponseSchema = v.object({
     credentials: credentialsList,
-    supported_wallets: v.record(v.string(), v.string()),
+    // v.optional() only substitutes its default for an ABSENT key, not an
+    // explicit null - Go's zero-value nil map marshals to JSON null (see
+    // UIMetadata's SupportedWallets fix), so this needs v.nullish() to
+    // actually tolerate that, not v.optional().
+    supported_wallets: v.nullish(v.record(v.string(), v.string()), {}),
     dc_api_enabled: v.optional(v.boolean(), false),
     presets: v.optional(v.record(v.string(), v.object({
         label: v.string(),
@@ -110,9 +114,13 @@ const metadataResponseSchema = v.object({
 const dcqlQueryCredentialSchema = v.object({
     id: v.string(),
     format: v.optional(v.string(), "dc+sd-jwt"),
+    // vct_values (dc+sd-jwt/jwt_vc_json) and doctype_value (mso_mdoc) are
+    // both optional here, not either/or required - which meta property
+    // applies depends on the credential's format (OpenID4VP 1.0 6.4.1).
     meta: v.intersect([
         v.object({
-            vct_values: v.array(v.string()),
+            vct_values: v.optional(v.array(v.string())),
+            doctype_value: v.optional(v.string()),
         }),
         v.record(v.string(), v.union([v.string(), v.array(v.string())])),
     ]),
@@ -419,13 +427,20 @@ Alpine.data("app", () => ({
             claims.push({ path });
         }
 
+        // mso_mdoc credentials have no vct - the DCQL equivalent constraint
+        // is doctype_value (OpenID4VP 1.0 6.4.1), not vct_values. Sending
+        // vct_values for an mdoc credential matches nothing on the wallet
+        // side (no mdoc credential has a vct), so the request always comes
+        // back empty.
+        const meta = this.credentialAttributes.format === "mso_mdoc"
+            ? { doctype_value: this.credentialAttributes.vct }
+            : { vct_values: [this.credentialAttributes.vct] };
+
         /** @satisfies {DCQLQueryCredential} */
         const credential = {
             id: this.credentialAttributes.id,
             format: this.credentialAttributes.format,
-            meta: {
-                vct_values: [this.credentialAttributes.vct]
-            },
+            meta,
             claims,
         };
 
@@ -490,6 +505,14 @@ Alpine.data("app", () => ({
 
     /**
      * Attempt credential request via native DC API.
+     *
+     * The authorization_request URI is the same openid4vp://...?client_id=...
+     * &request_uri=... deep link used for QR/redirect - NOT itself a valid DC
+     * API `request` value for any protocol. requestCredentialFromAuthorizationRequestURI
+     * (from @sirosfoundation/dc-api) resolves it into whatever shape the
+     * detected protocol actually needs (fetching request_uri for the JWT when
+     * required) before calling navigator.credentials.get().
+     *
      * @returns {Promise<boolean>} true if handled, false to fall through
      */
     async _tryNativeDCAPI() {
@@ -500,10 +523,11 @@ Alpine.data("app", () => ({
             const abortController = new AbortController();
             this._dcAbort = abortController;
 
-            const result = await requestCredential(
+            const result = await requestCredentialFromAuthorizationRequestURI(
                 this.presentationDefinition.authorization_request,
                 { signal: abortController.signal },
             );
+            if (!result) return false;
 
             if (result.data?.redirect_uri) {
                 globalThis.location.href = result.data.redirect_uri;


### PR DESCRIPTION
## Summary

Follow-up to #504 (the DC API polyfill integration, merged 2026-07-29). Live end-to-end testing against a real Android device (Chrome DC API + native mdoc credential presentation) surfaced a real bug in the native DC API path introduced there, plus two related bugs found in the same testing pass.

## Bugs fixed

1. **Native DC API path never worked**: the verifier passed the redirect-flow `authorization_request` URI (`openid4vp://...?client_id=...&request_uri=...`) directly as the DC API `request` value. That URI is neither a valid JWT (`openid4vp-v1-signed` needs one) nor a valid raw-params object (`openid4vp-v1-unsigned` needs that instead) - no protocol handler could parse it, so every native DC API attempt failed silently ("Your info wasn't found"). Fixed by bumping the vendored `@sirosfoundation/dc-api` bundle to v0.5.0 and wiring the native path through its new `requestCredentialFromAuthorizationRequestURI()` helper, which resolves a standard authorization request URI into whatever `data` shape the detected protocol actually needs (fetching `request_uri` for the JWT when required).
2. **`/ui/metadata` failed to parse when no wallets are configured**: `supported_wallets` can arrive as JSON `null` (an unconfigured Go map marshals that way) - the schema had no fallback for it, so the whole response failed to parse and the page hung on its loading spinner before a user could ever select a credential.
3. **mdoc claim selection built the wrong DCQL constraint**: the claim-selection form always built `meta.vct_values`, even for `mso_mdoc` credentials, which have no `vct` - the correct constraint there is `meta.doctype_value` (OpenID4VP 1.0 §6.4.1). Sending `vct_values` for an mdoc credential matches nothing on the wallet side.

## Test plan

- [x] `go build ./...` - clean.
- [x] `make test-js` - 49/49 passing.
- [x] Verified end-to-end against a real Android device (Chrome DC API + native mdoc credential presentation).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>