### PR TITLE
registry: don't block credential issuance on synchronous status-list cache refresh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	go.uber.org/zap v1.28.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.83.0
 	google.golang.org/protobuf v1.36.11
@@ -213,7 +214,6 @@ require (
 	golang.org/x/arch v0.29.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect

--- a/internal/registry/tokenstatuslistissuer/async_refresh_test.go
+++ b/internal/registry/tokenstatuslistissuer/async_refresh_test.go
@@ -1,0 +1,186 @@
+package tokenstatuslistissuer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SUNET/vc/internal/registry/cache"
+	"github.com/SUNET/vc/internal/registry/db"
+)
+
+// fakeTokenStatusListStore is a minimal db.TokenStatusListStore whose
+// GetAllStatusesForSection can be made to block for as long as the test wants,
+// standing in for the full-section fetch that (per the benchmark run against a
+// real MongoDB instance with a realistic 1,000,000-entry section) takes on the
+// order of 15-20 seconds in a production-sized deployment.
+type fakeTokenStatusListStore struct {
+	// blockGetAll, if non-nil, is read from GetAllStatusesForSection before it
+	// returns. The test controls when it's closed to simulate the slow fetch
+	// finishing.
+	blockGetAll chan struct{}
+	// entered is closed the first time GetAllStatusesForSection is called, so the
+	// test can deterministically wait for the background refresh to have started
+	// before asserting anything about how long it's blocked for.
+	entered chan struct{}
+
+	statuses []uint8
+}
+
+func (f *fakeTokenStatusListStore) CountAll(ctx context.Context) (int64, error) { return 0, nil }
+
+func (f *fakeTokenStatusListStore) CountDecoysInSectionWithLimit(ctx context.Context, section int64, limit int64) (int64, error) {
+	// Report plenty of remaining decoys so CreateNewSectionIfNeeded never tries
+	// to create a new section.
+	return 2000, nil
+}
+
+func (f *fakeTokenStatusListStore) CreateNewSection(ctx context.Context, section int64, sectionSize int64) error {
+	return nil
+}
+
+func (f *fakeTokenStatusListStore) Add(ctx context.Context, section int64, status uint8) (int64, error) {
+	return 42, nil
+}
+
+func (f *fakeTokenStatusListStore) UpdateStatus(ctx context.Context, section int64, index int64, status uint8) error {
+	return nil
+}
+
+func (f *fakeTokenStatusListStore) GetAllStatusesForSection(ctx context.Context, section int64) ([]uint8, error) {
+	if f.entered != nil {
+		select {
+		case <-f.entered:
+		default:
+			close(f.entered)
+		}
+	}
+	if f.blockGetAll != nil {
+		<-f.blockGetAll
+	}
+	return f.statuses, nil
+}
+
+func (f *fakeTokenStatusListStore) InitializeIfEmpty(ctx context.Context) error { return nil }
+
+func (f *fakeTokenStatusListStore) FindOne(ctx context.Context, section, index int64) (*db.TokenStatusListDoc, error) {
+	return &db.TokenStatusListDoc{Index: index, Section: section}, nil
+}
+
+type fakeTokenStatusListMetadataStore struct{}
+
+func (f *fakeTokenStatusListMetadataStore) GetCurrentSection(ctx context.Context) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeTokenStatusListMetadataStore) UpdateCurrentSection(ctx context.Context, newSection int64) error {
+	return nil
+}
+
+func (f *fakeTokenStatusListMetadataStore) GetAllSections(ctx context.Context) ([]int64, error) {
+	return []int64{0}, nil
+}
+
+// newAsyncTestSuite builds a Service backed by fake, in-memory stores instead of a
+// real MongoDB testcontainer. This lets the test control exactly how long a
+// "full section fetch" takes (via fakeTokenStatusListStore.blockGetAll) without
+// depending on real Mongo timing, which would otherwise make a test that proves
+// AddStatus doesn't block on it either slow (a real 1M-entry section) or flaky
+// (a smaller one, with no reliable margin between "fast" and "slow").
+func newAsyncTestSuite(t *testing.T, store *fakeTokenStatusListStore) *testSuite {
+	// Unlike the other suites in this file, this one needs neither Docker nor a
+	// real MongoDB: cache.New only touches Mongo when HA is enabled (default:
+	// disabled), and Service.New only needs a signing key file plus the fake
+	// stores constructed below.
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	suite := &testSuite{t: t, ctx: ctx, cancel: cancel}
+	suite.generateSigningKey()
+	suite.initializeConfiguration()
+	suite.initializeLogging()
+	suite.initializeTracing()
+
+	suite.dbService = &db.Service{
+		TokenStatusListColl:     store,
+		TokenStatusListMetadata: &fakeTokenStatusListMetadataStore{},
+	}
+
+	var err error
+	suite.cacheService, err = cache.New(ctx, suite.cfg, suite.dbService, suite.tracer, suite.log)
+	require.NoError(t, err)
+
+	return suite
+}
+
+func (s *testSuite) cleanupAsync() {
+	s.cancel()
+}
+
+// TestAddStatus_DoesNotBlockOnSlowCacheRefresh is a regression test for the root
+// cause of the "minting a credential takes ~20 seconds" report: AddStatus used to
+// call refreshSection synchronously, which re-fetches every entry in the section
+// (up to SectionSize, default 1,000,000) and re-signs the JWT/CWT representations
+// before returning. Benchmarked against a real MongoDB instance with a realistic
+// 1,000,000-entry section (the config default), that full fetch alone took ~15-20
+// seconds even though it's fully served by the section+index index (no missing
+// index, no collection scan) -- the cost is simply transferring and decoding a
+// million documents on every single credential issuance.
+//
+// This test simulates that slow fetch deterministically (via a store whose
+// GetAllStatusesForSection blocks until the test releases it) and asserts that
+// AddStatus returns quickly regardless, then that the cache still eventually
+// catches up once the slow refresh completes. Before the fix, this test would
+// block for the full duration of blockGetAll instead of returning almost
+// immediately.
+func TestAddStatus_DoesNotBlockOnSlowCacheRefresh(t *testing.T) {
+	store := &fakeTokenStatusListStore{
+		blockGetAll: make(chan struct{}),
+		entered:     make(chan struct{}),
+		statuses:    []uint8{0, 1, 2},
+	}
+	suite := newAsyncTestSuite(t, store)
+	defer suite.cleanupAsync()
+
+	service, err := New(suite.ctx, suite.cfg, suite.cacheService, suite.dbService, suite.log)
+	require.NoError(t, err)
+	defer service.Close(suite.ctx)
+
+	// Wait for the initial startup refresh (refreshLoop's immediate
+	// refreshAllSections call) to have entered GetAllStatusesForSection and
+	// blocked, so we know AddStatus below is genuinely racing a slow refresh
+	// rather than running before one ever started.
+	select {
+	case <-store.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial refresh to start")
+	}
+
+	start := time.Now()
+	section, index, err := service.AddStatus(suite.ctx, 0)
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), section)
+	assert.Equal(t, int64(42), index)
+
+	// The slow refresh (store.blockGetAll) is still blocked at this point. If
+	// AddStatus still refreshed the cache synchronously, this would take at
+	// least as long as the refresh is blocked for. We assert a generous but
+	// meaningful bound: comfortably above normal scheduling noise, comfortably
+	// below the multi-second refresh this test deliberately never unblocks
+	// until after AddStatus has already returned.
+	assert.Less(t, elapsed, 2*time.Second,
+		"AddStatus should not block on the (still in-progress) cache refresh")
+
+	// Cache must not be populated yet -- the refresh is still blocked.
+	assert.Empty(t, service.GetCachedJWT(suite.ctx, section))
+
+	// Now let the slow refresh finish and confirm the cache does eventually
+	// catch up, proving the async refresh isn't just dropped.
+	close(store.blockGetAll)
+
+	require.Eventually(t, func() bool {
+		return service.GetCachedJWT(suite.ctx, section) != ""
+	}, 5*time.Second, 50*time.Millisecond, "cache should be populated once the background refresh completes")
+}

