### PR TITLE
fix: send redirect_uri in same-device verifier oidc op flow

### DIFF
--- a/internal/verifier/apiv1/handler_oidc.go
+++ b/internal/verifier/apiv1/handler_oidc.go
@@ -752,11 +752,26 @@ func (c *Client) ProcessDirectPost(ctx context.Context, req *DirectPostRequest) 
 
 	c.log.Info("VP processed successfully", "session_id", session.SessionID, "claims_count", len(oidcClaims))
 
-	// Do NOT return redirect_uri here. The browser's /authorize page polls
-	// for session status and handles the redirect to the RP. Returning
-	// redirect_uri would cause the wallet to also redirect, consuming the
-	// authorization code before the browser can use it.
-	return &DirectPostResponse{}, nil
+	// Cross-device (QR / native wallet): the /authorize page is still
+	// polling and will redirect the original browser to the RP. Returning
+	// redirect_uri here would also send the wallet there and race on the
+	// one-time authorization code.
+	//
+	// Same-device web wallet: the user left /authorize, so nothing is
+	// polling. Return the RP callback so the wallet can navigate there.
+	if !session.WalletFollowsRedirect {
+		return &DirectPostResponse{}, nil
+	}
+
+	redirectURI, err := authorizationCodeRedirectURI(session)
+	if err != nil {
+		c.log.Error(err, "Failed to parse redirect URI")
+		return nil, ErrServerError
+	}
+
+	return &DirectPostResponse{
+		RedirectURI: redirectURI,
+	}, nil
 }
 
 // CallbackRequest represents a callback request
