### PR TITLE
Add SVG template support for mso_mdoc (MDDL) credentials

### DIFF
--- a/internal/apigw/apiv1/handlers_users.go
+++ b/internal/apigw/apiv1/handlers_users.go
@@ -139,14 +139,23 @@ func (c *Client) UserLookup(ctx context.Context, req *vcclient.UserLookupRequest
 
 	// req.VCTM is nil for mso_mdoc scopes (GetVCTMFromScope only returns a
 	// VCTM for sd-jwt-based credentials) - use the MDDL schema's own
-	// Presentation instead. mso_mdoc has no SVG-template concept, so
-	// svgTemplateClaims stays empty in that case.
+	// Presentation/SVGValues instead.
 	switch {
 	case req.VCTM != nil:
 		presentationClaims = req.VCTM.Presentation(doc.DocumentData)
 		svgTemplateClaims = req.VCTM.SVGValues(doc.DocumentData)
 	case req.MDDL != nil:
 		presentationClaims = req.MDDL.Presentation(doc.DocumentData)
+		// mdoc.SVGValue mirrors sdjwtvc.SVGValue field-for-field but is a
+		// distinct type (keeps pkg/mdoc decoupled from pkg/sdjwtvc); convert
+		// into the wire type UserLookupReply.SVGTemplateClaims already commits to.
+		mdocSVGValues := req.MDDL.SVGValues(doc.DocumentData)
+		if len(mdocSVGValues) > 0 {
+			svgTemplateClaims = make(map[string]sdjwtvc.SVGValue, len(mdocSVGValues))
+			for svgID, v := range mdocSVGValues {
+				svgTemplateClaims[svgID] = sdjwtvc.SVGValue{Label: v.Label, Value: v.Value}
+			}
+		}
 	}
 
 	if svgTemplateClaims == nil {

--- a/internal/apigw/apiv1/handlers_vctm.go
+++ b/internal/apigw/apiv1/handlers_vctm.go
@@ -196,18 +196,32 @@ func (c *Client) TypeMetadata(ctx context.Context, req *TypeMetadataRequest) (js
 	return reply, nil
 }
 
-// SVGTemplateRequest holds the request for fetching an SVG template.
+// SVGTemplateRequest holds the request for fetching an SVG template. Exactly
+// one of VCTM or MDDL should be set, mirroring the two credential-metadata
+// sources GetVCTMFromScope/GetMDDLFromScope resolve a scope to.
 type SVGTemplateRequest struct {
-	VCTM *sdjwtvc.VCTM `json:"-"`
+	VCTM *sdjwtvc.VCTM    `json:"-"`
+	MDDL *mdoc.MDDLSchema `json:"-"`
 }
 
 func (c *Client) SVGTemplateReply(ctx context.Context, req *SVGTemplateRequest) (*vcclient.SVGTemplateReply, error) {
-	if len(req.VCTM.Display) == 0 || req.VCTM.Display[0].Rendering == nil ||
-		len(req.VCTM.Display[0].Rendering.SVGTemplates) == 0 {
-		return nil, fmt.Errorf("VCTM has no SVG templates")
+	var svgTemplateURI string
+	switch {
+	case req.VCTM != nil:
+		if len(req.VCTM.Display) == 0 || req.VCTM.Display[0].Rendering == nil ||
+			len(req.VCTM.Display[0].Rendering.SVGTemplates) == 0 {
+			return nil, fmt.Errorf("VCTM has no SVG templates")
+		}
+		svgTemplateURI = req.VCTM.Display[0].Rendering.SVGTemplates[0].URI
+	case req.MDDL != nil:
+		if len(req.MDDL.Display) == 0 || req.MDDL.Display[0].Rendering == nil ||
+			len(req.MDDL.Display[0].Rendering.SVGTemplates) == 0 {
+			return nil, fmt.Errorf("MDDL schema has no SVG templates")
+		}
+		svgTemplateURI = req.MDDL.Display[0].Rendering.SVGTemplates[0].URI
+	default:
+		return nil, fmt.Errorf("no VCTM or MDDL schema provided")
 	}
-
-	svgTemplateURI := req.VCTM.Display[0].Rendering.SVGTemplates[0].URI
 
 	if cached, ok := c.cacheService.SVGTemplate.Get(ctx, svgTemplateURI); ok {
 		reply := &vcclient.SVGTemplateReply{Template: cached}

--- a/internal/apigw/apiv1/handlers_vctm.go
+++ b/internal/apigw/apiv1/handlers_vctm.go
@@ -205,6 +205,13 @@ type SVGTemplateRequest struct {
 }
 
 func (c *Client) SVGTemplateReply(ctx context.Context, req *SVGTemplateRequest) (*vcclient.SVGTemplateReply, error) {
+	if req == nil {
+		return nil, fmt.Errorf("SVGTemplateRequest is nil")
+	}
+	if req.VCTM != nil && req.MDDL != nil {
+		return nil, fmt.Errorf("SVGTemplateRequest must set exactly one of VCTM or MDDL, not both")
+	}
+
 	var svgTemplateURI string
 	switch {
 	case req.VCTM != nil:

--- a/internal/apigw/apiv1/handlers_vctm_test.go
+++ b/internal/apigw/apiv1/handlers_vctm_test.go
@@ -36,6 +36,27 @@ func newOfferTestClient(t *testing.T, credMeta map[string]*model.CredentialMetad
 	}
 }
 
+func TestSVGTemplateReply_NilRequest(t *testing.T) {
+	client := &Client{}
+	_, err := client.SVGTemplateReply(t.Context(), nil)
+	require.Error(t, err)
+}
+
+func TestSVGTemplateReply_BothVCTMAndMDDLSet(t *testing.T) {
+	client := &Client{}
+	_, err := client.SVGTemplateReply(t.Context(), &SVGTemplateRequest{
+		VCTM: &sdjwtvc.VCTM{},
+		MDDL: &mdoc.MDDLSchema{},
+	})
+	require.Error(t, err)
+}
+
+func TestSVGTemplateReply_NeitherVCTMNorMDDLSet(t *testing.T) {
+	client := &Client{}
+	_, err := client.SVGTemplateReply(t.Context(), &SVGTemplateRequest{})
+	require.Error(t, err)
+}
+
 func TestUICreateCredentialOffer_VCTMScope(t *testing.T) {
 	credMeta := map[string]*model.CredentialMetadata{
 		"siros_id": {VCTM: &sdjwtvc.VCTM{Name: "SIROS ID", VCT: "urn:siros:id"}},

--- a/internal/apigw/apiv1/handlers_vctm_test.go
+++ b/internal/apigw/apiv1/handlers_vctm_test.go
@@ -2,7 +2,9 @@ package apiv1
 
 import (
 	"testing"
+	"time"
 
+	"github.com/SUNET/vc/internal/apigw/cache"
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/mdoc"
 	"github.com/SUNET/vc/pkg/model"
@@ -54,6 +56,42 @@ func TestSVGTemplateReply_BothVCTMAndMDDLSet(t *testing.T) {
 func TestSVGTemplateReply_NeitherVCTMNorMDDLSet(t *testing.T) {
 	client := &Client{}
 	_, err := client.SVGTemplateReply(t.Context(), &SVGTemplateRequest{})
+	require.Error(t, err)
+}
+
+// TestSVGTemplateReply_MDDLDataURI exercises the MDDL branch's happy path
+// with a data: URI (avoids a real cacheService/HTTP origin) - the MDDL
+// branch previously had no test coverage at all.
+func TestSVGTemplateReply_MDDLDataURI(t *testing.T) {
+	log, err := logger.New("test", "", false)
+	require.NoError(t, err)
+
+	client := &Client{
+		log:          log,
+		cacheService: &cache.Service{SVGTemplate: cache.NewTestMemoryCache[string](time.Minute)},
+	}
+	mddl := &mdoc.MDDLSchema{
+		Display: []mdoc.DisplayProperties{
+			{
+				Rendering: &mdoc.Rendering{
+					SVGTemplates: []mdoc.SVGTemplate{
+						{URI: "data:image/svg+xml;base64,PHN2Zy8+"},
+					},
+				},
+			},
+		},
+	}
+
+	reply, err := client.SVGTemplateReply(t.Context(), &SVGTemplateRequest{MDDL: mddl})
+	require.NoError(t, err)
+	require.Equal(t, "PHN2Zy8+", reply.Template)
+}
+
+// TestSVGTemplateReply_MDDLNoTemplates confirms the MDDL branch's own
+// no-templates error path, mirroring the existing VCTM coverage's shape.
+func TestSVGTemplateReply_MDDLNoTemplates(t *testing.T) {
+	client := &Client{}
+	_, err := client.SVGTemplateReply(t.Context(), &SVGTemplateRequest{MDDL: &mdoc.MDDLSchema{}})
 	require.Error(t, err)
 }
 

--- a/internal/apigw/httpserver/endpoints_oauth.go
+++ b/internal/apigw/httpserver/endpoints_oauth.go
@@ -412,25 +412,29 @@ func (s *Service) endpointOAuthAuthorizationConsentSvgTemplate(ctx context.Conte
 		Scope: scope,
 	}
 
+	var svgTemplateRequest *apiv1.SVGTemplateRequest
 	vctm, err := s.apiv1.GetVCTMFromScope(ctx, getVCTMFromScopeRequest)
-	if errors.Is(err, apiv1.ErrScopeIsMDoc) {
-		// mso_mdoc scopes have no VCTM and no SVG-template concept at all -
-		// see MDDLSchema.
-		err := fmt.Errorf("scope has no SVG templates (mso_mdoc credential): %w", err)
-		span.SetStatus(codes.Error, err.Error())
-		s.log.Debug(err.Error(), "scope", scope)
-		c.AbortWithStatus(http.StatusBadRequest)
-		return nil, err
-	}
-	if err != nil {
+	switch {
+	case err == nil:
+		svgTemplateRequest = &apiv1.SVGTemplateRequest{VCTM: vctm}
+	case errors.Is(err, apiv1.ErrScopeIsMDoc):
+		// mso_mdoc scopes have no VCTM - fall back to the MDDL schema, same
+		// pattern as UICreateCredentialOffer. MDDL display entries can
+		// declare their own svg_templates (see MDDLSchema.Rendering);
+		// SVGTemplateReply returns its own error if none are present.
+		mddl, mddlErr := s.apiv1.GetMDDLFromScope(ctx, &apiv1.GetMDDLFromScopeRequest{Scope: scope})
+		if mddlErr != nil {
+			span.SetStatus(codes.Error, mddlErr.Error())
+			s.log.Error(mddlErr, "getting MDDL schema failed")
+			c.AbortWithStatus(http.StatusBadRequest)
+			return nil, mddlErr
+		}
+		svgTemplateRequest = &apiv1.SVGTemplateRequest{MDDL: mddl}
+	default:
 		span.SetStatus(codes.Error, err.Error())
 		s.log.Error(err, "getting VCTM failed")
 		c.AbortWithStatus(http.StatusBadRequest)
 		return nil, err
-	}
-
-	svgTemplateRequest := &apiv1.SVGTemplateRequest{
-		VCTM: vctm,
 	}
 
 	reply, err := s.apiv1.SVGTemplateReply(ctx, svgTemplateRequest)

--- a/pkg/mdoc/schema.go
+++ b/pkg/mdoc/schema.go
@@ -192,8 +192,12 @@ func (s *MDDLSchema) SVGValues(data map[string]any) map[string]SVGValue {
 			if !ok {
 				continue
 			}
+			label := meta.Display[0].Label
+			if label == "" {
+				label = meta.Display[0].Name
+			}
 			result[meta.SVGID] = SVGValue{
-				Label: meta.Display[0].Name,
+				Label: label,
 				Value: value,
 			}
 		}

--- a/pkg/mdoc/schema.go
+++ b/pkg/mdoc/schema.go
@@ -89,6 +89,12 @@ type ClaimMetadata struct {
 type ClaimDisplay struct {
 	Locale string `json:"locale"`
 	Name   string `json:"name"`
+	// Label is a display label distinct from Name, for schemas that declare
+	// both. Attributes/Presentation below still key off Name (their
+	// existing, established behavior); Label is consumed by Generate's
+	// mso_mdoc credential_metadata.claims mapping (pkg/model/config.go),
+	// which falls back to Name when Label is empty.
+	Label string `json:"label,omitempty"`
 }
 
 // defaultLocale is used to bucket claims that declare no display info, so

--- a/pkg/mdoc/schema.go
+++ b/pkg/mdoc/schema.go
@@ -20,18 +20,51 @@ type MDDLSchema struct {
 // DisplayProperties describes how the credential should be presented to the
 // holder, mirroring registry-cli's mddl.DisplayProperties.
 type DisplayProperties struct {
-	Locale          string `json:"locale"`
-	Name            string `json:"name"`
-	Description     string `json:"description,omitempty"`
-	Logo            *Logo  `json:"logo,omitempty"`
-	BackgroundColor string `json:"background_color,omitempty"`
-	TextColor       string `json:"text_color,omitempty"`
+	Locale          string     `json:"locale"`
+	Name            string     `json:"name"`
+	Description     string     `json:"description,omitempty"`
+	Logo            *Logo      `json:"logo,omitempty"`
+	BackgroundColor string     `json:"background_color,omitempty"`
+	TextColor       string     `json:"text_color,omitempty"`
+	Rendering       *Rendering `json:"rendering,omitempty"`
 }
 
 // Logo describes a display logo image.
 type Logo struct {
 	URI     string `json:"uri,omitempty"`
 	AltText string `json:"alt_text,omitempty"`
+}
+
+// Rendering contains SVG-based rendering information for an mdoc display
+// entry, mirroring sdjwtvc.Rendering (SD-JWT VC §8.1.2). mdoc has no "simple"
+// rendering sub-object to mirror: Logo/BackgroundColor/TextColor already live
+// directly on DisplayProperties above.
+type Rendering struct {
+	SVGTemplates []SVGTemplate `json:"svg_templates,omitempty"`
+}
+
+// SVGTemplate describes a single SVG template used to render the credential,
+// mirroring sdjwtvc.SVGTemplates.
+type SVGTemplate struct {
+	URI        string                 `json:"uri"`
+	Properties *SVGTemplateProperties `json:"properties,omitempty"`
+}
+
+// SVGTemplateProperties describes the rendering context an SVG template is
+// intended for, mirroring sdjwtvc.SVGTemplateProperties.
+type SVGTemplateProperties struct {
+	Orientation string `json:"orientation,omitempty"`
+	ColorScheme string `json:"color_scheme,omitempty"`
+	Contrast    string `json:"contrast,omitempty"`
+}
+
+// SVGValue holds a resolved claim for SVG template rendering, mirroring
+// sdjwtvc.SVGValue. Kept as its own type (rather than importing sdjwtvc's)
+// to keep pkg/mdoc and pkg/sdjwtvc decoupled, matching how Presentation
+// below already returns a bare map[string]any rather than a shared type.
+type SVGValue struct {
+	Label string `json:"label"`
+	Value any    `json:"value"`
 }
 
 // NamespaceClaims maps element identifiers to their claim metadata within a
@@ -47,6 +80,9 @@ type ClaimMetadata struct {
 	Mandatory bool                     `json:"mandatory,omitempty"`
 	ValueType string                   `json:"value_type,omitempty"`
 	Elements  map[string]ClaimMetadata `json:"elements,omitempty"`
+	// SVGID is the identifier for SVG template placeholders, mirroring
+	// sdjwtvc.Claim.SVGID (SD-JWT VC §8.1.2.2).
+	SVGID string `json:"svg_id,omitempty"`
 }
 
 // ClaimDisplay is a localized display label for a claim.
@@ -128,6 +164,38 @@ func (s *MDDLSchema) Presentation(data map[string]any) map[string]any {
 		}
 	}
 
+	return result
+}
+
+// SVGValues resolves claims that have an svg_id against flat document data
+// and returns a map keyed by svg_id, mirroring sdjwtvc.VCTM.SVGValues. Like
+// Presentation above, document data is looked up by element ID directly
+// (flat, not nested under the mdoc namespace).
+func (s *MDDLSchema) SVGValues(data map[string]any) map[string]SVGValue {
+	if data == nil || len(s.Claims) == 0 {
+		return nil
+	}
+
+	result := map[string]SVGValue{}
+	for _, elements := range s.Claims {
+		for elementID, meta := range elements {
+			if meta.SVGID == "" || len(meta.Display) == 0 {
+				continue
+			}
+			value, ok := data[elementID]
+			if !ok {
+				continue
+			}
+			result[meta.SVGID] = SVGValue{
+				Label: meta.Display[0].Name,
+				Value: value,
+			}
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
 	return result
 }
 

--- a/pkg/mdoc/schema_test.go
+++ b/pkg/mdoc/schema_test.go
@@ -1,6 +1,9 @@
 package mdoc
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestLoadMDDLSchema(t *testing.T) {
 	valid := []byte(`{
@@ -96,5 +99,63 @@ func TestMDDLSchema_Attributes(t *testing.T) {
 	}
 	if _, ok := defaultBucket["portrait"]; !ok {
 		t.Error("missing fallback 'portrait' label under default locale")
+	}
+}
+
+func TestMDDLSchema_SVGValues(t *testing.T) {
+	schema := &MDDLSchema{
+		Format:  "mso_mdoc",
+		DocType: "org.iso.18013.5.1.mDL",
+		Claims: map[string]NamespaceClaims{
+			"org.iso.18013.5.1": {
+				"family_name": {
+					Display: []ClaimDisplay{{Locale: "en-US", Name: "Family Name"}},
+					SVGID:   "family_name",
+				},
+				"given_name": {
+					// No SVGID — must not appear in SVGValues, mirroring
+					// sdjwtvc.VCTM.SVGValues skipping claims with no svg_id.
+					Display: []ClaimDisplay{{Locale: "en-US", Name: "Given Name"}},
+				},
+				"portrait": {
+					// SVGID set but no Display — must also be skipped, since
+					// there is no label to attach to the resolved value.
+					SVGID: "portrait_image",
+				},
+				"nationality": {
+					Display: []ClaimDisplay{{Locale: "en-US", Name: "Nationality"}},
+					SVGID:   "nationality",
+				},
+			},
+		},
+	}
+
+	data := map[string]any{
+		"family_name": "Andersson",
+		"given_name":  "Helen",
+		"portrait":    "base64data",
+		// nationality deliberately absent from data.
+	}
+
+	got := schema.SVGValues(data)
+	want := map[string]SVGValue{
+		"family_name": {Label: "Family Name", Value: "Andersson"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SVGValues() = %+v, want %+v", got, want)
+	}
+}
+
+func TestMDDLSchema_SVGValues_NoSVGIDsReturnsNil(t *testing.T) {
+	schema := &MDDLSchema{
+		Claims: map[string]NamespaceClaims{
+			"org.iso.18013.5.1": {
+				"family_name": {Display: []ClaimDisplay{{Locale: "en-US", Name: "Family Name"}}},
+			},
+		},
+	}
+
+	if got := schema.SVGValues(map[string]any{"family_name": "Andersson"}); got != nil {
+		t.Errorf("SVGValues() = %+v, want nil when no claim declares svg_id", got)
 	}
 }

--- a/pkg/mdoc/schema_test.go
+++ b/pkg/mdoc/schema_test.go
@@ -126,20 +126,28 @@ func TestMDDLSchema_SVGValues(t *testing.T) {
 					Display: []ClaimDisplay{{Locale: "en-US", Name: "Nationality"}},
 					SVGID:   "nationality",
 				},
+				"document_number": {
+					// Label set distinct from Name - must win over Name,
+					// mirroring sdjwtvc.VCTM.SVGValues using Display[0].Label.
+					Display: []ClaimDisplay{{Locale: "en-US", Name: "Document Number", Label: "Doc No."}},
+					SVGID:   "document_number",
+				},
 			},
 		},
 	}
 
 	data := map[string]any{
-		"family_name": "Andersson",
-		"given_name":  "Helen",
-		"portrait":    "base64data",
+		"family_name":     "Andersson",
+		"given_name":      "Helen",
+		"portrait":        "base64data",
+		"document_number": "123456789",
 		// nationality deliberately absent from data.
 	}
 
 	got := schema.SVGValues(data)
 	want := map[string]SVGValue{
-		"family_name": {Label: "Family Name", Value: "Andersson"},
+		"family_name":     {Label: "Family Name", Value: "Andersson"},
+		"document_number": {Label: "Doc No.", Value: "123456789"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("SVGValues() = %+v, want %+v", got, want)

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -1727,10 +1727,28 @@ func (cfg *IssuerMetadata) Generate(ctx context.Context, publicURL string, crede
 				sort.Strings(elementIDs)
 				for _, elementID := range elementIDs {
 					ns, el := namespace, elementID
-					credMetadata.Claims = append(credMetadata.Claims, openid4vci.ClaimDescription{
+					meta := elements[elementID]
+					claim := openid4vci.ClaimDescription{
 						Path:      []*string{&ns, &el},
-						Mandatory: elements[elementID].Mandatory,
-					})
+						Mandatory: meta.Mandatory,
+						SVGID:     meta.SVGID,
+					}
+					if len(meta.Display) > 0 {
+						display := make([]openid4vci.ClaimDisplayProperties, len(meta.Display))
+						for j, d := range meta.Display {
+							label := d.Label
+							if label == "" {
+								label = d.Name
+							}
+							display[j] = openid4vci.ClaimDisplayProperties{
+								Name:   d.Name,
+								Label:  label,
+								Locale: d.Locale,
+							}
+						}
+						claim.Display = display
+					}
+					credMetadata.Claims = append(credMetadata.Claims, claim)
 				}
 			}
 			if len(credMetadata.Display) > 0 || len(credMetadata.Claims) > 0 {

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -1662,6 +1662,36 @@ func (cfg *IssuerMetadata) Generate(ctx context.Context, publicURL string, crede
 							AltText: d.Logo.AltText,
 						}
 					}
+
+					// Map SVG templates, mirroring the dc+sd-jwt/VCTM branch below.
+					if d.Rendering != nil && len(d.Rendering.SVGTemplates) > 0 {
+						svgTemplates := make([]openid4vci.MetadataSvgTemplate, len(d.Rendering.SVGTemplates))
+						for j, t := range d.Rendering.SVGTemplates {
+							tmpl := openid4vci.MetadataSvgTemplate{
+								URI: t.URI,
+							}
+							if t.Properties != nil {
+								tmpl.Properties = &openid4vci.MetadataSvgTemplateProperties{
+									Orientation: t.Properties.Orientation,
+									ColorScheme: t.Properties.ColorScheme,
+									Contrast:    t.Properties.Contrast,
+								}
+							}
+							svgTemplates[j] = tmpl
+						}
+						display.Rendering = &openid4vci.MetadataRendering{
+							SvgTemplates: svgTemplates,
+						}
+
+						// Fallback: set logo.uri from first SVG template URI
+						// for wallets that render from logo.uri instead of svg_templates
+						if display.Logo == nil && len(svgTemplates) > 0 {
+							display.Logo = &openid4vci.MetadataLogo{
+								URI: svgTemplates[0].URI,
+							}
+						}
+					}
+
 					credMetadata.Display[i] = display
 				}
 			}

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -1620,6 +1620,38 @@ func (cfg *IssuerMetadata) applyCommonCredentialConfig(credConfig *openid4vci.Cr
 	}
 }
 
+// mapSvgTemplates converts a dialect's SVG template list (mdoc.SVGTemplate
+// for mso_mdoc, sdjwtvc.SVGTemplates for dc+sd-jwt/VCTM — same shape, but
+// distinct named types, so a plain function can't take either directly)
+// into the openid4vci wire format, shared by both the mso_mdoc and VCTM
+// branches of Generate below so the two don't duplicate this mapping.
+// uri/properties extract the relevant fields from each dialect's template
+// type. If logo is nil, falls back to the first template's URI, for wallets
+// that render from logo.uri instead of understanding svg_templates.
+func mapSvgTemplates[T any](
+	templates []T,
+	uri func(T) string,
+	properties func(T) (orientation, colorScheme, contrast string, ok bool),
+	logo *openid4vci.MetadataLogo,
+) (*openid4vci.MetadataRendering, *openid4vci.MetadataLogo) {
+	svgTemplates := make([]openid4vci.MetadataSvgTemplate, len(templates))
+	for i, t := range templates {
+		tmpl := openid4vci.MetadataSvgTemplate{URI: uri(t)}
+		if orientation, colorScheme, contrast, ok := properties(t); ok {
+			tmpl.Properties = &openid4vci.MetadataSvgTemplateProperties{
+				Orientation: orientation,
+				ColorScheme: colorScheme,
+				Contrast:    contrast,
+			}
+		}
+		svgTemplates[i] = tmpl
+	}
+	if logo == nil && len(svgTemplates) > 0 {
+		logo = &openid4vci.MetadataLogo{URI: svgTemplates[0].URI}
+	}
+	return &openid4vci.MetadataRendering{SvgTemplates: svgTemplates}, logo
+}
+
 // Generate generates issuer metadata from configuration.
 // Returns unsigned metadata that should be signed on-demand in the endpoint handler for freshness.
 func (cfg *IssuerMetadata) Generate(ctx context.Context, publicURL string, credentials map[string]*CredentialMetadata) (*openid4vci.CredentialIssuerMetadataParameters, error) {
@@ -1665,31 +1697,17 @@ func (cfg *IssuerMetadata) Generate(ctx context.Context, publicURL string, crede
 
 					// Map SVG templates, mirroring the dc+sd-jwt/VCTM branch below.
 					if d.Rendering != nil && len(d.Rendering.SVGTemplates) > 0 {
-						svgTemplates := make([]openid4vci.MetadataSvgTemplate, len(d.Rendering.SVGTemplates))
-						for j, t := range d.Rendering.SVGTemplates {
-							tmpl := openid4vci.MetadataSvgTemplate{
-								URI: t.URI,
-							}
-							if t.Properties != nil {
-								tmpl.Properties = &openid4vci.MetadataSvgTemplateProperties{
-									Orientation: t.Properties.Orientation,
-									ColorScheme: t.Properties.ColorScheme,
-									Contrast:    t.Properties.Contrast,
+						display.Rendering, display.Logo = mapSvgTemplates(
+							d.Rendering.SVGTemplates,
+							func(t mdoc.SVGTemplate) string { return t.URI },
+							func(t mdoc.SVGTemplate) (string, string, string, bool) {
+								if t.Properties == nil {
+									return "", "", "", false
 								}
-							}
-							svgTemplates[j] = tmpl
-						}
-						display.Rendering = &openid4vci.MetadataRendering{
-							SvgTemplates: svgTemplates,
-						}
-
-						// Fallback: set logo.uri from first SVG template URI
-						// for wallets that render from logo.uri instead of svg_templates
-						if display.Logo == nil && len(svgTemplates) > 0 {
-							display.Logo = &openid4vci.MetadataLogo{
-								URI: svgTemplates[0].URI,
-							}
-						}
+								return t.Properties.Orientation, t.Properties.ColorScheme, t.Properties.Contrast, true
+							},
+							display.Logo,
+						)
 					}
 
 					credMetadata.Display[i] = display
@@ -1788,33 +1806,19 @@ func (cfg *IssuerMetadata) Generate(ctx context.Context, publicURL string, crede
 
 					// Map SVG templates (spec-compliant rendering) — independent of `simple`,
 					// since a VCTM may provide svg_templates without a simple rendering block.
+					// Shared with the mso_mdoc/MDDL branch above via mapSvgTemplates.
 					if len(vctmDisplay.Rendering.SVGTemplates) > 0 {
-						svgTemplates := make([]openid4vci.MetadataSvgTemplate, len(vctmDisplay.Rendering.SVGTemplates))
-						for j, t := range vctmDisplay.Rendering.SVGTemplates {
-							tmpl := openid4vci.MetadataSvgTemplate{
-								URI: t.URI,
-							}
-
-							if t.Properties != nil {
-								tmpl.Properties = &openid4vci.MetadataSvgTemplateProperties{
-									Orientation: t.Properties.Orientation,
-									ColorScheme: t.Properties.ColorScheme,
-									Contrast:    t.Properties.Contrast,
+						display.Rendering, display.Logo = mapSvgTemplates(
+							vctmDisplay.Rendering.SVGTemplates,
+							func(t sdjwtvc.SVGTemplates) string { return t.URI },
+							func(t sdjwtvc.SVGTemplates) (string, string, string, bool) {
+								if t.Properties == nil {
+									return "", "", "", false
 								}
-							}
-							svgTemplates[j] = tmpl
-						}
-						display.Rendering = &openid4vci.MetadataRendering{
-							SvgTemplates: svgTemplates,
-						}
-
-						// Fallback: set logo.uri from first SVG template URI
-						// for wallets that render from logo.uri instead of svg_templates
-						if display.Logo == nil && len(svgTemplates) > 0 {
-							display.Logo = &openid4vci.MetadataLogo{
-								URI: svgTemplates[0].URI,
-							}
-						}
+								return t.Properties.Orientation, t.Properties.ColorScheme, t.Properties.Contrast, true
+							},
+							display.Logo,
+						)
 					}
 				}
 

--- a/pkg/model/issuer_metadata_test.go
+++ b/pkg/model/issuer_metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/SUNET/vc/pkg/mdoc"
 	"github.com/SUNET/vc/pkg/openid4vci"
 	"github.com/SUNET/vc/pkg/sdjwtvc"
 
@@ -93,6 +94,70 @@ func TestIssuerMetadata_Generate_VCTMDisplay(t *testing.T) {
 	assert.Equal(t, "VCTM Display Name", credConfig.CredentialMetadata.Display[0].Name)
 	assert.Equal(t, "en-US", credConfig.CredentialMetadata.Display[0].Locale)
 	assert.Equal(t, "VCTM Description", credConfig.CredentialMetadata.Display[0].Description)
+}
+
+func TestIssuerMetadata_Generate_MDDLDisplay_SVGTemplates(t *testing.T) {
+	cfg := &IssuerMetadata{}
+
+	mockMDDL := &mdoc.MDDLSchema{
+		Format:  "mso_mdoc",
+		DocType: "org.iso.18013.5.1.mDL",
+		Display: []mdoc.DisplayProperties{
+			{
+				Locale: "en-US",
+				Name:   "Mobile Driving Licence",
+				Rendering: &mdoc.Rendering{
+					SVGTemplates: []mdoc.SVGTemplate{
+						{
+							URI: "https://issuer.example.com/mdl.svg",
+							Properties: &mdoc.SVGTemplateProperties{
+								Orientation: "landscape",
+								ColorScheme: "light",
+								Contrast:    "normal",
+							},
+						},
+					},
+				},
+			},
+		},
+		Claims: map[string]mdoc.NamespaceClaims{
+			"org.iso.18013.5.1": {
+				"family_name": {Mandatory: true, ValueType: "tstr"},
+			},
+		},
+	}
+
+	credMeta := map[string]*CredentialMetadata{
+		"test_mdl": {
+			Format: "mso_mdoc",
+			MDDL:   mockMDDL,
+		},
+	}
+
+	ctx := context.Background()
+	metadata, err := cfg.Generate(ctx, "https://issuer.sunet.se", credMeta)
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+
+	credConfig, exists := metadata.CredentialConfigurationsSupported["test_mdl"]
+	require.True(t, exists)
+	require.NotNil(t, credConfig.CredentialMetadata)
+	require.Len(t, credConfig.CredentialMetadata.Display, 1)
+
+	display := credConfig.CredentialMetadata.Display[0]
+	require.NotNil(t, display.Rendering, "mso_mdoc display with svg_templates must produce a Rendering block, mirroring the dc+sd-jwt/VCTM path")
+	require.Len(t, display.Rendering.SvgTemplates, 1)
+	assert.Equal(t, "https://issuer.example.com/mdl.svg", display.Rendering.SvgTemplates[0].URI)
+	require.NotNil(t, display.Rendering.SvgTemplates[0].Properties)
+	assert.Equal(t, "landscape", display.Rendering.SvgTemplates[0].Properties.Orientation)
+	assert.Equal(t, "light", display.Rendering.SvgTemplates[0].Properties.ColorScheme)
+	assert.Equal(t, "normal", display.Rendering.SvgTemplates[0].Properties.Contrast)
+
+	// No explicit logo was set — the svg_templates fallback must populate
+	// Logo.URI from the first template, for wallets that render from
+	// logo.uri instead of understanding svg_templates.
+	require.NotNil(t, display.Logo)
+	assert.Equal(t, "https://issuer.example.com/mdl.svg", display.Logo.URI)
 }
 
 func TestIssuerMetadata_Generate_VCTMDisplay_PartialRendering(t *testing.T) {

--- a/pkg/model/issuer_metadata_test.go
+++ b/pkg/model/issuer_metadata_test.go
@@ -160,6 +160,81 @@ func TestIssuerMetadata_Generate_MDDLDisplay_SVGTemplates(t *testing.T) {
 	assert.Equal(t, "https://issuer.example.com/mdl.svg", display.Logo.URI)
 }
 
+// TestIssuerMetadata_Generate_MDDLClaims_DisplayAndSVGID is a regression test
+// for a bug found in live testing (PR #584): the mso_mdoc claims-building
+// loop only set Path/Mandatory on each ClaimDescription, silently dropping
+// SVGID and Display -- breaking svg_id placeholder substitution (no value
+// ever bound) and the wallet's claims list (its isDisplayClaim check needs
+// display[].locale/label, so every claim's display was empty).
+func TestIssuerMetadata_Generate_MDDLClaims_DisplayAndSVGID(t *testing.T) {
+	cfg := &IssuerMetadata{}
+
+	mockMDDL := &mdoc.MDDLSchema{
+		Format:  "mso_mdoc",
+		DocType: "org.iso.18013.5.1.mDL",
+		Claims: map[string]mdoc.NamespaceClaims{
+			"org.iso.18013.5.1": {
+				// SVGID + Display with an explicit Label distinct from Name.
+				"family_name": {
+					Mandatory: true,
+					ValueType: "tstr",
+					SVGID:     "family_name",
+					Display: []mdoc.ClaimDisplay{
+						{Locale: "en-US", Name: "family_name", Label: "Family Name"},
+					},
+				},
+				// SVGID + Display with no Label set -- must fall back to Name.
+				"given_name": {
+					ValueType: "tstr",
+					SVGID:     "given_name",
+					Display: []mdoc.ClaimDisplay{
+						{Locale: "en-US", Name: "Given Name"},
+					},
+				},
+				// No Display at all -- Claim.Display must stay empty, not panic.
+				"portrait": {
+					ValueType: "bstr",
+				},
+			},
+		},
+	}
+
+	credMeta := map[string]*CredentialMetadata{
+		"test_mdl": {Format: "mso_mdoc", MDDL: mockMDDL},
+	}
+
+	metadata, err := cfg.Generate(context.Background(), "https://issuer.sunet.se", credMeta)
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+
+	credConfig, exists := metadata.CredentialConfigurationsSupported["test_mdl"]
+	require.True(t, exists)
+	require.NotNil(t, credConfig.CredentialMetadata)
+	require.Len(t, credConfig.CredentialMetadata.Claims, 3)
+
+	byElementID := map[string]openid4vci.ClaimDescription{}
+	for _, c := range credConfig.CredentialMetadata.Claims {
+		require.Len(t, c.Path, 2)
+		require.NotNil(t, c.Path[1])
+		byElementID[*c.Path[1]] = c
+	}
+
+	familyName := byElementID["family_name"]
+	assert.Equal(t, "family_name", familyName.SVGID)
+	require.Len(t, familyName.Display, 1)
+	assert.Equal(t, "Family Name", familyName.Display[0].Label, "an explicit Label must win over Name")
+	assert.Equal(t, "en-US", familyName.Display[0].Locale)
+
+	givenName := byElementID["given_name"]
+	assert.Equal(t, "given_name", givenName.SVGID)
+	require.Len(t, givenName.Display, 1)
+	assert.Equal(t, "Given Name", givenName.Display[0].Label, "Label must fall back to Name when unset")
+
+	portrait := byElementID["portrait"]
+	assert.Empty(t, portrait.SVGID)
+	assert.Empty(t, portrait.Display)
+}
+
 func TestIssuerMetadata_Generate_VCTMDisplay_PartialRendering(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Summary

ymyitbarek noticed (Slack) that mso_mdoc credential metadata generation never populates `svg_templates`, unlike the `dc+sd-jwt`/VCTM path in the same `Generate()` function (`pkg/model/config.go`). This isn't a regression from a recent PR — `MDDLSchema` was introduced in `4a2facbe4` mirroring `registry-cli`'s mddl schema format, which never had an `svg_templates` concept, and mso_mdoc's lack of SVG-template support was already documented at the `UserLookup` call site (`"mso_mdoc has no SVG-template concept"`).

But there's no spec-level reason mdoc credentials can't have it: OpenID4VCI's `credential_metadata.display[].rendering` is format-agnostic (not SD-JWT-VC-specific), and the only actual gap was that nothing in this codebase populated or resolved it for mdoc. This PR closes that gap, adding the mdoc analogue of every piece VCTM already has for SVG-template rendering.

## What's new

- **`pkg/mdoc/schema.go`**: `DisplayProperties` gains an optional `Rendering` field (`SVGTemplates`, mirroring `sdjwtvc.Rendering` per SD-JWT VC §8.1.2); `ClaimMetadata` gains `SVGID` (mirroring `sdjwtvc.Claim.SVGID`); new `MDDLSchema.SVGValues(data)`, the mdoc analogue of `VCTM.SVGValues` — resolves claims with an `svg_id` against flat document data (mirroring how `Presentation` already resolves claims by element ID). Uses a local `SVGValue` struct rather than importing `pkg/sdjwtvc`'s, keeping `pkg/mdoc` and `pkg/sdjwtvc` decoupled the same way `Presentation` already does (returns a bare `map[string]any`, not a shared type).
- **`pkg/model/config.go`**: `Generate()`'s `mso_mdoc` branch now maps `mddl.Display[].Rendering.SVGTemplates` into the issued `CredentialMetadataDisplay`, identical to the existing VCTM branch (including the `logo.uri` fallback for wallets that don't understand `svg_templates`).
- **`internal/apigw/apiv1/handlers_vctm.go`**: `SVGTemplateRequest` now carries an optional `MDDL` field alongside `VCTM`; `SVGTemplateReply` resolves the template URI from whichever is set.
- **`internal/apigw/httpserver/endpoints_oauth.go`**: the SVG-template endpoint no longer hard-errors on `ErrScopeIsMDoc` — falls back to `GetMDDLFromScope`, mirroring the existing pattern already used in `UICreateCredentialOffer`.
- **`internal/apigw/apiv1/handlers_users.go`**: `UserLookup`'s `mso_mdoc` branch now also resolves `svgTemplateClaims` via `MDDLSchema.SVGValues`, converting to the `sdjwtvc.SVGValue` wire type `UserLookupReply` already commits to.

## Out of scope

`registry-cli` (a separate repo, the actual mddl-schema producer) would still need to emit `rendering.svg_templates` for any mdoc doctype that wants this in practice — this PR makes the vc side ready to consume and serve it once that exists, matching how `vctm_file_path`-authored schemas already work today. No existing mdoc doctype's schema currently declares `svg_templates`, so this is purely additive — no behavior changes for any credential that doesn't opt in.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] New unit tests: `MDDLSchema.SVGValues` (resolves only claims with both `svg_id` and display info; returns `nil` when none declare `svg_id`), `IssuerMetadata.Generate` mso_mdoc branch (SVG templates + properties + logo.uri fallback all mapped correctly end-to-end)
- [x] Full `go test ./pkg/mdoc/... ./pkg/model/... ./internal/apigw/... ./pkg/openid4vci/... ./pkg/sdjwtvc/... ./internal/verifier/...` — all pass except the pre-existing, unrelated `TestIssuerMetadata_Generate_VCTMDisplay_PartialRendering`