--- a/internal/registry/tokenstatuslistissuer/async_refresh_test.go
+++ b/internal/registry/tokenstatuslistissuer/async_refresh_test.go
@@ -59,7 +59,15 @@ func (f *fakeTokenStatusListStore) GetAllStatusesForSection(ctx context.Context,
 		}
 	}
 	if f.blockGetAll != nil {
-		<-f.blockGetAll
+		select {
+		case <-f.blockGetAll:
+		case <-ctx.Done():
+			// Respect context cancellation/timeout so a test failure before
+			// blockGetAll is closed (e.g. a require.* failure) doesn't leave
+			// this goroutine (and the refreshLoop/refreshSectionAsync
+			// goroutine that called it) blocked indefinitely past the end
+			// of the test.
+		}
 	}
 	return f.statuses, nil
 }

--- a/internal/registry/tokenstatuslistissuer/methods.go
+++ b/internal/registry/tokenstatuslistissuer/methods.go
@@ -117,8 +117,9 @@ func (s *Service) AddStatus(ctx context.Context, status uint8) (int64, int64, er
 		return 0, 0, err
 	}
 
-	// Refresh cache so the new status is immediately visible in the served token
-	s.refreshSection(ctx, currentSection)
+	// Refresh the cached Status List Token in the background; see refreshSectionAsync
+	// for why this must not run inline on the credential-issuance request path.
+	s.refreshSectionAsync(ctx, currentSection)
 
 	return currentSection, index, nil
 }
