### PR TITLE
feat(trust): add etsi/ietf mode flag for wallet attestation trust model

### DIFF
--- a/internal/apigw/apiv1/client.go
+++ b/internal/apigw/apiv1/client.go
@@ -177,7 +177,7 @@ func New(ctx context.Context, db *db.Service, cacheService *cache.Service, trace
 		case "", trust.WIAModeETSI, trust.WIAModeIETF:
 			// valid (empty = accept either format)
 		default:
-			c.log.Warn("wallet_attestation.mode is not \"etsi\" or \"ietf\" - ignoring, accepting either WIA format",
+			c.log.Warn("apigw.trust.wallet_attestation.mode is not \"etsi\" or \"ietf\" - ignoring, accepting either WIA format",
 				"configured_mode", waMode)
 			waMode = ""
 		}

--- a/internal/apigw/apiv1/client.go
+++ b/internal/apigw/apiv1/client.go
@@ -170,7 +170,7 @@ func New(ctx context.Context, db *db.Service, cacheService *cache.Service, trace
 		Log:                        c.log,
 	})
 
-	// Wallet attestation: enabled when trust.wallet_attestation.enabled + pdp_url are set
+	// Wallet attestation: enabled when apigw.trust.wallet_attestation.enabled + pdp_url are set
 	if cfg.APIGW.Trust.WalletAttestation.Enabled && pdpURL != "" {
 		waMode := cfg.APIGW.Trust.WalletAttestation.Mode
 		switch waMode {

--- a/internal/apigw/apiv1/client.go
+++ b/internal/apigw/apiv1/client.go
@@ -172,7 +172,16 @@ func New(ctx context.Context, db *db.Service, cacheService *cache.Service, trace
 
 	// Wallet attestation: enabled when trust.wallet_attestation.enabled + pdp_url are set
 	if cfg.APIGW.Trust.WalletAttestation.Enabled && pdpURL != "" {
-		c.walletAttestationEvaluator = trust.NewWalletAttestationEvaluator(trustEvaluator, c.jwtTrustVerifier)
+		waMode := cfg.APIGW.Trust.WalletAttestation.Mode
+		switch waMode {
+		case "", trust.WIAModeETSI, trust.WIAModeIETF:
+			// valid (empty = accept either format)
+		default:
+			c.log.Warn("wallet_attestation.mode is not \"etsi\" or \"ietf\" - ignoring, accepting either WIA format",
+				"configured_mode", waMode)
+			waMode = ""
+		}
+		c.walletAttestationEvaluator = trust.NewWalletAttestationEvaluator(trustEvaluator, c.jwtTrustVerifier, waMode)
 
 		// Build SPOCP policy engine for tier-based scope authorization (nil = default open)
 		policy := cfg.APIGW.Trust.WalletAttestation.Policy
@@ -182,11 +191,15 @@ func New(ctx context.Context, db *db.Service, cacheService *cache.Service, trace
 		}
 		c.walletAttestationPolicy = policyEngine
 
+		modeLabel := waMode
+		if modeLabel == "" {
+			modeLabel = "auto (either)"
+		}
 		if policyEngine != nil {
 			c.log.Info("Wallet attestation enabled (PDP + SPOCP policy)",
-				"rules", policyEngine.RuleCount())
+				"rules", policyEngine.RuleCount(), "mode", modeLabel)
 		} else {
-			c.log.Info("Wallet attestation enabled (PDP trust, no scope restrictions)")
+			c.log.Info("Wallet attestation enabled (PDP trust, no scope restrictions)", "mode", modeLabel)
 		}
 	}
 

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -677,6 +677,33 @@ type WalletAttestationConfig struct {
 	// checks whether the attestation tier (attestation_source) is authorized for the
 	// requested scope. When empty, all trusted wallets are authorized (default open).
 	Policy WalletAttestationPolicy `yaml:"policy,omitempty"`
+
+	// Mode restricts which WIA trust model this deployment accepts, matching
+	// the same "etsi"/"ietf" terminology used by go-wallet-backend's
+	// WIAConfig.Mode:
+	//
+	//   - "etsi": require x5c (EC TS03 v1.5.2 / ETSI TS 119 472-3 model,
+	//     identity verified against the Trusted List for Wallet Providers).
+	//     A WIA without x5c is rejected before signature verification.
+	//   - "ietf": require iss + no x5c (the plain IETF
+	//     draft-ietf-oauth-attestation-based-client-auth format, resolved via
+	//     JWKS discovery — no ARF/ETSI counterpart). A WIA with x5c is
+	//     rejected before signature verification.
+	//   - "" (default): accept either format, as determined by the WIA
+	//     itself (trust.wallet_attestation.WalletAttestationEvaluator.Evaluate's
+	//     existing hasX5C-based branching) — preserves pre-Mode behavior for
+	//     deployments that haven't opted into pinning one trust model.
+	//
+	// Any other value is treated the same as "" (a warning is logged, not a
+	// startup failure — this package has no config.Validate() convention to
+	// hard-fail against).
+	//
+	// Pinning this matters beyond documentation: without it, an operator
+	// expecting only ARF-conformant ("etsi") wallets would still silently
+	// accept an iss/JWKS-based ("ietf") WIA from a misconfigured or
+	// malicious wallet, trusting a JWKS discovery chain instead of the
+	// Trusted List for Wallet Providers PKI anchor.
+	Mode string `yaml:"mode,omitempty"`
 }
 
 // TrustPolicyConfig defines trust policy settings for a specific role.

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -689,10 +689,10 @@ type WalletAttestationConfig struct {
 	//     draft-ietf-oauth-attestation-based-client-auth format, resolved via
 	//     JWKS discovery — no ARF/ETSI counterpart). A WIA with x5c is
 	//     rejected before signature verification.
-	//   - "" (default): accept either format, as determined by the WIA
-	//     itself (trust.wallet_attestation.WalletAttestationEvaluator.Evaluate's
-	//     existing hasX5C-based branching) — preserves pre-Mode behavior for
-	//     deployments that haven't opted into pinning one trust model.
+	//   - "" (default): accept either format, as determined by whether the
+	//     WIA carries an x5c header or an iss claim — preserves pre-Mode
+	//     behavior for deployments that haven't opted into pinning one trust
+	//     model.
 	//
 	// Any other value is treated the same as "" (a warning is logged, not a
 	// startup failure — this package has no config.Validate() convention to

--- a/pkg/trust/wallet_attestation.go
+++ b/pkg/trust/wallet_attestation.go
@@ -65,9 +65,9 @@ type WalletAttestationEvaluator struct {
 	// strategies, reused as-is here rather than reimplemented).
 	Verifier *JWTTrustVerifier
 	// Mode restricts which WIA trust model is accepted: WIAModeETSI
-	// (x5c-only, matching EC TS03 v1.5.2 / ETSI TS 119 472-3 — identity
+	// (x5c-based, matching EC TS03 v1.5.2 / ETSI TS 119 472-3 — identity
 	// verified against the Trusted List for Wallet Providers), WIAModeIETF
-	// (iss/JWKS-only, the plain IETF draft format with no ARF/ETSI
+	// (iss/JWKS-based, the plain IETF draft format with no ARF/ETSI
 	// counterpart), or "" to accept either (the pre-Mode default: whichever
 	// format the WIA itself uses). Enforced in Evaluate before any signature
 	// verification is attempted, so a mismatched WIA is rejected cheaply and

--- a/pkg/trust/wallet_attestation.go
+++ b/pkg/trust/wallet_attestation.go
@@ -33,6 +33,14 @@ type WalletAttestationResult struct {
 	TrustFramework string
 }
 
+// WIA trust-model modes — see WalletAttestationEvaluator.Mode. Mirrors
+// go-wallet-backend's WIAConfig.Mode terminology so operators configure both
+// sides of an interop pair consistently.
+const (
+	WIAModeETSI = "etsi"
+	WIAModeIETF = "ietf"
+)
+
 // WalletAttestationEvaluator evaluates wallet attestation JWTs by verifying
 // the WIA's own signature locally and then delegating the trust DECISION
 // (only) to the go-trust AuthZEN PDP - the PDP evaluates whether an
@@ -45,6 +53,9 @@ type WalletAttestationResult struct {
 //   - IETF draft-ietf-oauth-attestation-based-client-auth: iss claim present
 //   - EC TS03 §2.2.1 (EUDI): no iss, identity from x5c certificate chain in header
 //
+// Mode optionally pins which of the two a deployment accepts (see the Mode
+// field); when unset, both remain accepted as determined by the WIA itself.
+//
 // PKCE (mandatory for public clients) is the sole code-binding mechanism.
 type WalletAttestationEvaluator struct {
 	TrustEvaluator TrustEvaluator
@@ -53,11 +64,22 @@ type WalletAttestationEvaluator struct {
 	// (JWTTrustVerifier.extractJWTKeyMaterial's existing resolution
 	// strategies, reused as-is here rather than reimplemented).
 	Verifier *JWTTrustVerifier
+	// Mode restricts which WIA trust model is accepted: WIAModeETSI
+	// (x5c-only, matching EC TS03 v1.5.2 / ETSI TS 119 472-3 — identity
+	// verified against the Trusted List for Wallet Providers), WIAModeIETF
+	// (iss/JWKS-only, the plain IETF draft format with no ARF/ETSI
+	// counterpart), or "" to accept either (the pre-Mode default: whichever
+	// format the WIA itself uses). Enforced in Evaluate before any signature
+	// verification is attempted, so a mismatched WIA is rejected cheaply and
+	// never reaches the PDP with the "wrong" trust model's data.
+	Mode string
 }
 
-// NewWalletAttestationEvaluator creates a new evaluator.
-func NewWalletAttestationEvaluator(evaluator TrustEvaluator, verifier *JWTTrustVerifier) *WalletAttestationEvaluator {
-	return &WalletAttestationEvaluator{TrustEvaluator: evaluator, Verifier: verifier}
+// NewWalletAttestationEvaluator creates a new evaluator. mode is one of
+// WIAModeETSI, WIAModeIETF, or "" to accept either format — see
+// WalletAttestationEvaluator.Mode.
+func NewWalletAttestationEvaluator(evaluator TrustEvaluator, verifier *JWTTrustVerifier, mode string) *WalletAttestationEvaluator {
+	return &WalletAttestationEvaluator{TrustEvaluator: evaluator, Verifier: verifier, Mode: mode}
 }
 
 // Evaluate verifies a wallet attestation JWT's signature, then evaluates
@@ -77,6 +99,20 @@ func (e *WalletAttestationEvaluator) Evaluate(ctx context.Context, attestation s
 	identity, err := parseAttestationIdentity(attestation)
 	if err != nil {
 		return nil, err
+	}
+
+	// Enforce the configured trust model, if pinned, before any signature
+	// verification: reject a mismatched WIA cheaply, and never let it reach
+	// the PDP call below with the "wrong" model's KeyType/Key data.
+	switch e.Mode {
+	case WIAModeETSI:
+		if !identity.hasX5C {
+			return nil, errors.New("wallet attestation rejected: this deployment requires the etsi (x5c) trust model, but the WIA has no x5c header")
+		}
+	case WIAModeIETF:
+		if identity.hasX5C {
+			return nil, errors.New("wallet attestation rejected: this deployment requires the ietf (iss/JWKS) trust model, but the WIA has an x5c header")
+		}
 	}
 
 	// Verify the WIA's own signature and resolve its actual signing key

--- a/pkg/trust/wallet_attestation.go
+++ b/pkg/trust/wallet_attestation.go
@@ -113,6 +113,10 @@ func (e *WalletAttestationEvaluator) Evaluate(ctx context.Context, attestation s
 		if identity.hasX5C {
 			return nil, errors.New("wallet attestation rejected: this deployment requires the ietf (iss/JWKS) trust model, but the WIA has an x5c header")
 		}
+	case "":
+		// accept either format, as determined by the WIA itself
+	default:
+		return nil, fmt.Errorf("wallet attestation rejected: invalid trust model mode %q (must be %q, %q, or empty)", e.Mode, WIAModeETSI, WIAModeIETF)
 	}
 
 	// Verify the WIA's own signature and resolve its actual signing key

--- a/pkg/trust/wallet_attestation.go
+++ b/pkg/trust/wallet_attestation.go
@@ -386,37 +386,41 @@ func parseAttestationIdentity(attestation string) (*attestationIdentity, error) 
 
 	// Check for x5c in JWT header
 	if x5cRaw, ok := token.Header["x5c"]; ok {
-		if x5cArr, ok := x5cRaw.([]interface{}); ok && len(x5cArr) > 0 {
-			result.hasX5C = true
-			for _, cert := range x5cArr {
-				if s, ok := cert.(string); ok {
-					result.x5cChain = append(result.x5cChain, s)
-				}
-			}
-
-			// Fail closed: x5c header present but no valid cert strings extracted.
-			// This prevents falling back to self-asserted iss with a malformed x5c.
-			if len(result.x5cChain) == 0 {
-				return nil, errors.New("x5c header present but contains no valid certificate strings")
-			}
-
-			// When x5c is present, identity MUST come from the certificate.
-			// The x5c chain is the cryptographic proof; iss is self-asserted
-			// and must not override the cert-derived identity.
-			if len(result.x5cChain) > 0 {
-				certIdentity, err := issuerFromX5CLeaf(result.x5cChain[0])
-				if err != nil {
-					return nil, fmt.Errorf("failed to extract issuer from x5c: %w", err)
-				}
-				// If iss is present, validate consistency (not strict equality —
-				// iss is typically a URL like "https://host" while cert SAN is
-				// a bare hostname "host")
-				if issClaim != "" && !issMatchesCertIdentity(issClaim, certIdentity) {
-					return nil, fmt.Errorf("iss claim %q does not match x5c certificate identity %q", issClaim, certIdentity)
-				}
-				result.issuer = certIdentity
+		// Fail closed: an x5c header that isn't a non-empty array is malformed.
+		// Treating it as "no x5c" here would let it silently masquerade as an
+		// IETF/iss-only WIA, slipping past WIAModeIETF's "reject any x5c
+		// header" enforcement in Evaluate.
+		x5cArr, isArr := x5cRaw.([]interface{})
+		if !isArr || len(x5cArr) == 0 {
+			return nil, errors.New("x5c header present but malformed (not a non-empty array)")
+		}
+		result.hasX5C = true
+		for _, cert := range x5cArr {
+			if s, ok := cert.(string); ok {
+				result.x5cChain = append(result.x5cChain, s)
 			}
 		}
+
+		// Fail closed: x5c header present but no valid cert strings extracted.
+		// This prevents falling back to self-asserted iss with a malformed x5c.
+		if len(result.x5cChain) == 0 {
+			return nil, errors.New("x5c header present but contains no valid certificate strings")
+		}
+
+		// When x5c is present, identity MUST come from the certificate.
+		// The x5c chain is the cryptographic proof; iss is self-asserted
+		// and must not override the cert-derived identity.
+		certIdentity, err := issuerFromX5CLeaf(result.x5cChain[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract issuer from x5c: %w", err)
+		}
+		// If iss is present, validate consistency (not strict equality —
+		// iss is typically a URL like "https://host" while cert SAN is
+		// a bare hostname "host")
+		if issClaim != "" && !issMatchesCertIdentity(issClaim, certIdentity) {
+			return nil, fmt.Errorf("iss claim %q does not match x5c certificate identity %q", issClaim, certIdentity)
+		}
+		result.issuer = certIdentity
 	}
 
 	// No x5c: use iss claim (IETF draft format — PDP validates via JWKS)

--- a/pkg/trust/wallet_attestation_test.go
+++ b/pkg/trust/wallet_attestation_test.go
@@ -396,6 +396,18 @@ func TestWalletAttestationEvaluator_Evaluate_ModeEnforcement(t *testing.T) {
 			require.NotNil(t, evaluator.lastRequest)
 		}
 	})
+
+	t.Run("invalid mode rejects both formats", func(t *testing.T) {
+		for _, wia := range []string{x5cWIA, ietfWIA} {
+			evaluator := &capturingEvaluator{trustDecision: true}
+			we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), "bogus")
+
+			_, err := we.Evaluate(context.Background(), wia)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid trust model mode")
+			assert.Nil(t, evaluator.lastRequest, "PDP must never be called for an invalid mode")
+		}
+	})
 }
 
 func TestWalletAttestationEvaluator_Evaluate_RejectsSignatureMismatch(t *testing.T) {

--- a/pkg/trust/wallet_attestation_test.go
+++ b/pkg/trust/wallet_attestation_test.go
@@ -292,7 +292,7 @@ func TestWalletAttestationEvaluator_Evaluate_SignatureVerified(t *testing.T) {
 	wia := signTestWIAWithJWK(t, signingKey, "https://wallet-provider.example.com", "instance-jkt-123", "backend_attested")
 
 	evaluator := &capturingEvaluator{trustDecision: true}
-	we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator))
+	we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), "")
 
 	result, err := we.Evaluate(context.Background(), wia)
 	require.NoError(t, err)
@@ -327,7 +327,7 @@ func TestWalletAttestationEvaluator_Evaluate_X5CIssuerFormatMismatchAllowed(t *t
 	wia := signTestWIAWithX5C(t, "wallet-provider.example.com", "https://wallet-provider.example.com", "instance-jkt-123")
 
 	evaluator := &capturingEvaluator{trustDecision: true}
-	we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator))
+	we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), "")
 
 	result, err := we.Evaluate(context.Background(), wia)
 	require.NoError(t, err)
@@ -336,6 +336,66 @@ func TestWalletAttestationEvaluator_Evaluate_X5CIssuerFormatMismatchAllowed(t *t
 
 	require.NotNil(t, evaluator.lastRequest)
 	assert.Equal(t, KeyTypeX5C, evaluator.lastRequest.KeyType)
+}
+
+// TestWalletAttestationEvaluator_Evaluate_ModeEnforcement covers Mode
+// pinning: a deployment configured for one WIA trust model must reject the
+// other before ever reaching the PDP (evaluator.lastRequest must stay nil).
+func TestWalletAttestationEvaluator_Evaluate_ModeEnforcement(t *testing.T) {
+	x5cWIA := signTestWIAWithX5C(t, "wallet-provider.example.com", "https://wallet-provider.example.com", "instance-jkt-123")
+
+	signingKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ietfWIA := signTestWIAWithJWK(t, signingKey, "https://wallet-provider.example.com", "instance-jkt-123", "backend_attested")
+
+	t.Run("etsi mode rejects an iss/JWK-only WIA", func(t *testing.T) {
+		evaluator := &capturingEvaluator{trustDecision: true}
+		we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), WIAModeETSI)
+
+		_, err := we.Evaluate(context.Background(), ietfWIA)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires the etsi")
+		assert.Nil(t, evaluator.lastRequest, "PDP must never be called for a mode-mismatched WIA")
+	})
+
+	t.Run("etsi mode accepts an x5c WIA", func(t *testing.T) {
+		evaluator := &capturingEvaluator{trustDecision: true}
+		we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), WIAModeETSI)
+
+		_, err := we.Evaluate(context.Background(), x5cWIA)
+		require.NoError(t, err)
+		require.NotNil(t, evaluator.lastRequest)
+	})
+
+	t.Run("ietf mode rejects an x5c WIA", func(t *testing.T) {
+		evaluator := &capturingEvaluator{trustDecision: true}
+		we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), WIAModeIETF)
+
+		_, err := we.Evaluate(context.Background(), x5cWIA)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires the ietf")
+		assert.Nil(t, evaluator.lastRequest, "PDP must never be called for a mode-mismatched WIA")
+	})
+
+	t.Run("ietf mode accepts an iss/JWK-only WIA", func(t *testing.T) {
+		evaluator := &capturingEvaluator{trustDecision: true}
+		we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), WIAModeIETF)
+
+		_, err := we.Evaluate(context.Background(), ietfWIA)
+		require.NoError(t, err)
+		require.NotNil(t, evaluator.lastRequest)
+	})
+
+	t.Run("empty mode accepts either format", func(t *testing.T) {
+		for _, wia := range []string{x5cWIA, ietfWIA} {
+			evaluator := &capturingEvaluator{trustDecision: true}
+			we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), "")
+
+			_, err := we.Evaluate(context.Background(), wia)
+			require.NoError(t, err)
+			require.NotNil(t, evaluator.lastRequest)
+		}
+	})
 }
 
 func TestWalletAttestationEvaluator_Evaluate_RejectsSignatureMismatch(t *testing.T) {
@@ -366,7 +426,7 @@ func TestWalletAttestationEvaluator_Evaluate_RejectsSignatureMismatch(t *testing
 	forged := wiaParts[0] + "." + wiaParts[1] + "." + decoyParts[2]
 
 	evaluator := &capturingEvaluator{trustDecision: true}
-	we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator))
+	we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), "")
 
 	_, err = we.Evaluate(context.Background(), forged)
 	require.Error(t, err)
