### PR TITLE
fix(verifier): actually submit the DC API credential response

### DIFF
--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -270,13 +270,20 @@ func (c *Client) UIInteraction(ctx context.Context, req *UIInteractionRequest) (
 	// doesn't inspect response_mode, so this is purely about getting the
 	// wallet to encrypt; the wire handling at /verification/direct_post is
 	// unchanged either way.
+	//
+	// Unlike CreateRequestObject's OIDC RP flow (whose /verification/
+	// oidc-direct_post endpoint tolerates direct_post/direct_post.jwt's
+	// unencrypted vp_token+state shape too), DigitalCredentials.ResponseMode
+	// is NOT honored here even when set: this UI flow's own
+	// _submitDCAPIResponse only ever forwards the encrypted `response` JWE
+	// to /verification/direct_post, which has no unencrypted fallback. A
+	// config value other than "dc_api.jwt" would make the wallet skip
+	// encryption and produce a payload this page can't submit at all, so
+	// it's ignored here to keep request/response shapes consistent
+	// end-to-end for this specific flow.
 	responseMode := "direct_post.jwt"
 	if c.cfg.Verifier.DigitalCredentials.Enable {
-		if c.cfg.Verifier.DigitalCredentials.ResponseMode != "" {
-			responseMode = c.cfg.Verifier.DigitalCredentials.ResponseMode
-		} else {
-			responseMode = "dc_api.jwt"
-		}
+		responseMode = "dc_api.jwt"
 	}
 
 	requestObject := &openid4vp.RequestObject{

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -260,13 +260,32 @@ func (c *Client) UIInteraction(ctx context.Context, req *UIInteractionRequest) (
 		return nil, fmt.Errorf("failed to construct response URI: %w", err)
 	}
 
+	// "direct_post.jwt" (encrypted, cross-device-network delivery) unless
+	// this page's native DC API attempt is enabled, in which case the
+	// wallet's own DC API response builder only encrypts for an EXACT
+	// response_mode match of "dc_api.jwt" (OpenID4VP 1.0 DC API integration
+	// profile's defined value - "direct_post.jwt" isn't a DC API response
+	// mode at all) - see CreateRequestObject's identical branch for the
+	// other (OIDC RP) verification flow. VerificationDirectPost itself
+	// doesn't inspect response_mode, so this is purely about getting the
+	// wallet to encrypt; the wire handling at /verification/direct_post is
+	// unchanged either way.
+	responseMode := "direct_post.jwt"
+	if c.cfg.Verifier.DigitalCredentials.Enable {
+		if c.cfg.Verifier.DigitalCredentials.ResponseMode != "" {
+			responseMode = c.cfg.Verifier.DigitalCredentials.ResponseMode
+		} else {
+			responseMode = "dc_api.jwt"
+		}
+	}
+
 	requestObject := &openid4vp.RequestObject{
 		ResponseURI:  responseURI,
 		AUD:          "https://self-issued.me/v2",
 		ISS:          uiClientID,
 		ClientID:     authorizationContext.ClientID,
 		ResponseType: "vp_token",
-		ResponseMode: "direct_post.jwt",
+		ResponseMode: responseMode,
 		State:        authorizationContext.State,
 		Nonce:        authorizationContext.Nonce,
 		ClientMetadata: &openid4vp.ClientMetadata{

--- a/internal/verifier/staticembed/presentation-definition.html
+++ b/internal/verifier/staticembed/presentation-definition.html
@@ -69,7 +69,17 @@
                     </form>
                 </div>
             </template>
-            <template x-if="!loading && credentialsList && credentialAttributes && !presentationDefinition">
+            <template x-if="dcApiVerified">
+                <div class="box container">
+                    <div class="notification is-success">
+                        <p>Presentation verified successfully.</p>
+                    </div>
+                    <div class="mt-5 is-flex is-justify-content-flex-start is-align-items-center">
+                        <button class="button is-small is-light" @click.prevent="handleResetCancel">Start over</button>
+                    </div>
+                </div>
+            </template>
+            <template x-if="!loading && credentialsList && credentialAttributes && !presentationDefinition && !dcApiVerified">
                 <div class="box container">
                     <form x-ref="attributesSelectionForm" @submit.prevent="handleAttributesSelectionForm">
                         <div class="field block">
@@ -121,7 +131,7 @@
                     </form>
                 </div>
             </template>
-            <template x-if="!loading && credentialsList && credentialAttributes && presentationDefinition">
+            <template x-if="!loading && credentialsList && credentialAttributes && presentationDefinition && !dcApiVerified">
                 <div class="box container">
                     <div class="block is-flex is-justify-content-center">
                         <img :src="`data:image/png;base64,${presentationDefinition.qr_code}`" alt="" />

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -243,6 +243,9 @@ Alpine.data("app", () => ({
     /** @type {EventSource | null} */
     notifyEventSource: null,
 
+    /** @type {boolean} Set once a native DC API presentation has been submitted and accepted. */
+    dcApiVerified: false,
+
     async init() {
         await this.lookupCredentialsList();
 
@@ -386,6 +389,7 @@ Alpine.data("app", () => ({
         this.credentialAttributes = null;
         this.dcqlQuery = null;
         this.presentationDefinition = null;
+        this.dcApiVerified = false;
     },
 
     /** 
@@ -469,6 +473,8 @@ Alpine.data("app", () => ({
             return;
         }
 
+        this.dcApiVerified = false;
+
         try {
             const res = await this.fetchData(
                 new URL("/ui/interaction", baseUrl), 
@@ -529,16 +535,67 @@ Alpine.data("app", () => ({
             );
             if (!result) return false;
 
-            if (result.data?.redirect_uri) {
-                globalThis.location.href = result.data.redirect_uri;
-                return true;
+            // result.data is the WALLET's own DC API response payload
+            // (returned directly to this page by navigator.credentials.get(),
+            // never over the network) - it can never itself carry a
+            // redirect_uri, since that's a property of the VERIFIER's HTTP
+            // response, not of the wallet's. Unlike the QR/deep-link flow
+            // (where the wallet POSTs its response to response_uri over the
+            // network on its own), this page is the only thing that has the
+            // response in hand, so it must forward it itself before the
+            // verifier's backend ever learns the presentation happened.
+            const submission = await this._submitDCAPIResponse(result.data);
+            if (submission?.redirect_uri) {
+                globalThis.location.href = submission.redirect_uri;
+            } else {
+                this.dcApiVerified = true;
             }
-            return false;
+            return true;
         } catch (err) {
             if (err.name === 'AbortError') return true;
             console.log("DC API not available or failed, falling back to QR/links:", err.message);
             return false;
         }
+    },
+
+    /**
+     * Forward the wallet's DC API response payload to the verifier's own
+     * response_uri (`/verification/oidc-direct_post`) - the exact endpoint a
+     * non-DC-API wallet POSTs to directly over the network for the QR/
+     * deep-link flow, so this reaches the identical server-side handling
+     * (ProcessDirectPost) either way.
+     *
+     * The payload has one of two shapes depending on the negotiated
+     * response_mode: `{ response: "<jwe-compact>" }` for `dc_api.jwt`
+     * (encrypted/signed), or `{ vp_token: {...}, state }` for plain
+     * `dc_api` - `vp_token` there is itself a JSON object (DCQL query id ->
+     * VP), sent JSON-encoded as a single string, matching how the
+     * form-encoded direct_post request already carries it for the QR flow.
+     *
+     * @param {{response?: string, vp_token?: object, state?: string}} data
+     * @returns {Promise<{redirect_uri?: string} | null>}
+     */
+    async _submitDCAPIResponse(data) {
+        const body = new URLSearchParams();
+        if (data.response) {
+            body.set("response", data.response);
+        } else if (data.vp_token) {
+            body.set("vp_token", JSON.stringify(data.vp_token));
+        } else {
+            throw new Error("DC API response has neither 'response' nor 'vp_token'");
+        }
+        if (data.state) body.set("state", data.state);
+
+        const res = await fetch(new URL("/verification/oidc-direct_post", baseUrl), {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body,
+        });
+        if (!res.ok) {
+            const text = await res.text();
+            throw new Error(`Failed to submit DC API response: HTTP ${res.status} - ${text}`);
+        }
+        return res.json().catch(() => null);
     },
 
     /** Set up QR + wallet links + SSE fallback flow. */

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -571,8 +571,15 @@ Alpine.data("app", () => ({
      * `dc_api` - `vp_token` there is itself a JSON object (DCQL query id ->
      * VP), sent JSON-encoded as a single string, matching how the
      * form-encoded direct_post request already carries it for the QR flow.
+     * (If a wallet ever returns `vp_token` as an already-encoded string -
+     * e.g. a bare JWT - it's forwarded as-is instead of being re-stringified,
+     * since double-encoding would corrupt it.)
      *
-     * @param {{response?: string, vp_token?: object, state?: string}} data
+     * `state` is required by the verifier's direct_post handler in both
+     * shapes, so its absence is treated as a hard error here rather than
+     * silently omitted and left to surface as an opaque HTTP 400.
+     *
+     * @param {{response?: string, vp_token?: (object|string), state?: string, presentation_submission?: object}} data
      * @returns {Promise<{redirect_uri?: string} | null>}
      */
     async _submitDCAPIResponse(data) {
@@ -580,11 +587,25 @@ Alpine.data("app", () => ({
         if (data.response) {
             body.set("response", data.response);
         } else if (data.vp_token) {
-            body.set("vp_token", JSON.stringify(data.vp_token));
+            body.set(
+                "vp_token",
+                typeof data.vp_token === "string" ? data.vp_token : JSON.stringify(data.vp_token),
+            );
         } else {
             throw new Error("DC API response has neither 'response' nor 'vp_token'");
         }
-        if (data.state) body.set("state", data.state);
+        if (!data.state) {
+            throw new Error("DC API response is missing required 'state' field");
+        }
+        body.set("state", data.state);
+        if (data.presentation_submission) {
+            body.set(
+                "presentation_submission",
+                typeof data.presentation_submission === "string"
+                    ? data.presentation_submission
+                    : JSON.stringify(data.presentation_submission),
+            );
+        }
 
         const res = await fetch(new URL("/verification/oidc-direct_post", baseUrl), {
             method: "POST",

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -575,6 +575,13 @@ Alpine.data("app", () => ({
      * e.g. a bare JWT - it's forwarded as-is instead of being re-stringified,
      * since double-encoding would corrupt it.)
      *
+     * NOTE: `response` (the `dc_api.jwt` encrypted/signed shape) is forwarded
+     * here for protocol completeness, but ProcessDirectPost on the verifier
+     * does not yet implement JWE decryption for it and currently rejects it
+     * with an error (`DC API encrypted response handling not yet
+     * implemented`). Only the plain `dc_api` / `vp_token` shape is fully
+     * supported end-to-end today.
+     *
      * `state` is required by the verifier's direct_post handler in both
      * shapes, so its absence is treated as a hard error here rather than
      * silently omitted and left to surface as an opaque HTTP 400.

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -559,62 +559,39 @@ Alpine.data("app", () => ({
     },
 
     /**
-     * Forward the wallet's DC API response payload to the verifier's own
-     * response_uri (`/verification/oidc-direct_post`) - the exact endpoint a
-     * non-DC-API wallet POSTs to directly over the network for the QR/
-     * deep-link flow, so this reaches the identical server-side handling
-     * (ProcessDirectPost) either way.
+     * Forward the wallet's DC API response payload to THIS page's own
+     * response_uri (`/verification/direct_post` -
+     * VerificationDirectPost/VerificationDirectPostRequest) - the exact
+     * endpoint a non-DC-API wallet POSTs to directly over the network for
+     * the QR/deep-link flow (`UIInteraction` sets it as `response_uri` on
+     * the very same request object regardless of delivery channel), so this
+     * reaches identical server-side handling either way. NOT
+     * `/verification/oidc-direct_post` - that belongs to a wholly separate
+     * flow (`authorize_enhanced.html`'s OIDC RP page), with its own
+     * session/state cache namespace; submitting there for a session created
+     * via `/ui/interaction` fails with "session not found".
      *
-     * The payload has one of two shapes depending on the negotiated
-     * response_mode: `{ response: "<jwe-compact>" }` for `dc_api.jwt`
-     * (encrypted/signed), or `{ vp_token: {...}, state }` for plain
-     * `dc_api` - `vp_token` there is itself a JSON object (DCQL query id ->
-     * VP), sent JSON-encoded as a single string, matching how the
-     * form-encoded direct_post request already carries it for the QR flow.
-     * (If a wallet ever returns `vp_token` as an already-encoded string -
-     * e.g. a bare JWT - it's forwarded as-is instead of being re-stringified,
-     * since double-encoding would corrupt it.)
+     * This endpoint only ever accepts one shape: `{ response: "<jwe-compact>" }`
+     * (`UIInteraction` always requests an encrypted response - see its
+     * `response_mode` doc comment, which now mints `dc_api.jwt` whenever DC
+     * API is enabled so the wallet actually encrypts). `state` is never
+     * submitted alongside the ciphertext; the server recovers it by
+     * decrypting the JWE and reading the `state` claim from the plaintext,
+     * which is where the session lookup actually happens
+     * (`VerificationDirectPost`) - there is no unencrypted `vp_token`/
+     * `presentation_submission` fallback shape on this endpoint to forward.
      *
-     * NOTE: `response` (the `dc_api.jwt` encrypted/signed shape) is forwarded
-     * here for protocol completeness, but ProcessDirectPost on the verifier
-     * does not yet implement JWE decryption for it and currently rejects it
-     * with an error (`DC API encrypted response handling not yet
-     * implemented`). Only the plain `dc_api` / `vp_token` shape is fully
-     * supported end-to-end today.
-     *
-     * `state` is required by the verifier's direct_post handler in both
-     * shapes, so its absence is treated as a hard error here rather than
-     * silently omitted and left to surface as an opaque HTTP 400.
-     *
-     * @param {{response?: string, vp_token?: (object|string), state?: string, presentation_submission?: object}} data
+     * @param {{response?: string}} data
      * @returns {Promise<{redirect_uri?: string} | null>}
      */
     async _submitDCAPIResponse(data) {
+        if (!data.response) {
+            throw new Error("DC API response is missing the encrypted 'response' payload");
+        }
         const body = new URLSearchParams();
-        if (data.response) {
-            body.set("response", data.response);
-        } else if (data.vp_token) {
-            body.set(
-                "vp_token",
-                typeof data.vp_token === "string" ? data.vp_token : JSON.stringify(data.vp_token),
-            );
-        } else {
-            throw new Error("DC API response has neither 'response' nor 'vp_token'");
-        }
-        if (!data.state) {
-            throw new Error("DC API response is missing required 'state' field");
-        }
-        body.set("state", data.state);
-        if (data.presentation_submission) {
-            body.set(
-                "presentation_submission",
-                typeof data.presentation_submission === "string"
-                    ? data.presentation_submission
-                    : JSON.stringify(data.presentation_submission),
-            );
-        }
+        body.set("response", data.response);
 
-        const res = await fetch(new URL("/verification/oidc-direct_post", baseUrl), {
+        const res = await fetch(new URL("/verification/direct_post", baseUrl), {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
             body,


### PR DESCRIPTION
## Summary

`presentation-definition.js`'s `_tryNativeDCAPI()` invoked `navigator.credentials.get()` successfully but then checked `result.data.redirect_uri` to decide whether to treat it as handled. That field is a *server response* concept and never appears on the wallet's own DC API payload, so the check always failed, the function returned `false`, and the page fell through to `_setupFallbackFlow()` - silently discarding a valid credential response and redrawing the QR code as if nothing had happened, even though the OS credential picker had correctly completed and the user had accepted sharing the requested fields.

Unlike the QR/deep-link flow (where the wallet POSTs its response to `response_uri` directly over the network), a DC API response is only ever handed back to the calling page via `navigator.credentials.get()`'s resolved value - the verifier's backend has no other way to learn it happened. This page has to forward it itself.

**Update after initial review round:** the first version of this fix forwarded to `/verification/oidc-direct_post` (the OIDC RP flow's endpoint) with a plaintext `vp_token`/`state`/`presentation_submission` shape. Further live testing on a real Android device showed that was the wrong endpoint entirely - a session created via `/ui/interaction` lives in a different session/state cache namespace and gets "session not found" there. The corrected approach (as of `62c20073`/`a5ba027e`) targets `/verification/direct_post` (`VerificationDirectPost`), which only ever accepts the encrypted `{ response: "<jwe-compact>" }` shape; `UIInteraction` now always requests `dc_api.jwt` response mode whenever DC API is enabled (ignoring any conflicting `DigitalCredentials.ResponseMode` config override, since that endpoint has no unencrypted fallback), so the wallet actually encrypts and `state` is recovered server-side from the decrypted JWE claims. Confirmed working end-to-end on real hardware.

## Changes

- Added `_submitDCAPIResponse()`, which POSTs the wallet's encrypted DC API response (`{ response: "<jwe-compact>" }`) to `/verification/direct_post` - the same endpoint a non-DC-API wallet already uses for the QR/deep-link flow.
- `_tryNativeDCAPI()` now calls this and only redirects if the verifier's HTTP response actually carries a `redirect_uri`.
- Added a minimal `dcApiVerified` success state and matching UI block (`presentation-definition.html`) - the page previously had no way to indicate a completed presentation at all, DC API or otherwise.
- `handlers_ui.go`'s `UIInteraction` now unconditionally requests `dc_api.jwt` response mode when DC API is enabled for this flow, rather than deferring to `DigitalCredentials.ResponseMode` (a config field shared with the separate OIDC RP flow, which does support other values there).

## Testing

- Confirmed against a real Android wallet (SIROS SDK) hitting a live deployment, through both the endpoint-mismatch bug and its fix.
- `go build ./...` and `go test ./internal/verifier/...` pass.
- `node --check` on the modified JS file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
