### PR TITLE
fix(issuer): raise SignMetadata's metadata_json size limit from 64KB to 2MiB

### DIFF
--- a/internal/issuer/apiv1/sign_metadata.go
+++ b/internal/issuer/apiv1/sign_metadata.go
@@ -23,6 +23,22 @@ const (
 	MetadataTypeVCIIssuer = "vci-issuer"
 	// MetadataTypeOAuth2 identifies OAuth 2.0 Authorization Server Metadata (RFC 8414).
 	MetadataTypeOAuth2 = "oauth2-authorization-server"
+
+	// maxMetadataJSONBytes bounds the size of the metadata_json payload accepted
+	// by SignMetadata. This is an application-level guard, separate from gRPC's
+	// own transport-level message-size limit (grpc-go defaults to 4 MiB and
+	// neither the issuer's gRPC server nor the apigw client override it), so
+	// that an oversized payload gets a clear, specific InvalidArgument error
+	// here instead of a generic gRPC transport failure.
+	//
+	// A real deployment's Credential Issuer Metadata grows with the number of
+	// configured VCTM/MDDL scopes (each contributing a CredentialConfigurationsSupported
+	// entry with multi-language Display/ClaimDescription/ClaimDisplayProperties
+	// per claim, see pkg/openid4vci/issuer_metadata.go), so a handful of
+	// configured scopes can comfortably exceed a few hundred KB. 2 MiB leaves
+	// generous headroom for that while staying well under gRPC's 4 MiB default,
+	// so this check - not gRPC's - is the one that actually fires.
+	maxMetadataJSONBytes = 2 * 1024 * 1024
 )
 
 // signableMetadata is implemented by metadata structs that can be
@@ -50,7 +66,7 @@ func (c *Client) SignMetadata(ctx context.Context, req *apiv1_issuer.SignMetadat
 	if len(req.GetMetadataJson()) == 0 {
 		return nil, grpcstatus.Error(codes.InvalidArgument, "metadata_json is required")
 	}
-	if len(req.GetMetadataJson()) > 64*1024 {
+	if len(req.GetMetadataJson()) > maxMetadataJSONBytes {
 		return nil, grpcstatus.Error(codes.InvalidArgument, "metadata_json is too large")
 	}
 	if req.GetIss() != c.cfg.Issuer.IssuerURL {

--- a/internal/issuer/apiv1/sign_metadata_test.go
+++ b/internal/issuer/apiv1/sign_metadata_test.go
@@ -89,8 +89,15 @@ func metadataJSON(t *testing.T, m map[string]any) []byte {
 }
 
 func TestSignMetadata_Validation(t *testing.T) {
-	// Build an oversized payload once for reuse.
-	oversized := make([]byte, 64*1024+1)
+	// Build boundary payloads once for reuse: one exactly at the limit (junk,
+	// invalid JSON, so it must clear the size check but fail at JSON parsing),
+	// and one exactly one byte over (must be rejected for size before parsing
+	// is ever attempted).
+	atLimit := make([]byte, maxMetadataJSONBytes)
+	for i := range atLimit {
+		atLimit[i] = 'x'
+	}
+	oversized := make([]byte, maxMetadataJSONBytes+1)
 	for i := range oversized {
 		oversized[i] = 'x'
 	}
@@ -111,6 +118,20 @@ func TestSignMetadata_Validation(t *testing.T) {
 			},
 			wantCode:   codes.InvalidArgument,
 			wantSubstr: "metadata_json is required",
+		},
+		{
+			// Exactly at maxMetadataJSONBytes must pass the size check (i.e. not
+			// be rejected as "too large"). It's not valid JSON, so it's expected
+			// to fail one stage later, at parsing - which proves the size gate
+			// itself let it through.
+			name:         "metadata_json exactly at size limit is not rejected for size",
+			metadataJSON: func(t *testing.T) []byte { return atLimit },
+			req: &apiv1_issuer.SignMetadataRequest{
+				MetadataType: MetadataTypeVCIIssuer,
+				Iss:          testIssuerURL,
+			},
+			wantCode:   codes.InvalidArgument,
+			wantSubstr: "failed to parse metadata",
 		},
 		{
 			name:         "oversized metadata_json",


### PR DESCRIPTION
## Symptom

apigw logs a recurring error:

```
failed to refresh VCI signed metadata {"error": "failed to sign metadata via issuer: rpc error: code = InvalidArgument desc = metadata_json is too large"}
```

## Root cause

- apigw's 55-minute VCI signed-metadata refresh ticker (`StartSignedMetadataRefresher` → `refreshSignedMetadata` at [`internal/apigw/apiv1/sign_metadata.go:154`](internal/apigw/apiv1/sign_metadata.go)) calls `signMetadataViaIssuer` ([lines 39-60](internal/apigw/apiv1/sign_metadata.go)), which sends the full `CredentialIssuerMetadataParameters` JSON (built in `internal/apigw/apiv1/client.go`) over gRPC to the issuer service's `SignMetadata` RPC.
- That JSON includes one `CredentialConfigurationsSupported` entry per configured VCTM/MDDL scope, each with multi-language `Display`/`ClaimDescription`/`ClaimDisplayProperties` per claim (see `pkg/openid4vci/issuer_metadata.go`). A real deployment with ~10 configured credential-type scopes easily produces a combined metadata JSON over 64KB.
- `internal/issuer/apiv1/sign_metadata.go` (previously lines 53-55) hardcoded:
  ```go
  if len(req.GetMetadataJson()) > 64*1024 {
      return nil, grpcstatus.Error(codes.InvalidArgument, "metadata_json is too large")
  }
  ```
  This 64KB cap is an arbitrary application-level guard introduced in `ecd66687` ("Add constrains to signmetadata."), with no rationale given for the specific figure — it was evidently only ever exercised with 1-2 scopes configured.
- This is **not** gRPC's own transport-level message-size limit: no `MaxRecvMsgSize`/`MaxSendMsgSize` is configured anywhere in `internal/issuer/grpcserver/service.go` or the apigw gRPC client, so grpc-go's ~4MiB default applies there and isn't what's firing.

## Fix

Raised the hardcoded 64KB constant to 2 MiB, extracted into a named constant `maxMetadataJSONBytes` with a comment explaining the rationale:

- Kept the app-level guard (rather than removing it and relying solely on gRPC's own limit) so an oversized payload still gets a clear, specific `InvalidArgument` error instead of a generic gRPC transport failure.
- Sized it to 2 MiB — generous headroom over what a realistic multi-scope deployment produces, while staying comfortably under gRPC's own 4 MiB default, so this check (not gRPC's) is the one that actually fires.

Added a boundary test (`TestSignMetadata_Validation/metadata_json_exactly_at_size_limit_is_not_rejected_for_size`) asserting a payload exactly at the new limit clears the size check (and instead fails one stage later at JSON parsing, since the boundary payload isn't valid JSON — proving the size gate itself let it through), alongside the existing "one byte over the limit is rejected as too large" case (updated to use the new limit).

## Testing

- `go build ./...` — clean, no errors.
- `go test ./internal/issuer/apiv1/...` — all pass, including the new/updated boundary tests.
- `go test ./internal/apigw/apiv1/...` — all pass.
- Full `make test` scope (verifier, registry, apigw, issuer — both `cmd/...` and `internal/...`) — all pass.
- `go vet` and `gofmt -l` on changed files — clean.