### PR TITLE
feat: dns-prefetch redirect_uri in verifier oidc op flow

### DIFF
--- a/internal/verifier/httpserver/endpoints_oidc.go
+++ b/internal/verifier/httpserver/endpoints_oidc.go
@@ -104,6 +104,7 @@ func (s *Service) endpointAuthorize(ctx context.Context, c *gin.Context) (any, e
 		"CustomCSS":        response.CustomCSS,
 		"CSSFile":          response.CSSFile,
 		"LogoURL":          response.LogoURL,
+		"RedirectURI":      template.URL(request.RedirectURI),
 		"Config": gin.H{
 			"DigitalCredentials": gin.H{
 				"Enable":          s.cfg.Verifier.DigitalCredentials.Enable,

--- a/internal/verifier/httpserver/endpoints_oidc.go
+++ b/internal/verifier/httpserver/endpoints_oidc.go
@@ -104,7 +104,7 @@ func (s *Service) endpointAuthorize(ctx context.Context, c *gin.Context) (any, e
 		"CustomCSS":        response.CustomCSS,
 		"CSSFile":          response.CSSFile,
 		"LogoURL":          response.LogoURL,
-		"RedirectURI":      template.URL(request.RedirectURI),
+		"RedirectURI":      request.RedirectURI,
 		"Config": gin.H{
 			"DigitalCredentials": gin.H{
 				"Enable":          s.cfg.Verifier.DigitalCredentials.Enable,

--- a/internal/verifier/staticembed/authorize_enhanced.html
+++ b/internal/verifier/staticembed/authorize_enhanced.html
@@ -266,6 +266,9 @@
     <link rel="stylesheet" href="{{.CSSFile}}">
     {{end}}
     <link rel="icon" href="/static/favicon.png" type="image/png">
+    {{if .RedirectURI}}
+    <link rel="dns-prefetch" href="{{.RedirectURI}}">
+    {{end}}
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
Small speedup in the verifier OIDC OP authorize flow by using DNS-prefetching the redirect_uri.