@@ -380,7 +440,7 @@ func TestWalletAttestationEvaluator_Evaluate_UntrustedWalletProvider(t *testing.
 	wia := signTestWIAWithJWK(t, signingKey, "https://wallet-provider.example.com", "instance-jkt-123", "backend_attested")
 
 	evaluator := &capturingEvaluator{trustDecision: false, trustReason: "not in trust list"}
-	we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator))
+	we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), "")
 
 	_, err = we.Evaluate(context.Background(), wia)
 	require.Error(t, err)

--- a/pkg/trust/wallet_attestation_test.go
+++ b/pkg/trust/wallet_attestation_test.go
@@ -267,6 +267,24 @@ func signTestWIAWithX5C(t *testing.T, dnsSAN, iss, sub string) string {
 	return signed
 }
 
+// signTestWIAWithEmptyX5C creates a signed ES256 WIA with a malformed x5c
+// header: the key is present but its value is an empty array, rather than
+// being absent entirely. This must not be treated as "no x5c" (see
+// parseAttestationIdentity's fail-closed handling).
+func signTestWIAWithEmptyX5C(t *testing.T, iss, sub string) string {
+	t.Helper()
+	signingKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{"iss": iss, "sub": sub})
+	token.Header["typ"] = "oauth-client-attestation+jwt"
+	token.Header["x5c"] = []any{}
+
+	signed, err := token.SignedString(signingKey)
+	require.NoError(t, err)
+	return signed
+}
+
 // capturingEvaluator is a TrustEvaluator that records the last EvaluationRequest
 // it received, so tests can assert exactly what was sent to the PDP.
 type capturingEvaluator struct {
@@ -394,6 +412,19 @@ func TestWalletAttestationEvaluator_Evaluate_ModeEnforcement(t *testing.T) {
 			_, err := we.Evaluate(context.Background(), wia)
 			require.NoError(t, err)
 			require.NotNil(t, evaluator.lastRequest)
+		}
+	})
+
+	t.Run("empty-array x5c header is rejected, not silently treated as no-x5c", func(t *testing.T) {
+		malformedWIA := signTestWIAWithEmptyX5C(t, "https://wallet-provider.example.com", "instance-jkt-123")
+		for _, mode := range []string{"", WIAModeETSI, WIAModeIETF} {
+			evaluator := &capturingEvaluator{trustDecision: true}
+			we := NewWalletAttestationEvaluator(evaluator, newTestVerifier(evaluator), mode)
+
+			_, err := we.Evaluate(context.Background(), malformedWIA)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "malformed")
+			assert.Nil(t, evaluator.lastRequest, "PDP must never be called for a malformed x5c header")
 		}
 	})
 


### PR DESCRIPTION
## Summary
Follow-up to #556 (merged). Adds `trust.wallet_attestation.mode`, mirroring the `etsi`/`ietf` terminology just added to go-wallet-backend's `WIAConfig.Mode`, so an operator can pin which WIA trust model this deployment accepts instead of silently accepting whichever format an incoming WIA happens to use.

- `"etsi"`: require x5c (EC TS03 v1.5.2 / ETSI TS 119 472-3 — identity verified against the Trusted List for Wallet Providers). A WIA without x5c is rejected before any signature verification.
- `"ietf"`: require iss + no x5c (the plain IETF draft-ietf-oauth-attestation-based-client-auth format, resolved via JWKS discovery — no ARF/ETSI counterpart). A WIA with x5c is rejected the same way.
- `""` (default): accept either, preserving current behavior for deployments that haven't opted in.

Enforcement happens in `WalletAttestationEvaluator.Evaluate` before signature verification, so a mismatched WIA never reaches the go-trust PDP call with the "wrong" model's KeyType/Key data.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/trust/... ./internal/apigw/...` (new `ModeEnforcement` subtests cover all four etsi/ietf × x5c/iss-only combinations)
- [x] gofmt clean