@@ -133,7 +134,8 @@ func (s *Service) UpdateStatus(ctx context.Context, section int64, index int64, 
 	if err := s.tokenStatusListColl.UpdateStatus(ctx, section, index, status); err != nil {
 		return err
 	}
-	// Refresh cache so the updated status is immediately visible in the served token
-	s.refreshSection(ctx, section)
+	// Refresh the cached Status List Token in the background; see refreshSectionAsync
+	// for why this must not run inline on the request path.
+	s.refreshSectionAsync(ctx, section)
 	return nil
 }

--- a/internal/registry/tokenstatuslistissuer/service.go
+++ b/internal/registry/tokenstatuslistissuer/service.go
@@ -172,8 +172,19 @@ func (s *Service) refreshAllSections(ctx context.Context) {
 // cache catch up in the background instead of blocking on it here. The context is
 // detached from the caller's cancellation (via context.WithoutCancel) so the
 // refresh isn't aborted the moment the triggering RPC returns.
+//
+// Uses refreshGroup.DoChan directly rather than spawning our own goroutine:
+// DoChan is itself non-blocking and only starts a new goroutine when no refresh
+// for this section is already in flight, so a burst of AddStatus/UpdateStatus
+// calls landing while one refresh is running coalesces onto that single
+// in-flight call instead of each parking its own goroutine on refreshGroup.Do.
 func (s *Service) refreshSectionAsync(ctx context.Context, section int64) {
-	go s.refreshSectionCoalesced(context.WithoutCancel(ctx), section)
+	ctx = context.WithoutCancel(ctx)
+	key := strconv.FormatInt(section, 10)
+	s.refreshGroup.DoChan(key, func() (any, error) {
+		s.refreshSection(ctx, section)
+		return nil, nil
+	})
 }
 
 // refreshSectionCoalesced refreshes a section's cache, coalescing concurrent calls

--- a/internal/registry/tokenstatuslistissuer/service.go
+++ b/internal/registry/tokenstatuslistissuer/service.go
@@ -200,8 +200,24 @@ func (s *Service) refreshSectionCoalesced(ctx context.Context, section int64) {
 	})
 }
 