@@ -937,19 +952,33 @@ func (c *Client) PollSession(ctx context.Context, req *PollSessionRequest) (*Pol
 
 	// If code is issued, provide redirect URI
 	if session.Status == cache.SessionStatusCodeIssued {
-		u, err := url.Parse(session.RedirectURI)
+		redirectURI, err := authorizationCodeRedirectURI(session)
 		if err != nil {
 			c.log.Error(err, "Failed to parse redirect URI")
 			return nil, ErrServerError
 		}
-		q := u.Query()
-		q.Set("code", session.Code)
-		q.Set("state", session.State)
-		u.RawQuery = q.Encode()
-		response.RedirectURI = u.String()
+		response.RedirectURI = redirectURI
 	}
 
 	return response, nil
+}
+
+// authorizationCodeRedirectURI builds the RP callback URL with the issued
+// authorization code and original state. Empty when the session has no
+// redirect_uri (the wallet then stays put; the poller has nothing to follow).
+func authorizationCodeRedirectURI(session *cache.AuthorizationContext) (string, error) {
+	if session == nil || session.RedirectURI == "" {
+		return "", nil
+	}
+	u, err := url.Parse(session.RedirectURI)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("code", session.Code)
+	q.Set("state", session.State)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 // UserInfoRequest represents a UserInfo endpoint request

--- a/internal/verifier/apiv1/handler_oidc_test.go
+++ b/internal/verifier/apiv1/handler_oidc_test.go
@@ -2175,6 +2175,7 @@ func TestProcessDirectPost(t *testing.T) {
 		expectError            bool
 		expectedErrorType      error
 		expectShowCredentials  bool
+		expectWalletRedirect   bool
 		expectedStatus         cache.SessionStatus
 	}{
 		{ // #nosec G101
@@ -2269,6 +2270,33 @@ func TestProcessDirectPost(t *testing.T) {
 			expectError:    false,
 			expectedStatus: cache.SessionStatusCodeIssued,
 		},
+		{ // #nosec G101
+			name:      "same-device web wallet returns RP redirect_uri",
+			sessionID: "session-dp-8",
+			vpToken:   "eyJhbGciOiJFUzI1NiJ9.test-payload.signature",
+			authCtxSetup: func(s *cache.AuthorizationContext) {
+				s.Status = cache.SessionStatusPending
+				s.RedirectURI = "https://client.example.com/callback"
+				s.State = "client-state"
+				s.WalletFollowsRedirect = true
+			},
+			expectError:          false,
+			expectWalletRedirect: true,
+			expectedStatus:       cache.SessionStatusCodeIssued,
+		},
+		{ // #nosec G101
+			name:      "same-device web wallet without redirect URI",
+			sessionID: "session-dp-9",
+			vpToken:   "eyJhbGciOiJFUzI1NiJ9.test-payload.signature",
+			authCtxSetup: func(s *cache.AuthorizationContext) {
+				s.Status = cache.SessionStatusPending
+				s.RedirectURI = ""
+				s.State = "client-state"
+				s.WalletFollowsRedirect = true
+			},
+			expectError:    false,
+			expectedStatus: cache.SessionStatusCodeIssued,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2318,14 +2346,46 @@ func TestProcessDirectPost(t *testing.T) {
 				if tt.expectShowCredentials {
 					// Should redirect to display page
 					assert.Contains(t, resp.RedirectURI, "/verification/display/")
+				} else if tt.expectWalletRedirect {
+					assert.Contains(t, resp.RedirectURI, "https://client.example.com/callback")
+					assert.Contains(t, resp.RedirectURI, "state=client-state")
+					assert.Contains(t, resp.RedirectURI, "code="+authCtx.Code)
 				} else {
-					// Direct post must NOT return redirect_uri; the browser
-					// picks up the redirect via the poll endpoint instead.
+					// Cross-device: omit redirect_uri so the /authorize
+					// poller performs the RP redirect instead of the wallet.
 					assert.Empty(t, resp.RedirectURI)
 				}
 			}
 		})
 	}
+}
+
+func TestAuthorizationCodeRedirectURI(t *testing.T) {
+	t.Run("nil session", func(t *testing.T) {
+		got, err := authorizationCodeRedirectURI(nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+	t.Run("empty redirect URI", func(t *testing.T) {
+		got, err := authorizationCodeRedirectURI(&cache.AuthorizationContext{
+			Code:  "abc",
+			State: "xyz",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+	t.Run("appends code and state", func(t *testing.T) {
+		got, err := authorizationCodeRedirectURI(&cache.AuthorizationContext{
+			RedirectURI: "https://rp.example.com/cb?foo=bar",
+			Code:        "auth-code",
+			State:       "rp-state",
+		})
+		require.NoError(t, err)
+		assert.Contains(t, got, "https://rp.example.com/cb")
+		assert.Contains(t, got, "foo=bar")
+		assert.Contains(t, got, "code=auth-code")
+		assert.Contains(t, got, "state=rp-state")
+	})
 }
 
 // TestContainsOIDC tests the containsOIDC helper method

--- a/internal/verifier/apiv1/handler_session_preference.go
+++ b/internal/verifier/apiv1/handler_session_preference.go
@@ -14,6 +14,11 @@ import (
 type UpdateSessionPreferenceRequest struct {
 	SessionID             string `json:"session_id" binding:"required" validate:"required,max=128,printascii"`
 	ShowCredentialDetails bool   `json:"show_credential_details"`
+	// WalletFollowsRedirect is optional. When non-nil it records that the
+	// user is continuing in a same-device web wallet that should follow
+	// redirect_uri from direct_post. Omitted on credential-display saves
+	// so those POSTs do not clear a previously set flag.
+	WalletFollowsRedirect *bool `json:"wallet_follows_redirect"`
 }
 
 // UpdateSessionPreferenceResponse contains the response
@@ -34,6 +39,9 @@ func (c *Client) UpdateSessionPreference(ctx context.Context, req *UpdateSession
 
 	// Update preference
 	authCtx.ShowCredentialDetails = req.ShowCredentialDetails
+	if req.WalletFollowsRedirect != nil {
+		authCtx.WalletFollowsRedirect = *req.WalletFollowsRedirect
+	}
 
 	if err := c.cacheService.AuthContext.Update(ctx, authCtx); err != nil {
 		c.log.Error(err, "Failed to update session preference")

--- a/internal/verifier/apiv1/handler_session_preference_test.go
+++ b/internal/verifier/apiv1/handler_session_preference_test.go
@@ -79,7 +79,42 @@ func TestUpdateSessionPreference(t *testing.T) {
 	}
 }
 
-// TestConfirmCredentialDisplay tests the ConfirmCredentialDisplay handler
+func TestUpdateSessionPreference_WalletFollowsRedirect(t *testing.T) {
+	ctx := t.Context()
+	client, _ := CreateTestClientWithMock(nil)
+
+	authCtx := createTestDBSessionForPrefs("session-wallet-redirect")
+	authCtx.ShowCredentialDetails = true
+	require.NoError(t, client.cacheService.AuthContext.Create(ctx, authCtx))
+
+	flag := true
+	resp, err := client.UpdateSessionPreference(ctx, &UpdateSessionPreferenceRequest{
+		SessionID:             "session-wallet-redirect",
+		ShowCredentialDetails: true,
+		WalletFollowsRedirect: &flag,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Success)
+
+	updated, err := client.cacheService.AuthContext.GetByID(ctx, "session-wallet-redirect")
+	require.NoError(t, err)
+	assert.True(t, updated.WalletFollowsRedirect)
+	assert.True(t, updated.ShowCredentialDetails)
+
+	// A later display-preference save must not clear the flag.
+	resp, err = client.UpdateSessionPreference(ctx, &UpdateSessionPreferenceRequest{
+		SessionID:             "session-wallet-redirect",
+		ShowCredentialDetails: false,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	updated, err = client.cacheService.AuthContext.GetByID(ctx, "session-wallet-redirect")
+	require.NoError(t, err)
+	assert.True(t, updated.WalletFollowsRedirect, "omitting wallet_follows_redirect must leave the flag set")
+	assert.False(t, updated.ShowCredentialDetails)
+}
 func TestConfirmCredentialDisplay(t *testing.T) {
 	ctx := t.Context()
 

--- a/internal/verifier/httpserver/endpoints_openid4vp.go
+++ b/internal/verifier/httpserver/endpoints_openid4vp.go
@@ -75,9 +75,10 @@ func (s *Service) endpointOIDCDirectPost(ctx context.Context, c *gin.Context) (a
 	}
 
 	// Per OpenID4VP spec Section 7.2, the direct_post response MUST be
-	// 200 OK with a JSON body. A 302 redirect would cause the wallet to
-	// follow it and consume the authorization code before the browser can.
-	// The browser picks up the redirect via the poll endpoint instead.
+	// 200 OK with a JSON body. A 302 would make the wallet HTTP client
+	// follow the Location and consume the authorization code. Same-device
+	// web wallets instead get redirect_uri in the JSON body; cross-device
+	// flows omit it so the original /authorize tab can poll and redirect.
 	if response.RedirectURI != "" {
 		c.JSON(http.StatusOK, gin.H{
 			"redirect_uri": response.RedirectURI,

--- a/internal/verifier/staticembed/authorize_enhanced.html
+++ b/internal/verifier/staticembed/authorize_enhanced.html
@@ -360,7 +360,7 @@
                     {{range .WalletLinks}}
                     <div class="wallet-link-item" style="border: 1px solid var(--border-color, #e2e8f0); border-radius: 8px; padding: 12px;">
                         <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
-                            <a href="{{.URL}}" class="btn btn-secondary" style="text-decoration: none; text-align: center; flex: 1;">
+                            <a href="{{.URL}}" class="btn btn-secondary js-web-wallet-link" style="text-decoration: none; text-align: center; flex: 1;">
                                 🌐 Open {{.Name}}
                             </a>
                             <button class="btn btn-secondary wallet-qr-toggle" data-wallet-name="{{.Name}}" style="white-space: nowrap; padding: 8px 12px;" title="Show QR code to scan from another device">
@@ -679,6 +679,49 @@
                 if (qrDiv) {
                     const isHidden = qrDiv.classList.toggle('hidden');
                     btn.textContent = isHidden ? '📷 QR' : '✕ Hide QR';
+                }
+            });
+        });
+
+        // Same-device web wallet: tell the verifier this browser is leaving
+        // /authorize so direct_post can return redirect_uri. Cross-device
+        // (QR, modified-click new tab) keeps polling on this page instead.
+        async function markWalletFollowsRedirect() {
+            const showDetails = showCredentialDetailsCheckbox
+                ? showCredentialDetailsCheckbox.checked
+                : false;
+            const response = await fetch('/verification/session-preference', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    session_id: config.sessionId,
+                    show_credential_details: showDetails,
+                    wallet_follows_redirect: true,
+                }),
+                keepalive: true,
+            });
+            if (!response.ok) {
+                throw new Error(`Failed to mark same-device flow: ${response.status}`);
+            }
+        }
+
+        document.querySelectorAll('.js-web-wallet-link').forEach(link => {
+            link.addEventListener('click', async (event) => {
+                if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                    return;
+                }
+                event.preventDefault();
+                const url = link.href;
+                try {
+                    await markWalletFollowsRedirect();
+                    if (pollInterval) {
+                        clearInterval(pollInterval);
+                        pollInterval = null;
+                    }
+                    window.location.href = url;
+                } catch (err) {
+                    console.error('Failed to mark same-device flow, opening wallet in a new tab so this page can still redirect', err);
+                    window.open(url, '_blank', 'noopener');
                 }
             });
         });

--- a/pkg/cache/authcontext_types.go
+++ b/pkg/cache/authcontext_types.go
@@ -92,6 +92,11 @@ type AuthorizationContext struct {
 	ResponseType           string         `json:"response_type,omitempty" bson:"response_type,omitempty" validate:"omitempty,max=32,printascii"`
 	ResponseMode           string         `json:"response_mode,omitempty" bson:"response_mode,omitempty" validate:"omitempty,max=32,printascii"`
 	ShowCredentialDetails  bool           `json:"show_credential_details,omitempty" bson:"show_credential_details,omitempty"`
+	// WalletFollowsRedirect is set when the user leaves /authorize for a
+	// same-device web wallet. ProcessDirectPost then returns redirect_uri so
+	// the wallet can send the browser back to the RP. Cross-device flows
+	// leave this false; the /authorize page poller performs the redirect.
+	WalletFollowsRedirect  bool           `json:"wallet_follows_redirect,omitempty" bson:"wallet_follows_redirect,omitempty"`
 	CodeExpiresAt          int64          `json:"code_expires_at,omitempty" bson:"code_expires_at,omitempty"`                 // Unix timestamp
 	AccessTokenExpiresAt   int64          `json:"access_token_expires_at,omitempty" bson:"access_token_expires_at,omitempty"` // Unix timestamp
 	RefreshToken           string         `json:"refresh_token,omitempty" bson:"refresh_token,omitempty" validate:"omitempty,max=4096,printascii"`


### PR DESCRIPTION
In same-device flows, the redirect_uri was never sent to the wallet. This resulted in a successful credential validation but the user was never redirected to their destination.

Tested with both same-device and cross-device flows.