### PR TITLE
fix(apigw): UICreateCredentialOffer falls back to MDDL for mso_mdoc scopes

### DIFF
--- a/internal/apigw/apiv1/handlers_vctm.go
+++ b/internal/apigw/apiv1/handlers_vctm.go
@@ -43,8 +43,30 @@ func (c *Client) UICreateCredentialOffer(ctx context.Context, req *UICredentialO
 		Scope: req.Scope,
 	}
 
+	// mso_mdoc scopes have no VCTM by design (ErrScopeIsMDoc) - fall back to
+	// the MDDL schema for display name/id, same as every other caller of
+	// GetVCTMFromScope is expected to per its own doc comment. Without this,
+	// the offer-creation UI 500s for every mdoc scope even though issuance
+	// itself works fine via GetMDDLFromScope elsewhere.
+	var offerName, offerID string
 	vctm, err := c.GetVCTMFromScope(ctx, vctmReq)
-	if err != nil {
+	switch {
+	case err == nil:
+		offerName = vctm.Name
+		offerID = vctm.VCT
+	case errors.Is(err, ErrScopeIsMDoc):
+		mddl, mddlErr := c.GetMDDLFromScope(ctx, &GetMDDLFromScopeRequest{Scope: req.Scope})
+		if mddlErr != nil {
+			return nil, mddlErr
+		}
+		if len(mddl.Display) > 0 {
+			offerName = mddl.Display[0].Name
+		}
+		if offerName == "" {
+			offerName = mddl.DocType
+		}
+		offerID = mddl.DocType
+	default:
 		return nil, err
 	}
 
@@ -82,8 +104,8 @@ func (c *Client) UICreateCredentialOffer(ctx context.Context, req *UICredentialO
 	}
 
 	reply := &CredentialOfferReply{
-		Name: vctm.Name,
-		ID:   vctm.VCT,
+		Name: offerName,
+		ID:   offerID,
 		QR:   *qr,
 	}
 

--- a/internal/apigw/apiv1/handlers_vctm_test.go
+++ b/internal/apigw/apiv1/handlers_vctm_test.go
@@ -1,0 +1,114 @@
+package apiv1
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/logger"
+	"github.com/SUNET/vc/pkg/mdoc"
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sdjwtvc"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newOfferTestClient(t *testing.T, credMeta map[string]*model.CredentialMetadata) *Client {
+	t.Helper()
+	log, err := logger.New("test", "", false)
+	require.NoError(t, err)
+
+	return &Client{
+		log: log,
+		cfg: &model.Cfg{
+			Common: &model.Common{
+				CredentialMetadata: credMeta,
+			},
+			APIGW: &model.APIGW{
+				Delivery: model.APIGWDelivery{
+					CredentialOffers: model.CredentialOffers{
+						IssuerURL: "https://issuer.example.com",
+						Wallets: map[string]model.CredentialOfferWallets{
+							"local": {RedirectURI: "https://wallet.example.com/cb"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestUICreateCredentialOffer_VCTMScope(t *testing.T) {
+	credMeta := map[string]*model.CredentialMetadata{
+		"siros_id": {VCTM: &sdjwtvc.VCTM{Name: "SIROS ID", VCT: "urn:siros:id"}},
+	}
+	client := newOfferTestClient(t, credMeta)
+
+	reply, err := client.UICreateCredentialOffer(t.Context(), &UICredentialOfferRequest{
+		Scope:    "siros_id",
+		WalletID: "local",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "SIROS ID", reply.Name)
+	require.Equal(t, "urn:siros:id", reply.ID)
+}
+
+// Regression test for the bug this PR fixes: mso_mdoc scopes have no VCTM
+// by design (GetVCTMFromScope returns ErrScopeIsMDoc) - UICreateCredentialOffer
+// must fall back to the MDDL schema instead of propagating that error, since
+// mdoc issuance itself works fine via GetMDDLFromScope.
+func TestUICreateCredentialOffer_MDocScope(t *testing.T) {
+	credMeta := map[string]*model.CredentialMetadata{
+		"mdl": {MDDL: &mdoc.MDDLSchema{
+			DocType: "org.iso.18013.5.1.mDL",
+			Display: []mdoc.DisplayProperties{
+				{Locale: "en-US", Name: "Mobile Driving Licence"},
+			},
+		}},
+	}
+	client := newOfferTestClient(t, credMeta)
+
+	reply, err := client.UICreateCredentialOffer(t.Context(), &UICredentialOfferRequest{
+		Scope:    "mdl",
+		WalletID: "local",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Mobile Driving Licence", reply.Name)
+	require.Equal(t, "org.iso.18013.5.1.mDL", reply.ID)
+}
+
+func TestUICreateCredentialOffer_MDocScopeWithoutDisplay(t *testing.T) {
+	credMeta := map[string]*model.CredentialMetadata{
+		"mdl": {MDDL: &mdoc.MDDLSchema{DocType: "org.iso.18013.5.1.mDL"}},
+	}
+	client := newOfferTestClient(t, credMeta)
+
+	reply, err := client.UICreateCredentialOffer(t.Context(), &UICredentialOfferRequest{
+		Scope:    "mdl",
+		WalletID: "local",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "org.iso.18013.5.1.mDL", reply.Name, "should fall back to DocType when no Display entries")
+	require.Equal(t, "org.iso.18013.5.1.mDL", reply.ID)
+}
+
+func TestUICreateCredentialOffer_UnknownScope(t *testing.T) {
+	client := newOfferTestClient(t, map[string]*model.CredentialMetadata{})
+
+	_, err := client.UICreateCredentialOffer(t.Context(), &UICredentialOfferRequest{
+		Scope:    "nonexistent",
+		WalletID: "local",
+	})
+	require.Error(t, err)
+}
+
+func TestUICreateCredentialOffer_InvalidWalletID(t *testing.T) {
+	credMeta := map[string]*model.CredentialMetadata{
+		"siros_id": {VCTM: &sdjwtvc.VCTM{Name: "SIROS ID", VCT: "urn:siros:id"}},
+	}
+	client := newOfferTestClient(t, credMeta)
+
+	_, err := client.UICreateCredentialOffer(t.Context(), &UICredentialOfferRequest{
+		Scope:    "siros_id",
+		WalletID: "does-not-exist",
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

`GetVCTMFromScope` returns `ErrScopeIsMDoc` for any `mso_mdoc`-format scope (no VCTM exists for these by design). Its own doc comment says callers should catch this via `errors.Is` and fall back to `GetMDDLFromScope` — but `UICreateCredentialOffer` (the `/offers/:scope/:wallet_id` convenience endpoint used to generate a QR/offer link from a browser) just propagates the error, so it 500s for **every** mdoc scope, even though mdoc issuance itself works fine through `GetMDDLFromScope` elsewhere in the codebase.

Confirmed live against a real deployment: requesting an offer for a mso_mdoc scope (e.g. `mdl`) returned:
```
scope is an mso_mdoc credential (no VCTM)
```
with a 500, while the underlying issuance flow for that same scope works correctly.

## Fix

`UICreateCredentialOffer` now catches `ErrScopeIsMDoc` and falls back to `GetMDDLFromScope`, using:
- `Display[0].Name` (or `DocType` if no `Display` entries) for the offer's display name
- `DocType` as the offer id

mirroring how the VCTM path already uses `vctm.Name`/`vctm.VCT`.

## Test plan

- [x] New tests in `handlers_vctm_test.go`:
  - `TestUICreateCredentialOffer_VCTMScope` — existing SD-JWT/VCTM path still works
  - `TestUICreateCredentialOffer_MDocScope` — the actual regression test for this bug
  - `TestUICreateCredentialOffer_MDocScopeWithoutDisplay` — fallback to `DocType` when no `Display` entries
  - `TestUICreateCredentialOffer_UnknownScope` / `TestUICreateCredentialOffer_InvalidWalletID` — existing error paths unaffected
- [x] `go build ./...` clean
- [x] `go vet ./internal/apigw/apiv1/...` clean
- [x] `go test ./internal/apigw/apiv1/...` — all pass
- [x] `gofmt -l` clean