+// sectionRefreshTimeout bounds a single refreshSection call. Without this, a
+// hung Mongo fetch (network stall, server issue) would never return: the
+// goroutine running it leaks forever, and -- since refreshSectionAsync's
+// context is deliberately detached from the caller's cancellation via
+// context.WithoutCancel -- nothing else times it out either. Every
+// AddStatus/UpdateStatus call arriving while it's stuck would add another
+// waiter channel to the in-flight singleflight call, which is unbounded for
+// as long as that call never completes. 2 minutes is comfortably above the
+// ~15-20s measured for a full 1,000,000-entry section (this repo's default
+// SectionSize), leaving headroom for a larger configured section or a slow
+// disk, while still guaranteeing eventual cleanup either way.
+const sectionRefreshTimeout = 2 * time.Minute
+
 // refreshSection refreshes the cache for a single section
 func (s *Service) refreshSection(ctx context.Context, section int64) {
+	ctx, cancel := context.WithTimeout(ctx, sectionRefreshTimeout)
+	defer cancel()
+
 	statuses, err := s.tokenStatusListColl.GetAllStatusesForSection(ctx, section)
 	if err != nil {
 		s.log.Error(err, "Failed to get statuses for section", "section", section)

--- a/internal/registry/tokenstatuslistissuer/service.go
+++ b/internal/registry/tokenstatuslistissuer/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/SUNET/vc/internal/registry/cache"
 	"github.com/SUNET/vc/internal/registry/db"
@@ -26,6 +27,12 @@ type Service struct {
 	log                     *logger.Log
 
 	cacheService *cache.Service
+
+	// refreshGroup coalesces concurrent refreshSection calls for the same section
+	// (e.g. several credential issuances landing in the same section at once, or an
+	// async refresh overlapping with the periodic ticker) into a single underlying
+	// full-section fetch + re-sign instead of running them redundantly in parallel.
+	refreshGroup singleflight.Group
 
 	// refreshInterval is how often tokens are regenerated
 	refreshInterval time.Duration
@@ -139,10 +146,47 @@ func (s *Service) refreshAllSections(ctx context.Context) {
 	}
 
 	for _, section := range sections {
-		s.refreshSection(ctx, section)
+		s.refreshSectionCoalesced(ctx, section)
 	}
 
 	s.log.Debug("Cache refresh completed", "sections", len(sections))
+}
+
+// refreshSectionAsync schedules a background refresh of a section's cached Status
+// List Token without blocking the caller.
+//
+// refreshSection performs a full section re-fetch (every entry in the section, up
+// to SectionSize, default 1,000,000) plus JWT and CWT re-signing. Measured locally
+// against a MongoDB instance with a realistic 1,000,000-entry section (the config
+// default), that full fetch alone takes on the order of 15-20 seconds, even though
+// the query is fully served by the section+index index (no collection scan) —
+// the cost is simply transferring and decoding a million documents, not a missing
+// index. Running that inline on AddStatus/UpdateStatus — as this code used to do —
+// blocks every single credential issuance (or status update) on a full status-list
+// rebuild, which is the root cause of the ~16-20s "minting a credential is slow"
+// symptom.
+//
+// The database write these callers already performed is durable and synchronous,
+// and the cached token is already only refreshed periodically (every
+// TokenRefreshInterval, default 12h) by refreshLoop, so it is safe to let the
+// cache catch up in the background instead of blocking on it here. The context is
+// detached from the caller's cancellation (via context.WithoutCancel) so the
+// refresh isn't aborted the moment the triggering RPC returns.
+func (s *Service) refreshSectionAsync(ctx context.Context, section int64) {
+	go s.refreshSectionCoalesced(context.WithoutCancel(ctx), section)
+}
+
+// refreshSectionCoalesced refreshes a section's cache, coalescing concurrent calls
+// for the same section (from concurrent AddStatus/UpdateStatus callers, or an
+// in-flight async refresh overlapping with the periodic ticker) into a single
+// underlying refreshSection call rather than running redundant full-section scans
+// in parallel.
+func (s *Service) refreshSectionCoalesced(ctx context.Context, section int64) {
+	key := strconv.FormatInt(section, 10)
+	_, _, _ = s.refreshGroup.Do(key, func() (any, error) {
+		s.refreshSection(ctx, section)
+		return nil, nil
+	})
 }
 
 // refreshSection refreshes the cache for a single section


### PR DESCRIPTION
## Reported symptom

A user reported that minting a credential takes ~20 seconds during manual testing (against the EU Digital Identity Wallet reference implementation). An earlier analysis attributed this to the registry's Token Status List allocation doing an unbounded, sorted, no-limit MongoDB `find` over an entire 1,000,000-entry section on every `/credential` call.

## What I independently verified

I read `internal/registry/db/methods_token_status_list.go` and `internal/registry/tokenstatuslistissuer/{methods,service}.go` in full, and benchmarked the actual query against a real MongoDB 7.0 instance (docker) seeded with the section size this repo actually defaults to (`SectionSize: 1000000`, `pkg/model/config.go`), which is pre-seeded into section 0 on first startup, before any real credential is even issued.

**The original hypothesis is correct in substance, but slightly imprecise on mechanism:**

- It is **not** a missing-index bug. `createIndex()` already creates a `{section:1, index:1}` unique compound index, and `GetAllStatusesForSection`'s query (`find({section}).sort({index:1})`) uses it correctly — `explain("executionStats")` shows `IXSCAN → FETCH → PROJECTION_SIMPLE`, no in-memory `SORT` stage, no collection scan, and `totalKeysExamined == totalDocsExamined == nReturned`. Allocating a slot itself (`Add`) is also already fast — it was previously optimized (see `5a6c1f48b "Faster lookup in registry"` and `2f8b8dde3` upstream) to do O(1) random-index seeks via that same index instead of a full scan, and `CreateNewSectionIfNeeded` already uses a limited count (`CountDecoysInSectionWithLimit`) instead of an unbounded one.
- The **actual** bottleneck: `AddStatus` (called synchronously from the issuer's `/credential` path via the `TokenStatusListAddStatus` gRPC call, see `internal/issuer/apiv1/handlers.go`) calls `refreshSection()` **inline**, which re-fetches *every* status in the section and re-signs both a JWT and a CWT representation, purely to keep the cached, publicly-served Status List Token immediately fresh. Fetching+decoding 1,000,000 small documents this way — even though the index makes the query itself efficient — took **~15-21 seconds** in my benchmark (server-side `explain` execution alone is ~777ms; the difference is real driver-side network+BSON-decode cost of a million documents). That number lines up almost exactly with the reported 16-20s.
- Since `SectionSize` defaults to 1,000,000 and section 0 is pre-seeded with the full section at first startup (`InitializeIfEmpty` → `CreateNewSection`), this cost is paid on **every single credential issuance from the very first one**, not something that grows in over time.

## Fix

Minimal, targeted change in `internal/registry/tokenstatuslistissuer/{methods,service}.go`:

- `AddStatus` and `UpdateStatus` now call the cache refresh via `refreshSectionAsync`, which runs `refreshSection` in a background goroutine (context detached via `context.WithoutCancel` so it isn't aborted when the triggering RPC returns) instead of blocking the caller.
- This is safe: the DB write these methods perform is already durable and synchronous (source of truth), and the cached JWT/CWT was already only periodically refreshed by `refreshLoop` (every `TokenRefreshInterval`, default 12h) — the inline refresh was only there to shrink that staleness window after a write, at the cost of blocking every write. The public `/statuslists/{id}` endpoint only ever reads from this cache (`internal/registry/apiv1/handlers_token_status_list.go`), so it simply serves a very briefly stale token until the async refresh lands.
- Concurrent refreshes for the same section (bursts of `AddStatus` calls, or an async refresh racing the periodic ticker) are coalesced via `golang.org/x/sync/singleflight` so they don't pile up as redundant parallel full-section scans against MongoDB.
- No changes to the query, index, or storage model — those are already correct and don't need to change.

## Testing

- New deterministic regression test: `internal/registry/tokenstatuslistissuer/async_refresh_test.go`. It uses fake in-memory `db.TokenStatusListStore`/`db.TokenStatusListMetadataStore` implementations whose `GetAllStatusesForSection` blocks until the test releases it (standing in for the slow real fetch, without needing a real 1M-doc MongoDB in CI). It asserts `AddStatus` returns almost immediately while the refresh is still blocked, then that the cache eventually catches up once unblocked.
  - Verified this test actually catches the regression: reverting just the fix locally makes it hang/timeout, confirming it exercises the real bug.
- `go build ./...`, `go vet ./...`: clean.
- `go test ./internal/registry/...`: all pass (including the existing `tokenstatuslistissuer` suite, unmodified, which already uses `require.Eventually` for cache assertions so it tolerated the now-async refresh with no changes needed).
- `go test ./pkg/...`: all pass except the pre-existing, unrelated `TestIssuerMetadata_Generate_VCTMDisplay_PartialRendering` in `pkg/model`.
- `go.mod` gained one line promoting `golang.org/x/sync` from an indirect to a direct dependency (it was already vendored and already marked `explicit` in `vendor/modules.txt`; only `go.mod` itself was out of sync for this one module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwbstHozivxjVHugaYzG9D