### PR TITLE
fix: sort wallets in verifier oidc op authorize view

### DIFF
--- a/internal/verifier/apiv1/handler_oidc.go
+++ b/internal/verifier/apiv1/handler_oidc.go
@@ -208,6 +208,10 @@ func (c *Client) Authorize(ctx context.Context, req *AuthorizeRequest) (*Authori
 			QRCodeImageURL: walletQRURL,
 		})
 	}
+	// Maps have randomized iteration order; sort so the UI is stable across reloads.
+	slices.SortFunc(response.WalletLinks, func(a, b WalletLink) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	// Add Digital Credentials API configuration
 	response.PreferredFormats = c.cfg.Verifier.DigitalCredentials.PreferredFormats

--- a/internal/verifier/apiv1/handler_oidc_test.go
+++ b/internal/verifier/apiv1/handler_oidc_test.go
@@ -1517,6 +1517,9 @@ func TestAuthorize_WalletLinks(t *testing.T) {
 	}
 	assert.Contains(t, walletNames["SUNET Wallet"], "https://wallet.sunet.se/cb?")
 	assert.Contains(t, walletNames["Test Wallet"], "https://test-wallet.example.com/authorize?")
+
+	// Order must be stable (sorted by name) — map iteration would shuffle them
+	assert.Equal(t, []string{"SUNET Wallet", "Test Wallet"}, []string{resp.WalletLinks[0].Name, resp.WalletLinks[1].Name})
 }
 
 // TestAuthorize_NoWalletLinks tests that no wallet links when supported_wallets is empty


### PR DESCRIPTION
When using the OIDC OP feature in the verifier and having multiple configured wallets, the order of the wallets changed on every reload, which made it easy to accidentally use the wrong wallet.