### PR TITLE
verifier: SQL implementation of ClientStore

### DIFF
--- a/internal/apigw/db/mongo_contract_test.go
+++ b/internal/apigw/db/mongo_contract_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/testsupport"
+	"github.com/SUNET/vc/pkg/testsupport/tracertest"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// newTestServiceWithMongo builds a *Service backed by a real Mongo client,
+// for running the shared contract-test helpers against the existing Mongo
+// store implementations -- the same assertions used against Postgres and
+// MariaDB above, so behavioral drift between backends is caught by one
+// shared test suite rather than three separate ones.
+func newTestServiceWithMongo(t *testing.T, client *mongo.Client) *Service {
+	t.Helper()
+	log := testsupport.TestLogger(t)
+	tracer := tracertest.New(t, nil, log, "apigw-db-mongo-contract-test")
+	return &Service{MongoClient: client, tracer: tracer, log: log}
+}
+
+func TestCredentialOfferColl_Mongo(t *testing.T) {
+	client, cleanup := startMongoContainerForTest(t)
+	defer cleanup()
+
+	svc := newTestServiceWithMongo(t, client)
+	store, err := NewCredentialOfferColl(t.Context(), "credential_offer", svc, testsupport.TestLogger(t))
+	require.NoError(t, err)
+
+	testCredentialOfferStoreContract(t, store)
+}
+
+func TestDynamicRegistrationColl_Mongo(t *testing.T) {
+	client, cleanup := startMongoContainerForTest(t)
+	defer cleanup()
+
+	svc := newTestServiceWithMongo(t, client)
+	store, err := NewDynamicRegistrationColl(t.Context(), "oidc_dynamic_registration", svc, testsupport.TestLogger(t))
+	require.NoError(t, err)
+
+	testDynamicRegistrationStoreContract(t, store)
+}
+
+func TestIdentityMappingsColl_Mongo(t *testing.T) {
+	client, cleanup := startMongoContainerForTest(t)
+	defer cleanup()
+
+	svc := newTestServiceWithMongo(t, client)
+	store := &IdentityMappingsColl{
+		Service: svc,
+		Coll:    client.Database("vc").Collection("identity_mappings"),
+		log:     testsupport.TestLogger(t),
+	}
+	require.NoError(t, store.createIndex(t.Context()))
+
+	testIdentityMappingStoreContract(t, store)
+}
+
+func TestDatastoreColl_Mongo(t *testing.T) {
+	client, cleanup := startMongoContainerForTest(t)
+	defer cleanup()
+
+	svc := newTestServiceWithMongo(t, client)
+	store := &DatastoreColl{
+		Service: svc,
+		Coll:    client.Database("vc").Collection("datastore"),
+		log:     testsupport.TestLogger(t),
+	}
+	require.NoError(t, store.createIndex(t.Context()))
+
+	testDatastoreStoreContract(t, store)
+}
+
+func startMongoContainerForTest(t *testing.T) (*mongo.Client, func()) {
+	t.Helper()
+	_, client, cleanup := testsupport.StartMongoContainer(t)
+	return client, cleanup
+}

--- a/internal/apigw/db/service.go
+++ b/internal/apigw/db/service.go
@@ -117,7 +117,7 @@ func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logg
 	if err != nil {
 		return nil, err
 	}
-	if err := sqlstore.ApplySchema(db, dialect); err != nil {
+	if err := sqlstore.ApplySchema(ctx, db, dialect); err != nil {
 		return nil, err
 	}
 	service.SQLDB = db

--- a/internal/apigw/db/service.go
+++ b/internal/apigw/db/service.go
@@ -26,7 +26,7 @@ type Service struct {
 	cfg         *model.Cfg
 	log         *logger.Log
 	tracer      *trace.Tracer
-	probeStore  *apiv1_status.StatusProbeStore
+	probeStore  *sqlstore.ProbeCache
 
 	DatastoreColl           DatastoreStore
 	IdentityMappingsColl    IdentityMappingStore
@@ -49,7 +49,7 @@ func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.
 		log:         log.New("db"),
 		cfg:         cfg,
 		tracer:      tracer,
-		probeStore:  &apiv1_status.StatusProbeStore{},
+		probeStore:  &sqlstore.ProbeCache{},
 		MongoClient: conn.MongoClient,
 		SQLDB:       conn.SQLDB,
 	}

--- a/internal/apigw/db/service.go
+++ b/internal/apigw/db/service.go
@@ -117,7 +117,7 @@ func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logg
 	if err != nil {
 		return nil, err
 	}
-	if err := sqlstore.Migrate(db, dialect); err != nil {
+	if err := sqlstore.ApplySchema(db, dialect); err != nil {
 		return nil, err
 	}
 	service.SQLDB = db

--- a/internal/apigw/db/service.go
+++ b/internal/apigw/db/service.go
@@ -117,7 +117,7 @@ func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logg
 	if err != nil {
 		return nil, err
 	}
-	if err := sqlstore.ApplySchema(ctx, db, dialect); err != nil {
+	if err := sqlstore.ApplySchema(ctx, db, dialect, &cfg.Common.SQL); err != nil {
 		return nil, err
 	}
 	service.SQLDB = db

--- a/internal/apigw/db/service.go
+++ b/internal/apigw/db/service.go
@@ -73,6 +73,7 @@ func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.
 		log:     log.New("VCDatastoreColl"),
 	}
 	if err := datastoreColl.createIndex(ctx); err != nil {
+		service.disconnectMongoOnStartupError()
 		return nil, err
 	}
 	service.DatastoreColl = datastoreColl
@@ -83,6 +84,7 @@ func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.
 		log:     log.New("VCIdentityMappingsColl"),
 	}
 	if err := identityMappingsColl.createIndex(ctx); err != nil {
+		service.disconnectMongoOnStartupError()
 		return nil, err
 	}
 	service.IdentityMappingsColl = identityMappingsColl
@@ -90,18 +92,33 @@ func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.
 	service.CredentialOfferColl, err = NewCredentialOfferColl(ctx, "credential_offer", service, log.New("VCCredentialOfferColl"))
 	if err != nil {
 		service.log.Error(err, "failed to create credential offer collection")
+		service.disconnectMongoOnStartupError()
 		return nil, err
 	}
 
 	service.DynamicRegistrationColl, err = NewDynamicRegistrationColl(ctx, "oidc_dynamic_registration", service, log.New("VCDynamicRegistrationColl"))
 	if err != nil {
 		service.log.Error(err, "failed to create dynamic registration collection")
+		service.disconnectMongoOnStartupError()
 		return nil, err
 	}
 
 	service.log.Info("Started")
 
 	return service, nil
+}
+
+// disconnectMongoOnStartupError disconnects the Mongo client after a
+// collection/index setup failure in New, so a failed startup doesn't leak
+// the already-open connection. Uses a fresh background context (not the
+// caller's, which may be close to its own startup deadline) so cleanup
+// still runs even if that deadline has passed.
+func (s *Service) disconnectMongoOnStartupError() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.MongoClient.Disconnect(ctx); err != nil {
+		s.log.Error(err, "failed to disconnect mongo client after startup error")
+	}
 }
 
 // Status returns the status of the database

--- a/internal/apigw/db/service.go
+++ b/internal/apigw/db/service.go
@@ -8,8 +8,10 @@ import (
 	"github.com/SUNET/vc/internal/gen/status/apiv1_status"
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/trace"
 
+	"github.com/jmoiron/sqlx"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -20,6 +22,7 @@ var ErrNoDocuments = errors.New("no documents in result")
 // Service is the database service
 type Service struct {
 	MongoClient *mongo.Client
+	SQLDB       *sqlx.DB
 	cfg         *model.Cfg
 	log         *logger.Log
 	tracer      *trace.Tracer
@@ -31,8 +34,21 @@ type Service struct {
 	DynamicRegistrationColl DynamicRegistrationStore
 }
 
-// New creates a new database service
+// New creates a new database service. The storage backend is selected by
+// cfg.Common.SQL.Backend: "postgres" or "mariadb" connect to the
+// corresponding relational database (via pkg/sqlstore, running schema
+// migrations at startup); anything else (including unset, the default)
+// keeps the existing MongoDB-backed behavior unchanged.
 func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
+	switch cfg.Common.SQL.Backend {
+	case "postgres", "mariadb":
+		return newSQL(ctx, cfg, tracer, log)
+	default:
+		return newMongo(ctx, cfg, tracer, log)
+	}
+}
+
+func newMongo(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
 	service := &Service{
 		log:        log.New("db"),
 		cfg:        cfg,
@@ -86,6 +102,36 @@ func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.
 	return service, nil
 }
 
+func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
+	service := &Service{
+		log:        log.New("db"),
+		cfg:        cfg,
+		tracer:     tracer,
+		probeStore: &apiv1_status.StatusProbeStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	db, dialect, err := sqlstore.Connect(ctx, &cfg.Common.SQL)
+	if err != nil {
+		return nil, err
+	}
+	if err := sqlstore.Migrate(db, dialect); err != nil {
+		return nil, err
+	}
+	service.SQLDB = db
+
+	service.DatastoreColl = NewSQLDatastoreColl(service, db, dialect)
+	service.IdentityMappingsColl = NewSQLIdentityMappingsColl(service, db, dialect)
+	service.CredentialOfferColl = NewSQLCredentialOfferColl(service, db, dialect)
+	service.DynamicRegistrationColl = NewSQLDynamicRegistrationColl(service, db, dialect)
+
+	service.log.Info("Started", "backend", cfg.Common.SQL.Backend)
+
+	return service, nil
+}
+
 // connect connects to the database
 func (s *Service) connect(ctx context.Context) error {
 	ctx, span := s.tracer.Start(ctx, "apigw:db:connect")
@@ -119,7 +165,13 @@ func (s *Service) Status(ctx context.Context) *apiv1_status.StatusProbe {
 		LastCheckedTS: timestamppb.Now(),
 	}
 
-	if err := s.MongoClient.Ping(ctx, nil); err != nil {
+	var err error
+	if s.SQLDB != nil {
+		err = s.SQLDB.PingContext(ctx)
+	} else {
+		err = s.MongoClient.Ping(ctx, nil)
+	}
+	if err != nil {
 		probe.Message = err.Error()
 		probe.Healthy = false
 	}
@@ -132,6 +184,9 @@ func (s *Service) Status(ctx context.Context) *apiv1_status.StatusProbe {
 
 // Close closes the database connection
 func (s *Service) Close(ctx context.Context) error {
+	if s.SQLDB != nil {
+		return s.SQLDB.Close()
+	}
 	if err := s.MongoClient.Disconnect(ctx); err != nil {
 		return err
 	}

--- a/internal/apigw/db/service.go
+++ b/internal/apigw/db/service.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ErrNoDocuments is returned when no documents are found
@@ -113,11 +112,8 @@ func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logg
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	db, dialect, err := sqlstore.Connect(ctx, &cfg.Common.SQL)
+	db, dialect, err := sqlstore.ConnectAndApplySchema(ctx, &cfg.Common.SQL)
 	if err != nil {
-		return nil, err
-	}
-	if err := sqlstore.ApplySchema(ctx, db, dialect, &cfg.Common.SQL); err != nil {
 		return nil, err
 	}
 	service.SQLDB = db
@@ -155,41 +151,16 @@ func (s *Service) Status(ctx context.Context) *apiv1_status.StatusProbe {
 	ctx, span := s.tracer.Start(ctx, "db:status")
 	defer span.End()
 
-	if time.Now().Before(s.probeStore.NextCheck.AsTime()) {
-		return s.probeStore.PreviousResult
+	ping := func(ctx context.Context) error {
+		if s.SQLDB != nil {
+			return s.SQLDB.PingContext(ctx)
+		}
+		return s.MongoClient.Ping(ctx, nil)
 	}
-	probe := &apiv1_status.StatusProbe{
-		Name:          "db",
-		Healthy:       true,
-		Message:       "OK",
-		LastCheckedTS: timestamppb.Now(),
-	}
-
-	var err error
-	if s.SQLDB != nil {
-		err = s.SQLDB.PingContext(ctx)
-	} else {
-		err = s.MongoClient.Ping(ctx, nil)
-	}
-	if err != nil {
-		probe.Message = err.Error()
-		probe.Healthy = false
-	}
-
-	s.probeStore.PreviousResult = probe
-	s.probeStore.NextCheck = timestamppb.New(time.Now().Add(10 * time.Second))
-
-	return probe
+	return sqlstore.ProbeStatus(ctx, s.probeStore, ping)
 }
 
 // Close closes the database connection
 func (s *Service) Close(ctx context.Context) error {
-	if s.SQLDB != nil {
-		return s.SQLDB.Close()
-	}
-	if err := s.MongoClient.Disconnect(ctx); err != nil {
-		return err
-	}
-	ctx.Done()
-	return nil
+	return sqlstore.CloseBackend(s.SQLDB, func() error { return s.MongoClient.Disconnect(ctx) })
 }

--- a/internal/apigw/db/service.go
+++ b/internal/apigw/db/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/SUNET/vc/internal/gen/status/apiv1_status"
+	"github.com/SUNET/vc/pkg/dbservice"
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/sqlstore"
@@ -39,28 +40,32 @@ type Service struct {
 // migrations at startup); anything else (including unset, the default)
 // keeps the existing MongoDB-backed behavior unchanged.
 func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
-	switch cfg.Common.SQL.Backend {
-	case "postgres", "mariadb":
-		return newSQL(ctx, cfg, tracer, log)
-	default:
-		return newMongo(ctx, cfg, tracer, log)
+	conn, err := dbservice.Connect(ctx, cfg, tracer, "apigw:db:connect")
+	if err != nil {
+		return nil, err
 	}
-}
 
-func newMongo(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
 	service := &Service{
-		log:        log.New("db"),
-		cfg:        cfg,
-		tracer:     tracer,
-		probeStore: &apiv1_status.StatusProbeStore{},
+		log:         log.New("db"),
+		cfg:         cfg,
+		tracer:      tracer,
+		probeStore:  &apiv1_status.StatusProbeStore{},
+		MongoClient: conn.MongoClient,
+		SQLDB:       conn.SQLDB,
+	}
+
+	if conn.SQLDB != nil {
+		service.DatastoreColl = NewSQLDatastoreColl(service, conn.SQLDB, conn.Dialect)
+		service.IdentityMappingsColl = NewSQLIdentityMappingsColl(service, conn.SQLDB, conn.Dialect)
+		service.CredentialOfferColl = NewSQLCredentialOfferColl(service, conn.SQLDB, conn.Dialect)
+		service.DynamicRegistrationColl = NewSQLDynamicRegistrationColl(service, conn.SQLDB, conn.Dialect)
+
+		service.log.Info("Started", "backend", cfg.Common.SQL.Backend)
+		return service, nil
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
-
-	if err := service.connect(ctx); err != nil {
-		return nil, err
-	}
 
 	datastoreColl := &DatastoreColl{
 		Service: service,
@@ -82,8 +87,6 @@ func newMongo(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *lo
 	}
 	service.IdentityMappingsColl = identityMappingsColl
 
-	var err error
-
 	service.CredentialOfferColl, err = NewCredentialOfferColl(ctx, "credential_offer", service, log.New("VCCredentialOfferColl"))
 	if err != nil {
 		service.log.Error(err, "failed to create credential offer collection")
@@ -99,51 +102,6 @@ func newMongo(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *lo
 	service.log.Info("Started")
 
 	return service, nil
-}
-
-func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
-	service := &Service{
-		log:        log.New("db"),
-		cfg:        cfg,
-		tracer:     tracer,
-		probeStore: &apiv1_status.StatusProbeStore{},
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
-	defer cancel()
-
-	db, dialect, err := sqlstore.ConnectAndApplySchema(ctx, &cfg.Common.SQL)
-	if err != nil {
-		return nil, err
-	}
-	service.SQLDB = db
-
-	service.DatastoreColl = NewSQLDatastoreColl(service, db, dialect)
-	service.IdentityMappingsColl = NewSQLIdentityMappingsColl(service, db, dialect)
-	service.CredentialOfferColl = NewSQLCredentialOfferColl(service, db, dialect)
-	service.DynamicRegistrationColl = NewSQLDynamicRegistrationColl(service, db, dialect)
-
-	service.log.Info("Started", "backend", cfg.Common.SQL.Backend)
-
-	return service, nil
-}
-
-// connect connects to the database
-func (s *Service) connect(ctx context.Context) error {
-	ctx, span := s.tracer.Start(ctx, "apigw:db:connect")
-	defer span.End()
-
-	opts, err := s.cfg.Common.Mongo.MongoClientOptions()
-	if err != nil {
-		return err
-	}
-	client, err := mongo.Connect(opts)
-	if err != nil {
-		return err
-	}
-	s.MongoClient = client
-
-	return nil
 }
 
 // Status returns the status of the database

--- a/internal/apigw/db/service_sql_test.go
+++ b/internal/apigw/db/service_sql_test.go
@@ -6,29 +6,15 @@ import (
 	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/openid4vci"
 	"github.com/SUNET/vc/pkg/sqlstore"
-	"github.com/SUNET/vc/pkg/testsupport"
 	"github.com/SUNET/vc/pkg/testsupport/sqltest"
-	"github.com/SUNET/vc/pkg/testsupport/tracertest"
 
 	"github.com/stretchr/testify/require"
 )
 
-// testNewSQLService exercises the real New()/newSQL() code path end to end
-// (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring), as
-// opposed to the individual sql_*_test.go files, which construct each SQL
-// store directly against an already-migrated database.
-func testNewSQLService(t *testing.T, cfg *model.Cfg) *Service {
-	t.Helper()
-	log := testsupport.TestLogger(t)
-	tracer := tracertest.New(t, cfg, log, "apigw-db-sql-service-test")
-
-	svc, err := New(t.Context(), cfg, tracer, log)
-	require.NoError(t, err)
-	require.NotNil(t, svc)
-	t.Cleanup(func() { _ = svc.Close(t.Context()) })
-	return svc
-}
-
+// testNewServiceContract exercises the real New()/newSQL() code path end to
+// end (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring),
+// as opposed to the individual sql_*_test.go files, which construct each
+// SQL store directly against an already-migrated database.
 func testNewServiceContract(t *testing.T, svc *Service) {
 	t.Helper()
 	ctx := t.Context()
@@ -59,8 +45,7 @@ func TestNewService_Postgres(t *testing.T) {
 	defer cleanup()
 
 	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "postgres", Postgres: pgCfg}}}
-	svc := testNewSQLService(t, cfg)
-	testNewServiceContract(t, svc)
+	testNewServiceContract(t, sqltest.NewServiceForTest(t, "apigw-db-sql-service-test", cfg, New))
 }
 
 func TestNewService_MariaDB(t *testing.T) {
@@ -68,6 +53,5 @@ func TestNewService_MariaDB(t *testing.T) {
 	defer cleanup()
 
 	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
-	svc := testNewSQLService(t, cfg)
-	testNewServiceContract(t, svc)
+	testNewServiceContract(t, sqltest.NewServiceForTest(t, "apigw-db-sql-service-test", cfg, New))
 }

--- a/internal/apigw/db/service_sql_test.go
+++ b/internal/apigw/db/service_sql_test.go
@@ -3,55 +3,39 @@ package db
 import (
 	"testing"
 
-	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/openid4vci"
-	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/testsupport/sqltest"
 
 	"github.com/stretchr/testify/require"
 )
 
-// testNewServiceContract exercises the real New()/newSQL() code path end to
-// end (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring),
-// as opposed to the individual sql_*_test.go files, which construct each
-// SQL store directly against an already-migrated database.
-func testNewServiceContract(t *testing.T, svc *Service) {
-	t.Helper()
-	ctx := t.Context()
+// TestNewService exercises the real New()/newSQL() code path end to end
+// (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring)
+// against both Postgres and MariaDB, as opposed to the individual
+// sql_*_test.go files, which construct each SQL store directly against an
+// already-migrated database.
+func TestNewService(t *testing.T) {
+	sqltest.RunPostgresAndMariaDBContract(t, "apigw-db-sql-service-test", New, func(t *testing.T, svc *Service) {
+		ctx := t.Context()
 
-	require.NotNil(t, svc.DatastoreColl)
-	require.NotNil(t, svc.IdentityMappingsColl)
-	require.NotNil(t, svc.CredentialOfferColl)
-	require.NotNil(t, svc.DynamicRegistrationColl)
+		require.NotNil(t, svc.DatastoreColl)
+		require.NotNil(t, svc.IdentityMappingsColl)
+		require.NotNil(t, svc.CredentialOfferColl)
+		require.NotNil(t, svc.DynamicRegistrationColl)
 
-	// A minimal round-trip through one store confirms migrations actually
-	// ran and the wired stores work against a real connection.
-	require.NoError(t, svc.CredentialOfferColl.Save(ctx, &CredentialOfferDocument{
-		UUID: "svc-test-offer",
-		CredentialOfferParameters: openid4vci.CredentialOfferParameters{
-			CredentialIssuer: "https://issuer.example.com",
-		},
-	}))
-	got, err := svc.CredentialOfferColl.Get(ctx, "svc-test-offer")
-	require.NoError(t, err)
-	require.Equal(t, "https://issuer.example.com", got.CredentialOfferParameters.CredentialIssuer)
+		// A minimal round-trip through one store confirms migrations
+		// actually ran and the wired stores work against a real connection.
+		require.NoError(t, svc.CredentialOfferColl.Save(ctx, &CredentialOfferDocument{
+			UUID: "svc-test-offer",
+			CredentialOfferParameters: openid4vci.CredentialOfferParameters{
+				CredentialIssuer: "https://issuer.example.com",
+			},
+		}))
+		got, err := svc.CredentialOfferColl.Get(ctx, "svc-test-offer")
+		require.NoError(t, err)
+		require.Equal(t, "https://issuer.example.com", got.CredentialOfferParameters.CredentialIssuer)
 
-	probe := svc.Status(ctx)
-	require.True(t, probe.Healthy)
-}
-
-func TestNewService_Postgres(t *testing.T) {
-	pgCfg, cleanup := sqltest.PostgresConfig(t)
-	defer cleanup()
-
-	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "postgres", Postgres: pgCfg}}}
-	testNewServiceContract(t, sqltest.NewServiceForTest(t, "apigw-db-sql-service-test", cfg, New))
-}
-
-func TestNewService_MariaDB(t *testing.T) {
-	mdbCfg, cleanup := sqltest.MariaDBConfig(t)
-	defer cleanup()
-
-	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
-	testNewServiceContract(t, sqltest.NewServiceForTest(t, "apigw-db-sql-service-test", cfg, New))
+		probe := svc.Status(ctx)
+		require.True(t, probe.Healthy)
+	})
 }

--- a/internal/apigw/db/service_sql_test.go
+++ b/internal/apigw/db/service_sql_test.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/openid4vci"
+	"github.com/SUNET/vc/pkg/testsupport"
+	"github.com/SUNET/vc/pkg/testsupport/sqltest"
+	"github.com/SUNET/vc/pkg/testsupport/tracertest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testNewSQLService exercises the real New()/newSQL() code path end to end
+// (config -> sqlstore.Connect -> sqlstore.Migrate -> store wiring), as
+// opposed to the individual sql_*_test.go files, which construct each SQL
+// store directly against an already-migrated database.
+func testNewSQLService(t *testing.T, cfg *model.Cfg) *Service {
+	t.Helper()
+	log := testsupport.TestLogger(t)
+	tracer := tracertest.New(t, cfg, log, "apigw-db-sql-service-test")
+
+	svc, err := New(t.Context(), cfg, tracer, log)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	t.Cleanup(func() { _ = svc.Close(t.Context()) })
+	return svc
+}
+
+func testNewServiceContract(t *testing.T, svc *Service) {
+	t.Helper()
+	ctx := t.Context()
+
+	require.NotNil(t, svc.DatastoreColl)
+	require.NotNil(t, svc.IdentityMappingsColl)
+	require.NotNil(t, svc.CredentialOfferColl)
+	require.NotNil(t, svc.DynamicRegistrationColl)
+
+	// A minimal round-trip through one store confirms migrations actually
+	// ran and the wired stores work against a real connection.
+	require.NoError(t, svc.CredentialOfferColl.Save(ctx, &CredentialOfferDocument{
+		UUID: "svc-test-offer",
+		CredentialOfferParameters: openid4vci.CredentialOfferParameters{
+			CredentialIssuer: "https://issuer.example.com",
+		},
+	}))
+	got, err := svc.CredentialOfferColl.Get(ctx, "svc-test-offer")
+	require.NoError(t, err)
+	require.Equal(t, "https://issuer.example.com", got.CredentialOfferParameters.CredentialIssuer)
+
+	probe := svc.Status(ctx)
+	require.True(t, probe.Healthy)
+}
+
+func TestNewService_Postgres(t *testing.T) {
+	pgCfg, cleanup := sqltest.PostgresConfig(t)
+	defer cleanup()
+
+	cfg := &model.Cfg{Common: &model.Common{SQL: model.SQL{Backend: "postgres", Postgres: pgCfg}}}
+	svc := testNewSQLService(t, cfg)
+	testNewServiceContract(t, svc)
+}
+
+func TestNewService_MariaDB(t *testing.T) {
+	mdbCfg, cleanup := sqltest.MariaDBConfig(t)
+	defer cleanup()
+
+	cfg := &model.Cfg{Common: &model.Common{SQL: model.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
+	svc := testNewSQLService(t, cfg)
+	testNewServiceContract(t, svc)
+}

--- a/internal/apigw/db/service_sql_test.go
+++ b/internal/apigw/db/service_sql_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/openid4vci"
+	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/testsupport"
 	"github.com/SUNET/vc/pkg/testsupport/sqltest"
 	"github.com/SUNET/vc/pkg/testsupport/tracertest"
@@ -57,7 +58,7 @@ func TestNewService_Postgres(t *testing.T) {
 	pgCfg, cleanup := sqltest.PostgresConfig(t)
 	defer cleanup()
 
-	cfg := &model.Cfg{Common: &model.Common{SQL: model.SQL{Backend: "postgres", Postgres: pgCfg}}}
+	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "postgres", Postgres: pgCfg}}}
 	svc := testNewSQLService(t, cfg)
 	testNewServiceContract(t, svc)
 }
@@ -66,7 +67,7 @@ func TestNewService_MariaDB(t *testing.T) {
 	mdbCfg, cleanup := sqltest.MariaDBConfig(t)
 	defer cleanup()
 
-	cfg := &model.Cfg{Common: &model.Common{SQL: model.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
+	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
 	svc := testNewSQLService(t, cfg)
 	testNewServiceContract(t, svc)
 }

--- a/internal/apigw/db/service_sql_test.go
+++ b/internal/apigw/db/service_sql_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // testNewSQLService exercises the real New()/newSQL() code path end to end
-// (config -> sqlstore.Connect -> sqlstore.Migrate -> store wiring), as
+// (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring), as
 // opposed to the individual sql_*_test.go files, which construct each SQL
 // store directly against an already-migrated database.
 func testNewSQLService(t *testing.T, cfg *model.Cfg) *Service {

--- a/internal/apigw/db/sql_credential_offer.go
+++ b/internal/apigw/db/sql_credential_offer.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"context"
+
+	"github.com/SUNET/vc/pkg/openid4vci"
+	"github.com/SUNET/vc/pkg/sqlstore"
+
+	"github.com/jmoiron/sqlx"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// SQLCredentialOfferColl is a SQL-backed implementation of CredentialOfferStore.
+type SQLCredentialOfferColl struct {
+	Service *Service
+	db      *sqlx.DB
+	dialect sqlstore.Dialect
+}
+
+// NewSQLCredentialOfferColl creates a SQL-backed CredentialOfferStore.
+func NewSQLCredentialOfferColl(service *Service, db *sqlx.DB, dialect sqlstore.Dialect) *SQLCredentialOfferColl {
+	return &SQLCredentialOfferColl{Service: service, db: db, dialect: dialect}
+}
+
+type credentialOfferRow struct {
+	UUID       string                                              `db:"uuid"`
+	Parameters sqlstore.JSON[openid4vci.CredentialOfferParameters] `db:"credential_offer_parameters"`
+}
+
+// Save saves one credential offer document.
+func (c *SQLCredentialOfferColl) Save(ctx context.Context, doc *CredentialOfferDocument) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:credential_offer:save")
+	defer span.End()
+
+	query := c.dialect.Rebind(`INSERT INTO credential_offer (uuid, credential_offer_parameters) VALUES (?, ?)`)
+	_, err := c.db.ExecContext(ctx, query,
+		doc.UUID,
+		sqlstore.JSON[openid4vci.CredentialOfferParameters]{V: doc.CredentialOfferParameters},
+	)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// Delete deletes one credential offer by uuid.
+func (c *SQLCredentialOfferColl) Delete(ctx context.Context, uuid string) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:credential_offer:delete")
+	defer span.End()
+
+	query := c.dialect.Rebind(`DELETE FROM credential_offer WHERE uuid = ?`)
+	if _, err := c.db.ExecContext(ctx, query, uuid); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// Get returns the credential offer document for the given uuid.
+func (c *SQLCredentialOfferColl) Get(ctx context.Context, uuid string) (*CredentialOfferDocument, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:credential_offer:get")
+	defer span.End()
+
+	query := c.dialect.Rebind(`SELECT uuid, credential_offer_parameters FROM credential_offer WHERE uuid = ?`)
+	var row credentialOfferRow
+	if err := c.db.GetContext(ctx, &row, query, uuid); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	return &CredentialOfferDocument{
+		UUID:                      row.UUID,
+		CredentialOfferParameters: row.Parameters.V,
+	}, nil
+}

--- a/internal/apigw/db/sql_credential_offer_test.go
+++ b/internal/apigw/db/sql_credential_offer_test.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/openid4vci"
+	"github.com/SUNET/vc/pkg/testsupport"
+	"github.com/SUNET/vc/pkg/testsupport/sqltest"
+	"github.com/SUNET/vc/pkg/testsupport/tracertest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestService builds a *Service suitable for exercising SQL-backed store
+// implementations directly (bypassing New(), which would try to connect to
+// MongoDB): only the fields the sql_*.go implementations actually use
+// (tracer, log) are populated.
+func newTestService(t *testing.T) *Service {
+	t.Helper()
+	log := testsupport.TestLogger(t)
+	tracer := tracertest.New(t, nil, log, "apigw-db-test")
+	return &Service{tracer: tracer, log: log}
+}
+
+func testCredentialOfferStoreContract(t *testing.T, store CredentialOfferStore) {
+	t.Helper()
+	ctx := t.Context()
+
+	doc := &CredentialOfferDocument{
+		UUID: "offer-1",
+		CredentialOfferParameters: openid4vci.CredentialOfferParameters{
+			CredentialIssuer:           "https://issuer.example.com",
+			CredentialConfigurationIDs: []string{"pid"},
+			Grants: map[string]any{
+				openid4vci.GrantTypePreAuthorizedCode: map[string]any{"pre-authorized_code": "abc123"},
+			},
+		},
+	}
+	require.NoError(t, store.Save(ctx, doc))
+
+	got, err := store.Get(ctx, "offer-1")
+	require.NoError(t, err)
+	assert.Equal(t, "offer-1", got.UUID)
+	assert.Equal(t, "https://issuer.example.com", got.CredentialOfferParameters.CredentialIssuer)
+	assert.Equal(t, []string{"pid"}, got.CredentialOfferParameters.CredentialConfigurationIDs)
+	assert.NotNil(t, got.CredentialOfferParameters.Grants[openid4vci.GrantTypePreAuthorizedCode])
+
+	require.NoError(t, store.Delete(ctx, "offer-1"))
+
+	_, err = store.Get(ctx, "offer-1")
+	assert.Error(t, err, "expected an error looking up a deleted offer")
+}
+
+func TestSQLCredentialOfferColl_Postgres(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartPostgres(t)
+	defer cleanup()
+
+	testCredentialOfferStoreContract(t, NewSQLCredentialOfferColl(newTestService(t), sqlDB, dialect))
+}
+
+func TestSQLCredentialOfferColl_MariaDB(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartMariaDB(t)
+	defer cleanup()
+
+	testCredentialOfferStoreContract(t, NewSQLCredentialOfferColl(newTestService(t), sqlDB, dialect))
+}

--- a/internal/apigw/db/sql_datastore.go
+++ b/internal/apigw/db/sql_datastore.go
@@ -265,7 +265,13 @@ func (c *SQLDatastoreColl) AddIdentity(ctx context.Context, query *AddIdentityQu
 	// $addToSet semantics): one round-trip and one atomic statement, rather
 	// than one INSERT per id, which was both N round-trips and non-atomic
 	// (a failure partway through would leave a subset of ids inserted).
-	values, args := identityMappingRowsValues(query.AuthenticSource, query.Scope, query.DocumentID, query.IdentityMappingIDs)
+	// Dedupe first: model.CompleteDocument doesn't validate
+	// IdentityMappingIDs is duplicate-free, and a caller-supplied duplicate
+	// would otherwise still do unnecessary work in the same INSERT (or, on
+	// backends where ON CONFLICT/ON DUPLICATE KEY can't cleanly resolve two
+	// identical rows in one statement, fail).
+	identityMappingIDs := dedupeStrings(query.IdentityMappingIDs)
+	values, args := identityMappingRowsValues(query.AuthenticSource, query.Scope, query.DocumentID, identityMappingIDs)
 	q := c.dialect.Rebind(fmt.Sprintf(
 		`INSERT INTO datastore_identity_mapping (authentic_source, scope, document_id, identity_mapping_id) VALUES %s %s`,
 		values,

--- a/internal/apigw/db/sql_datastore.go
+++ b/internal/apigw/db/sql_datastore.go
@@ -130,10 +130,33 @@ func identityMappingRowsValues(authenticSource, scope, documentID string, identi
 	return strings.Join(placeholders, ", "), args
 }
 
+// dedupeStrings returns ids with duplicates removed, preserving the order
+// of first occurrence.
+func dedupeStrings(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	result := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result
+}
+
 func (c *SQLDatastoreColl) insertIdentityMappings(ctx context.Context, q sqlxExtQuerier, meta *model.MetaData, identityMappingIDs []string) error {
 	if len(identityMappingIDs) == 0 {
 		return nil
 	}
+	// The table's primary key is (authentic_source, scope, document_id,
+	// identity_mapping_id); model.CompleteDocument doesn't validate
+	// identityMappingIDs is duplicate-free, and Mongo's array field happily
+	// stores duplicate entries. Dedupe (first occurrence wins) before
+	// building the VALUES list so a caller-supplied duplicate doesn't turn
+	// into a constraint-violation error the Mongo backend would never hit
+	// for the exact same input.
+	identityMappingIDs = dedupeStrings(identityMappingIDs)
 	values, args := identityMappingRowsValues(meta.AuthenticSource, meta.Scope, meta.DocumentID, identityMappingIDs)
 	query := c.dialect.Rebind(fmt.Sprintf(
 		`INSERT INTO datastore_identity_mapping (authentic_source, scope, document_id, identity_mapping_id) VALUES %s`,

--- a/internal/apigw/db/sql_datastore.go
+++ b/internal/apigw/db/sql_datastore.go
@@ -1,0 +1,579 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/SUNET/vc/pkg/helpers"
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sqlstore"
+
+	"github.com/jmoiron/sqlx"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// SQLDatastoreColl is a SQL-backed implementation of DatastoreStore.
+type SQLDatastoreColl struct {
+	Service *Service
+	db      *sqlx.DB
+	dialect sqlstore.Dialect
+}
+
+// NewSQLDatastoreColl creates a SQL-backed DatastoreStore.
+func NewSQLDatastoreColl(service *Service, db *sqlx.DB, dialect sqlstore.Dialect) *SQLDatastoreColl {
+	return &SQLDatastoreColl{Service: service, db: db, dialect: dialect}
+}
+
+// sqlxExtQuerier is satisfied by both *sqlx.DB and *sqlx.Tx, so helper
+// methods below work identically inside or outside a transaction.
+type sqlxExtQuerier interface {
+	SelectContext(ctx context.Context, dest any, query string, args ...any) error
+	GetContext(ctx context.Context, dest any, query string, args ...any) error
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+type datastoreRow struct {
+	AuthenticSource        string                        `db:"authentic_source"`
+	Scope                  string                        `db:"scope"`
+	DocumentID             string                        `db:"document_id"`
+	DocumentDataValidation sql.NullString                `db:"document_data_validation"`
+	DocumentData           sqlstore.JSON[map[string]any] `db:"document_data"`
+	ValidNotAfter          sql.NullTime                  `db:"valid_not_after"`
+	CreatedAt              time.Time                     `db:"created_at"`
+}
+
+func (row datastoreRow) toMeta() *model.MetaData {
+	meta := &model.MetaData{
+		AuthenticSource:           row.AuthenticSource,
+		Scope:                     row.Scope,
+		DocumentID:                row.DocumentID,
+		DocumentDataValidationRef: row.DocumentDataValidation.String,
+		CreatedAt:                 row.CreatedAt,
+	}
+	if row.ValidNotAfter.Valid {
+		t := row.ValidNotAfter.Time
+		meta.ValidNotAfter = &t
+	}
+	return meta
+}
+
+type datastoreMetaRow struct {
+	AuthenticSource        string         `db:"authentic_source"`
+	Scope                  string         `db:"scope"`
+	DocumentID             string         `db:"document_id"`
+	DocumentDataValidation sql.NullString `db:"document_data_validation"`
+	ValidNotAfter          sql.NullTime   `db:"valid_not_after"`
+	CreatedAt              time.Time      `db:"created_at"`
+}
+
+func (row datastoreMetaRow) toMeta() *model.MetaData {
+	meta := &model.MetaData{
+		AuthenticSource:           row.AuthenticSource,
+		Scope:                     row.Scope,
+		DocumentID:                row.DocumentID,
+		DocumentDataValidationRef: row.DocumentDataValidation.String,
+		CreatedAt:                 row.CreatedAt,
+	}
+	if row.ValidNotAfter.Valid {
+		t := row.ValidNotAfter.Time
+		meta.ValidNotAfter = &t
+	}
+	return meta
+}
+
+// Count returns the (possibly approximate) number of documents in the datastore.
+func (c *SQLDatastoreColl) Count(ctx context.Context) (int64, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:datastore:count")
+	defer span.End()
+
+	var count int64
+	if err := c.db.GetContext(ctx, &count, "SELECT COUNT(*) FROM datastore"); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return 0, err
+	}
+	return count, nil
+}
+
+func (c *SQLDatastoreColl) insertDocument(ctx context.Context, q sqlxExtQuerier, doc *model.CompleteDocument) error {
+	query := c.dialect.Rebind(`INSERT INTO datastore
+		(authentic_source, scope, document_id, document_data_validation, document_data, valid_not_after, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`)
+
+	var validNotAfter sql.NullTime
+	if doc.Meta.ValidNotAfter != nil {
+		validNotAfter = sql.NullTime{Time: *doc.Meta.ValidNotAfter, Valid: true}
+	}
+
+	_, err := q.ExecContext(ctx, query,
+		doc.Meta.AuthenticSource, doc.Meta.Scope, doc.Meta.DocumentID,
+		doc.Meta.DocumentDataValidationRef, sqlstore.JSON[map[string]any]{V: doc.DocumentData},
+		validNotAfter, doc.Meta.CreatedAt,
+	)
+	return err
+}
+
+func (c *SQLDatastoreColl) insertIdentityMappings(ctx context.Context, q sqlxExtQuerier, meta *model.MetaData, identityMappingIDs []string) error {
+	if len(identityMappingIDs) == 0 {
+		return nil
+	}
+	placeholders := make([]string, 0, len(identityMappingIDs))
+	args := make([]any, 0, len(identityMappingIDs)*4)
+	for _, id := range identityMappingIDs {
+		placeholders = append(placeholders, "(?, ?, ?, ?)")
+		args = append(args, meta.AuthenticSource, meta.Scope, meta.DocumentID, id)
+	}
+	query := c.dialect.Rebind(fmt.Sprintf(
+		`INSERT INTO datastore_identity_mapping (authentic_source, scope, document_id, identity_mapping_id) VALUES %s`,
+		strings.Join(placeholders, ", "),
+	))
+	_, err := q.ExecContext(ctx, query, args...)
+	return err
+}
+
+// Save saves one document to the generic collection.
+func (c *SQLDatastoreColl) Save(ctx context.Context, doc *model.CompleteDocument) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:datastore:save")
+	defer span.End()
+
+	if err := helpers.Check(ctx, c.Service.cfg, doc, c.Service.log); err != nil {
+		return err
+	}
+	doc.Meta.CreatedAt = time.Now().UTC()
+
+	tx, err := c.db.BeginTxx(ctx, nil)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if err := c.insertDocument(ctx, tx, doc); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	if err := c.insertIdentityMappings(ctx, tx, doc.Meta, doc.IdentityMappingIDs); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// SaveMany saves multiple documents to the generic collection.
+func (c *SQLDatastoreColl) SaveMany(ctx context.Context, docs []*model.CompleteDocument) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:datastore:saveMany")
+	defer span.End()
+
+	now := time.Now().UTC()
+	for _, doc := range docs {
+		if err := helpers.Check(ctx, c.Service.cfg, doc, c.Service.log); err != nil {
+			return err
+		}
+		doc.Meta.CreatedAt = now
+	}
+
+	tx, err := c.db.BeginTxx(ctx, nil)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	for _, doc := range docs {
+		if err := c.insertDocument(ctx, tx, doc); err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+		if err := c.insertIdentityMappings(ctx, tx, doc.Meta, doc.IdentityMappingIDs); err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+func (c *SQLDatastoreColl) documentExists(ctx context.Context, q sqlxExtQuerier, authenticSource, scope, documentID string) (bool, error) {
+	query := c.dialect.Rebind(`SELECT 1 FROM datastore WHERE authentic_source = ? AND scope = ? AND document_id = ?`)
+	var exists int
+	err := q.GetContext(ctx, &exists, query, authenticSource, scope, documentID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// AddIdentity adds document identity.
+func (c *SQLDatastoreColl) AddIdentity(ctx context.Context, query *AddIdentityQuery) error {
+	ok, err := c.documentExists(ctx, c.db, query.AuthenticSource, query.Scope, query.DocumentID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return helpers.ErrNoDocumentFound
+	}
+	meta := &model.MetaData{AuthenticSource: query.AuthenticSource, Scope: query.Scope, DocumentID: query.DocumentID}
+
+	// Dedup: insert-if-absent per id, matching Mongo's $addToSet semantics.
+	for _, id := range query.IdentityMappingIDs {
+		q := c.dialect.Rebind(fmt.Sprintf(
+			`INSERT INTO datastore_identity_mapping (authentic_source, scope, document_id, identity_mapping_id) VALUES (?, ?, ?, ?) %s`,
+			c.dialect.UpsertClause([]string{"authentic_source", "scope", "document_id", "identity_mapping_id"}, nil),
+		))
+		if _, err := c.db.ExecContext(ctx, q, meta.AuthenticSource, meta.Scope, meta.DocumentID, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteIdentity deletes identity in document.
+func (c *SQLDatastoreColl) DeleteIdentity(ctx context.Context, query *DeleteIdentityQuery) error {
+	ok, err := c.documentExists(ctx, c.db, query.AuthenticSource, query.Scope, query.DocumentID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return helpers.ErrNoDocumentFound
+	}
+
+	sqlQuery := c.dialect.Rebind(`DELETE FROM datastore_identity_mapping
+		WHERE authentic_source = ? AND scope = ? AND document_id = ? AND identity_mapping_id = ?`)
+	_, err = c.db.ExecContext(ctx, sqlQuery, query.AuthenticSource, query.Scope, query.DocumentID, query.AuthenticSourcePersonID)
+	return err
+}
+
+// Delete deletes a document. Mirrors Mongo's Delete: silently succeeds even
+// if nothing matched.
+func (c *SQLDatastoreColl) Delete(ctx context.Context, doc *model.MetaData) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:datastore:delete")
+	defer span.End()
+
+	query := c.dialect.Rebind(`DELETE FROM datastore WHERE authentic_source = ? AND scope = ? AND document_id = ?`)
+	if _, err := c.db.ExecContext(ctx, query, doc.AuthenticSource, doc.Scope, doc.DocumentID); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// Get returns the matching document, or an error if none exists.
+func (c *SQLDatastoreColl) Get(ctx context.Context, meta *model.MetaData) (*model.Document, error) {
+	query := c.dialect.Rebind(`SELECT authentic_source, scope, document_id, document_data_validation, document_data, valid_not_after, created_at
+		FROM datastore WHERE authentic_source = ? AND scope = ? AND document_id = ?`)
+
+	var row datastoreRow
+	if err := c.db.GetContext(ctx, &row, query, meta.AuthenticSource, meta.Scope, meta.DocumentID); err != nil {
+		return nil, err
+	}
+
+	return &model.Document{Meta: row.toMeta(), DocumentData: row.DocumentData.V}, nil
+}
+
+// fetchIdentityMappingIDs returns all identity_mapping_id values for a given document key, sorted.
+func (c *SQLDatastoreColl) fetchIdentityMappingIDs(ctx context.Context, q sqlxExtQuerier, authenticSource, scope, documentID string) ([]string, error) {
+	query := c.dialect.Rebind(`SELECT identity_mapping_id FROM datastore_identity_mapping
+		WHERE authentic_source = ? AND scope = ? AND document_id = ? ORDER BY identity_mapping_id`)
+	var ids []string
+	if err := q.SelectContext(ctx, &ids, query, authenticSource, scope, documentID); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func (c *SQLDatastoreColl) toCompleteDocument(ctx context.Context, row datastoreRow) (*model.CompleteDocument, error) {
+	ids, err := c.fetchIdentityMappingIDs(ctx, c.db, row.AuthenticSource, row.Scope, row.DocumentID)
+	if err != nil {
+		return nil, err
+	}
+	return &model.CompleteDocument{
+		Meta:               row.toMeta(),
+		IdentityMappingIDs: ids,
+		DocumentData:       row.DocumentData.V,
+	}, nil
+}
+
+// GetByIdentity returns matching documents for a scope where any of the
+// document's identity mappings match the provided identifier.
+func (c *SQLDatastoreColl) GetByIdentity(ctx context.Context, scope, identityMappingID string) (map[string]*model.CompleteDocument, error) {
+	query := c.dialect.Rebind(`SELECT d.authentic_source, d.scope, d.document_id, d.document_data_validation, d.document_data, d.valid_not_after, d.created_at
+		FROM datastore d
+		JOIN datastore_identity_mapping m
+			ON d.authentic_source = m.authentic_source AND d.scope = m.scope AND d.document_id = m.document_id
+		WHERE d.scope = ? AND m.identity_mapping_id = ?`)
+
+	var rows []datastoreRow
+	if err := c.db.SelectContext(ctx, &rows, query, scope, identityMappingID); err != nil {
+		return nil, err
+	}
+
+	docs := make(map[string]*model.CompleteDocument, len(rows))
+	for _, row := range rows {
+		doc, err := c.toCompleteDocument(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+		docs[doc.Meta.AuthenticSource] = doc
+	}
+	return docs, nil
+}
+
+// List returns matching document metadata, filtered by identity mapping and
+// optionally authentic_source/scope.
+func (c *SQLDatastoreColl) List(ctx context.Context, query *ListQuery) ([]*model.DocumentList, error) {
+	if err := helpers.Check(ctx, c.Service.cfg, query, c.Service.log); err != nil {
+		return nil, err
+	}
+
+	conditions := []string{"m.identity_mapping_id = ?"}
+	args := []any{query.IdentityMappingID}
+	if query.AuthenticSource != "" {
+		conditions = append(conditions, "d.authentic_source = ?")
+		args = append(args, query.AuthenticSource)
+	}
+	if query.Scope != "" {
+		conditions = append(conditions, "d.scope = ?")
+		args = append(args, query.Scope)
+	}
+
+	sqlQuery := c.dialect.Rebind(fmt.Sprintf(
+		`SELECT d.authentic_source, d.scope, d.document_id, d.document_data_validation, d.valid_not_after, d.created_at
+		 FROM datastore d
+		 JOIN datastore_identity_mapping m
+			ON d.authentic_source = m.authentic_source AND d.scope = m.scope AND d.document_id = m.document_id
+		 WHERE %s`,
+		strings.Join(conditions, " AND "),
+	))
+
+	var rows []datastoreMetaRow
+	if err := c.db.SelectContext(ctx, &rows, sqlQuery, args...); err != nil {
+		return nil, err
+	}
+
+	res := make([]*model.DocumentList, len(rows))
+	for i, row := range rows {
+		res[i] = &model.DocumentList{Meta: row.toMeta()}
+	}
+	return res, nil
+}
+
+// Replace replaces one document, including its full set of identity
+// mappings, matching by natural key. Mirrors Mongo's ReplaceOne: silently
+// does nothing if no document matches.
+func (c *SQLDatastoreColl) Replace(ctx context.Context, doc *model.CompleteDocument) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:datastore:replace")
+	defer span.End()
+
+	tx, err := c.db.BeginTxx(ctx, nil)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	ok, err := c.documentExists(ctx, tx, doc.Meta.AuthenticSource, doc.Meta.Scope, doc.Meta.DocumentID)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	var validNotAfter sql.NullTime
+	if doc.Meta.ValidNotAfter != nil {
+		validNotAfter = sql.NullTime{Time: *doc.Meta.ValidNotAfter, Valid: true}
+	}
+	updateQuery := c.dialect.Rebind(`UPDATE datastore SET document_data_validation = ?, document_data = ?, valid_not_after = ?, created_at = ?
+		WHERE authentic_source = ? AND scope = ? AND document_id = ?`)
+	if _, err := tx.ExecContext(ctx, updateQuery,
+		doc.Meta.DocumentDataValidationRef, sqlstore.JSON[map[string]any]{V: doc.DocumentData}, validNotAfter, doc.Meta.CreatedAt,
+		doc.Meta.AuthenticSource, doc.Meta.Scope, doc.Meta.DocumentID,
+	); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	deleteQuery := c.dialect.Rebind(`DELETE FROM datastore_identity_mapping WHERE authentic_source = ? AND scope = ? AND document_id = ?`)
+	if _, err := tx.ExecContext(ctx, deleteQuery, doc.Meta.AuthenticSource, doc.Meta.Scope, doc.Meta.DocumentID); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	if err := c.insertIdentityMappings(ctx, tx, doc.Meta, doc.IdentityMappingIDs); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	c.Service.log.Info("updated document", "document_id", doc.Meta.DocumentID)
+	return nil
+}
+
+// GetByKey retrieves a document by its natural key (authentic_source, scope, document_id).
+func (c *SQLDatastoreColl) GetByKey(ctx context.Context, authenticSource, scope, documentID string) (*model.CompleteDocument, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:datastore:getDocumentByKey")
+	defer span.End()
+
+	query := c.dialect.Rebind(`SELECT authentic_source, scope, document_id, document_data_validation, document_data, valid_not_after, created_at
+		FROM datastore WHERE authentic_source = ? AND scope = ? AND document_id = ?`)
+
+	var row datastoreRow
+	if err := c.db.GetContext(ctx, &row, query, authenticSource, scope, documentID); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	return c.toCompleteDocument(ctx, row)
+}
+
+// DeleteByKey deletes a document by its natural key (authentic_source, scope, document_id).
+func (c *SQLDatastoreColl) DeleteByKey(ctx context.Context, authenticSource, scope, documentID string) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:datastore:deleteDocumentByKey")
+	defer span.End()
+
+	query := c.dialect.Rebind(`DELETE FROM datastore WHERE authentic_source = ? AND scope = ? AND document_id = ?`)
+	result, err := c.db.ExecContext(ctx, query, authenticSource, scope, documentID)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	if n == 0 {
+		return helpers.ErrNoDocumentFound
+	}
+	return nil
+}
+
+// Search returns documents matching a text search or filters, with a limit.
+// The document_data.* text search is a known perf tradeoff vs Mongo's
+// regex-across-BSON: neither Postgres nor MariaDB can cheaply full-text
+// index arbitrary, unschema'd JSON keys without knowing them in advance.
+func (c *SQLDatastoreColl) Search(ctx context.Context, query *SearchDocumentsQuery) ([]*model.CompleteDocument, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:datastore:searchDocuments")
+	defer span.End()
+
+	conditions := []string{}
+	args := []any{}
+
+	if query.AuthenticSource != "" {
+		if len(query.AllowedAuthenticSources) > 0 && !slices.Contains(query.AllowedAuthenticSources, query.AuthenticSource) {
+			return []*model.CompleteDocument{}, nil
+		}
+		conditions = append(conditions, "d.authentic_source = ?")
+		args = append(args, query.AuthenticSource)
+	} else if len(query.AllowedAuthenticSources) > 0 {
+		placeholders := make([]string, len(query.AllowedAuthenticSources))
+		for i, src := range query.AllowedAuthenticSources {
+			placeholders[i] = "?"
+			args = append(args, src)
+		}
+		conditions = append(conditions, fmt.Sprintf("d.authentic_source IN (%s)", strings.Join(placeholders, ", ")))
+	}
+
+	if query.Scope != "" {
+		if len(query.AllowedScopes) > 0 && !slices.Contains(query.AllowedScopes, query.Scope) {
+			return []*model.CompleteDocument{}, nil
+		}
+		conditions = append(conditions, "d.scope = ?")
+		args = append(args, query.Scope)
+	} else if len(query.AllowedScopes) > 0 {
+		placeholders := make([]string, len(query.AllowedScopes))
+		for i, scope := range query.AllowedScopes {
+			placeholders[i] = "?"
+			args = append(args, scope)
+		}
+		conditions = append(conditions, fmt.Sprintf("d.scope IN (%s)", strings.Join(placeholders, ", ")))
+	}
+
+	if query.Search != "" {
+		term := "%" + escapeLike(query.Search) + "%"
+		searchCols := []string{
+			"d.document_id",
+			"d.authentic_source",
+			"d.scope",
+			c.dialect.JSONTextExtract("d.document_data", "family_name"),
+			c.dialect.JSONTextExtract("d.document_data", "given_name"),
+			c.dialect.JSONTextExtract("d.document_data", "email"),
+			c.dialect.JSONTextExtract("d.document_data", "birthdate"),
+		}
+		orClauses := make([]string, 0, len(searchCols)+1)
+		for _, col := range searchCols {
+			orClauses = append(orClauses, c.dialect.CaseInsensitiveLike(col))
+			args = append(args, term)
+		}
+		orClauses = append(orClauses, `EXISTS (
+			SELECT 1 FROM datastore_identity_mapping m
+			WHERE m.authentic_source = d.authentic_source AND m.scope = d.scope AND m.document_id = d.document_id
+			AND `+c.dialect.CaseInsensitiveLike("m.identity_mapping_id")+`
+		)`)
+		args = append(args, term)
+		conditions = append(conditions, "("+strings.Join(orClauses, " OR ")+")")
+	}
+
+	limit := int64(50)
+	if query.Limit > 0 && query.Limit <= 200 {
+		limit = query.Limit
+	}
+
+	whereClause := "1=1"
+	if len(conditions) > 0 {
+		whereClause = strings.Join(conditions, " AND ")
+	}
+	sqlQuery := c.dialect.Rebind(fmt.Sprintf(
+		`SELECT d.authentic_source, d.scope, d.document_id, d.document_data_validation, d.document_data, d.valid_not_after, d.created_at
+		 FROM datastore d WHERE %s ORDER BY d.created_at DESC LIMIT ?`,
+		whereClause,
+	))
+	args = append(args, limit)
+
+	var rows []datastoreRow
+	if err := c.db.SelectContext(ctx, &rows, sqlQuery, args...); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	res := make([]*model.CompleteDocument, len(rows))
+	for i, row := range rows {
+		doc, err := c.toCompleteDocument(ctx, row)
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+		res[i] = doc
+	}
+	return res, nil
+}
+
+// ListAuthenticSources returns all unique authentic_source values in the datastore.
+func (c *SQLDatastoreColl) ListAuthenticSources(ctx context.Context) ([]string, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:datastore:listAuthenticSources")
+	defer span.End()
+
+	var results []string
+	query := "SELECT DISTINCT authentic_source FROM datastore ORDER BY authentic_source"
+	if err := c.db.SelectContext(ctx, &results, query); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	return results, nil
+}

--- a/internal/apigw/db/sql_datastore.go
+++ b/internal/apigw/db/sql_datastore.go
@@ -117,19 +117,27 @@ func (c *SQLDatastoreColl) insertDocument(ctx context.Context, q sqlxExtQuerier,
 	return err
 }
 
-func (c *SQLDatastoreColl) insertIdentityMappings(ctx context.Context, q sqlxExtQuerier, meta *model.MetaData, identityMappingIDs []string) error {
-	if len(identityMappingIDs) == 0 {
-		return nil
-	}
+// identityMappingRowsValues builds the "(?, ?, ?, ?), (?, ?, ?, ?), ..."
+// placeholder list and matching args for a multi-row insert into
+// datastore_identity_mapping, one row per id in identityMappingIDs.
+func identityMappingRowsValues(authenticSource, scope, documentID string, identityMappingIDs []string) (string, []any) {
 	placeholders := make([]string, 0, len(identityMappingIDs))
 	args := make([]any, 0, len(identityMappingIDs)*4)
 	for _, id := range identityMappingIDs {
 		placeholders = append(placeholders, "(?, ?, ?, ?)")
-		args = append(args, meta.AuthenticSource, meta.Scope, meta.DocumentID, id)
+		args = append(args, authenticSource, scope, documentID, id)
 	}
+	return strings.Join(placeholders, ", "), args
+}
+
+func (c *SQLDatastoreColl) insertIdentityMappings(ctx context.Context, q sqlxExtQuerier, meta *model.MetaData, identityMappingIDs []string) error {
+	if len(identityMappingIDs) == 0 {
+		return nil
+	}
+	values, args := identityMappingRowsValues(meta.AuthenticSource, meta.Scope, meta.DocumentID, identityMappingIDs)
 	query := c.dialect.Rebind(fmt.Sprintf(
 		`INSERT INTO datastore_identity_mapping (authentic_source, scope, document_id, identity_mapping_id) VALUES %s`,
-		strings.Join(placeholders, ", "),
+		values,
 	))
 	_, err := q.ExecContext(ctx, query, args...)
 	return err
@@ -226,19 +234,22 @@ func (c *SQLDatastoreColl) AddIdentity(ctx context.Context, query *AddIdentityQu
 	if !ok {
 		return helpers.ErrNoDocumentFound
 	}
-	meta := &model.MetaData{AuthenticSource: query.AuthenticSource, Scope: query.Scope, DocumentID: query.DocumentID}
-
-	// Dedup: insert-if-absent per id, matching Mongo's $addToSet semantics.
-	for _, id := range query.IdentityMappingIDs {
-		q := c.dialect.Rebind(fmt.Sprintf(
-			`INSERT INTO datastore_identity_mapping (authentic_source, scope, document_id, identity_mapping_id) VALUES (?, ?, ?, ?) %s`,
-			c.dialect.UpsertClause([]string{"authentic_source", "scope", "document_id", "identity_mapping_id"}, nil),
-		))
-		if _, err := c.db.ExecContext(ctx, q, meta.AuthenticSource, meta.Scope, meta.DocumentID, id); err != nil {
-			return err
-		}
+	if len(query.IdentityMappingIDs) == 0 {
+		return nil
 	}
-	return nil
+
+	// Single multi-row upsert (insert-if-absent per id, matching Mongo's
+	// $addToSet semantics): one round-trip and one atomic statement, rather
+	// than one INSERT per id, which was both N round-trips and non-atomic
+	// (a failure partway through would leave a subset of ids inserted).
+	values, args := identityMappingRowsValues(query.AuthenticSource, query.Scope, query.DocumentID, query.IdentityMappingIDs)
+	q := c.dialect.Rebind(fmt.Sprintf(
+		`INSERT INTO datastore_identity_mapping (authentic_source, scope, document_id, identity_mapping_id) VALUES %s %s`,
+		values,
+		c.dialect.UpsertClause([]string{"authentic_source", "scope", "document_id", "identity_mapping_id"}, nil),
+	))
+	_, err = c.db.ExecContext(ctx, q, args...)
+	return err
 }
 
 // DeleteIdentity deletes identity in document.
@@ -307,6 +318,68 @@ func (c *SQLDatastoreColl) toCompleteDocument(ctx context.Context, row datastore
 	}, nil
 }
 
+// documentKey identifies one datastore row by its natural key.
+type documentKey struct {
+	AuthenticSource string
+	Scope           string
+	DocumentID      string
+}
+
+// fetchIdentityMappingIDsBatch returns every row's identity_mapping_ids in a
+// single query, keyed by documentKey - used instead of calling
+// fetchIdentityMappingIDs once per row (an N+1 query pattern) when a caller
+// already has a whole result set of rows to resolve at once.
+func (c *SQLDatastoreColl) fetchIdentityMappingIDsBatch(ctx context.Context, q sqlxExtQuerier, rows []datastoreRow) (map[documentKey][]string, error) {
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(rows))
+	args := make([]any, 0, len(rows)*3)
+	for i, row := range rows {
+		placeholders[i] = "(?, ?, ?)"
+		args = append(args, row.AuthenticSource, row.Scope, row.DocumentID)
+	}
+	query := c.dialect.Rebind(fmt.Sprintf(
+		`SELECT authentic_source, scope, document_id, identity_mapping_id FROM datastore_identity_mapping
+		WHERE (authentic_source, scope, document_id) IN (%s) ORDER BY document_id, identity_mapping_id`,
+		strings.Join(placeholders, ", "),
+	))
+	var mappingRows []struct {
+		AuthenticSource   string `db:"authentic_source"`
+		Scope             string `db:"scope"`
+		DocumentID        string `db:"document_id"`
+		IdentityMappingID string `db:"identity_mapping_id"`
+	}
+	if err := q.SelectContext(ctx, &mappingRows, query, args...); err != nil {
+		return nil, err
+	}
+	result := make(map[documentKey][]string, len(rows))
+	for _, r := range mappingRows {
+		key := documentKey{AuthenticSource: r.AuthenticSource, Scope: r.Scope, DocumentID: r.DocumentID}
+		result[key] = append(result[key], r.IdentityMappingID)
+	}
+	return result, nil
+}
+
+// toCompleteDocumentsBatch is toCompleteDocument for a whole result set at
+// once: one batched identity-mapping query instead of one per row.
+func (c *SQLDatastoreColl) toCompleteDocumentsBatch(ctx context.Context, rows []datastoreRow) ([]*model.CompleteDocument, error) {
+	idsByKey, err := c.fetchIdentityMappingIDsBatch(ctx, c.db, rows)
+	if err != nil {
+		return nil, err
+	}
+	docs := make([]*model.CompleteDocument, len(rows))
+	for i, row := range rows {
+		key := documentKey{AuthenticSource: row.AuthenticSource, Scope: row.Scope, DocumentID: row.DocumentID}
+		docs[i] = &model.CompleteDocument{
+			Meta:               row.toMeta(),
+			IdentityMappingIDs: idsByKey[key],
+			DocumentData:       row.DocumentData.V,
+		}
+	}
+	return docs, nil
+}
+
 // GetByIdentity returns matching documents for a scope where any of the
 // document's identity mappings match the provided identifier.
 func (c *SQLDatastoreColl) GetByIdentity(ctx context.Context, scope, identityMappingID string) (map[string]*model.CompleteDocument, error) {
@@ -321,12 +394,12 @@ func (c *SQLDatastoreColl) GetByIdentity(ctx context.Context, scope, identityMap
 		return nil, err
 	}
 
-	docs := make(map[string]*model.CompleteDocument, len(rows))
-	for _, row := range rows {
-		doc, err := c.toCompleteDocument(ctx, row)
-		if err != nil {
-			return nil, err
-		}
+	completeDocs, err := c.toCompleteDocumentsBatch(ctx, rows)
+	if err != nil {
+		return nil, err
+	}
+	docs := make(map[string]*model.CompleteDocument, len(completeDocs))
+	for _, doc := range completeDocs {
 		docs[doc.Meta.AuthenticSource] = doc
 	}
 	return docs, nil
@@ -552,14 +625,10 @@ func (c *SQLDatastoreColl) Search(ctx context.Context, query *SearchDocumentsQue
 		return nil, err
 	}
 
-	res := make([]*model.CompleteDocument, len(rows))
-	for i, row := range rows {
-		doc, err := c.toCompleteDocument(ctx, row)
-		if err != nil {
-			span.SetStatus(codes.Error, err.Error())
-			return nil, err
-		}
-		res[i] = doc
+	res, err := c.toCompleteDocumentsBatch(ctx, rows)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
 	return res, nil
 }

--- a/internal/apigw/db/sql_datastore_test.go
+++ b/internal/apigw/db/sql_datastore_test.go
@@ -1,0 +1,158 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/helpers"
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/testsupport/sqltest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mkDoc(authenticSource, scope, documentID string, identityIDs []string, data map[string]any) *model.CompleteDocument {
+	return &model.CompleteDocument{
+		Meta: &model.MetaData{
+			AuthenticSource: authenticSource,
+			Scope:           scope,
+			DocumentID:      documentID,
+		},
+		IdentityMappingIDs: identityIDs,
+		DocumentData:       data,
+	}
+}
+
+func testDatastoreStoreContract(t *testing.T, store DatastoreStore) {
+	t.Helper()
+	ctx := t.Context()
+
+	count, err := store.Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+
+	doc1 := mkDoc("SUNET", "pid", "doc-1", []string{"identity-1"}, map[string]any{
+		"family_name": "Svensson", "given_name": "Magnus", "email": "magnus@example.com",
+	})
+	require.NoError(t, store.Save(ctx, doc1))
+
+	count, err = store.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
+	// Get
+	got, err := store.Get(ctx, doc1.Meta)
+	require.NoError(t, err)
+	assert.Equal(t, "SUNET", got.Meta.AuthenticSource)
+	gotData, ok := got.DocumentData.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Svensson", gotData["family_name"])
+
+	// GetByKey
+	full, err := store.GetByKey(ctx, "SUNET", "pid", "doc-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"identity-1"}, full.IdentityMappingIDs)
+
+	// AddIdentity
+	require.NoError(t, store.AddIdentity(ctx, &AddIdentityQuery{
+		AuthenticSource: "SUNET", Scope: "pid", DocumentID: "doc-1",
+		IdentityMappingIDs: []string{"identity-2"},
+	}))
+	full, err = store.GetByKey(ctx, "SUNET", "pid", "doc-1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"identity-1", "identity-2"}, full.IdentityMappingIDs)
+
+	// AddIdentity on a nonexistent document.
+	err = store.AddIdentity(ctx, &AddIdentityQuery{AuthenticSource: "NOPE", Scope: "x", DocumentID: "y", IdentityMappingIDs: []string{"z"}})
+	assert.ErrorIs(t, err, helpers.ErrNoDocumentFound)
+
+	// GetByIdentity
+	byIdentity, err := store.GetByIdentity(ctx, "pid", "identity-1")
+	require.NoError(t, err)
+	require.Contains(t, byIdentity, "SUNET")
+	assert.Equal(t, "doc-1", byIdentity["SUNET"].Meta.DocumentID)
+
+	// List
+	listed, err := store.List(ctx, &ListQuery{IdentityMappingID: "identity-2"})
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, "doc-1", listed[0].Meta.DocumentID)
+
+	// DeleteIdentity
+	require.NoError(t, store.DeleteIdentity(ctx, &DeleteIdentityQuery{
+		AuthenticSource: "SUNET", Scope: "pid", DocumentID: "doc-1", AuthenticSourcePersonID: "identity-2",
+	}))
+	full, err = store.GetByKey(ctx, "SUNET", "pid", "doc-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"identity-1"}, full.IdentityMappingIDs)
+
+	// Second doc for Search/SaveMany/ListAuthenticSources coverage.
+	doc2 := mkDoc("OTHER", "ehic", "doc-2", []string{"identity-3"}, map[string]any{"family_name": "Karlsson"})
+	doc3 := mkDoc("OTHER", "ehic", "doc-3", []string{"identity-4"}, map[string]any{"family_name": "Nilsson"})
+	require.NoError(t, store.SaveMany(ctx, []*model.CompleteDocument{doc2, doc3}))
+
+	count, err = store.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+
+	sources, err := store.ListAuthenticSources(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"OTHER", "SUNET"}, sources)
+
+	// Search by free text across document_data.
+	results, err := store.Search(ctx, &SearchDocumentsQuery{Search: "Karlsson"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "doc-2", results[0].Meta.DocumentID)
+
+	// Search by authentic_source filter.
+	results, err = store.Search(ctx, &SearchDocumentsQuery{AuthenticSource: "OTHER"})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// Search respecting AllowedAuthenticSources restriction.
+	results, err = store.Search(ctx, &SearchDocumentsQuery{AuthenticSource: "SUNET", AllowedAuthenticSources: []string{"OTHER"}})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+
+	// Replace
+	replaced := mkDoc("SUNET", "pid", "doc-1", []string{"identity-9"}, map[string]any{"family_name": "Replaced"})
+	require.NoError(t, store.Replace(ctx, replaced))
+	full, err = store.GetByKey(ctx, "SUNET", "pid", "doc-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"identity-9"}, full.IdentityMappingIDs)
+	assert.Equal(t, "Replaced", full.DocumentData["family_name"])
+
+	// Replace on a nonexistent document is a silent no-op.
+	require.NoError(t, store.Replace(ctx, mkDoc("NOPE", "x", "y", nil, nil)))
+
+	// DeleteByKey
+	require.NoError(t, store.DeleteByKey(ctx, "OTHER", "ehic", "doc-3"))
+	count, err = store.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	err = store.DeleteByKey(ctx, "OTHER", "ehic", "doc-3")
+	assert.ErrorIs(t, err, helpers.ErrNoDocumentFound)
+
+	// Delete (silent, no error even if nothing matches).
+	require.NoError(t, store.Delete(ctx, &model.MetaData{AuthenticSource: "SUNET", Scope: "pid", DocumentID: "doc-1"}))
+	require.NoError(t, store.Delete(ctx, &model.MetaData{AuthenticSource: "GONE", Scope: "x", DocumentID: "y"}))
+	count, err = store.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestSQLDatastoreColl_Postgres(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartPostgres(t)
+	defer cleanup()
+
+	testDatastoreStoreContract(t, NewSQLDatastoreColl(newTestService(t), sqlDB, dialect))
+}
+
+func TestSQLDatastoreColl_MariaDB(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartMariaDB(t)
+	defer cleanup()
+
+	testDatastoreStoreContract(t, NewSQLDatastoreColl(newTestService(t), sqlDB, dialect))
+}

--- a/internal/apigw/db/sql_datastore_test.go
+++ b/internal/apigw/db/sql_datastore_test.go
@@ -126,6 +126,22 @@ func testDatastoreStoreContract(t *testing.T, store DatastoreStore) {
 	// Replace on a nonexistent document is a silent no-op.
 	require.NoError(t, store.Replace(ctx, mkDoc("NOPE", "x", "y", nil, nil)))
 
+	// Save with duplicate identity mapping IDs must not error - the SQL
+	// backend's (authentic_source, scope, document_id, identity_mapping_id)
+	// primary key can't represent a literal duplicate row, so it dedupes;
+	// Mongo's array field has no such constraint and keeps the duplicate
+	// verbatim. Both are acceptable (this only asserts every distinct ID
+	// still resolves, not an exact-multiset match) - a caller-supplied
+	// duplicate must never turn into a constraint-violation error on one
+	// backend but not the other.
+	dupDoc := mkDoc("SUNET", "pid", "doc-dup", []string{"dup-1", "dup-1", "dup-2"}, map[string]any{"family_name": "Duplicate"})
+	require.NoError(t, store.Save(ctx, dupDoc))
+	full, err = store.GetByKey(ctx, "SUNET", "pid", "doc-dup")
+	require.NoError(t, err)
+	assert.Contains(t, full.IdentityMappingIDs, "dup-1")
+	assert.Contains(t, full.IdentityMappingIDs, "dup-2")
+	require.NoError(t, store.DeleteByKey(ctx, "SUNET", "pid", "doc-dup"))
+
 	// DeleteByKey
 	require.NoError(t, store.DeleteByKey(ctx, "OTHER", "ehic", "doc-3"))
 	count, err = store.Count(ctx)

--- a/internal/apigw/db/sql_dynamic_registration.go
+++ b/internal/apigw/db/sql_dynamic_registration.go
@@ -38,7 +38,7 @@ func (c *SQLDynamicRegistrationColl) Save(ctx context.Context, creds *DynamicReg
 	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:dynamic_registration:save")
 	defer span.End()
 
-	creds.RegisteredAt = time.Now()
+	creds.RegisteredAt = time.Now().UTC()
 
 	updateCols := []string{
 		"client_secret", "registration_access_token", "registration_client_uri",

--- a/internal/apigw/db/sql_dynamic_registration.go
+++ b/internal/apigw/db/sql_dynamic_registration.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/SUNET/vc/pkg/sqlstore"
+
+	"github.com/jmoiron/sqlx"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// SQLDynamicRegistrationColl is a SQL-backed implementation of DynamicRegistrationStore.
+type SQLDynamicRegistrationColl struct {
+	Service *Service
+	db      *sqlx.DB
+	dialect sqlstore.Dialect
+}
+
+// NewSQLDynamicRegistrationColl creates a SQL-backed DynamicRegistrationStore.
+func NewSQLDynamicRegistrationColl(service *Service, db *sqlx.DB, dialect sqlstore.Dialect) *SQLDynamicRegistrationColl {
+	return &SQLDynamicRegistrationColl{Service: service, db: db, dialect: dialect}
+}
+
+type dynamicRegistrationRow struct {
+	ClientID                string    `db:"client_id"`
+	ClientSecret            string    `db:"client_secret"`
+	RegistrationAccessToken string    `db:"registration_access_token"`
+	RegistrationClientURI   string    `db:"registration_client_uri"`
+	ClientSecretExpiresAt   int64     `db:"client_secret_expires_at"`
+	RegisteredAt            time.Time `db:"registered_at"`
+}
+
+// Save stores or replaces dynamic registration credentials, upserting by client_id.
+func (c *SQLDynamicRegistrationColl) Save(ctx context.Context, creds *DynamicRegistrationCredentials) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:dynamic_registration:save")
+	defer span.End()
+
+	creds.RegisteredAt = time.Now()
+
+	updateCols := []string{
+		"client_secret", "registration_access_token", "registration_client_uri",
+		"client_secret_expires_at", "registered_at",
+	}
+	query := c.dialect.Rebind(`INSERT INTO oidc_dynamic_registration
+		(client_id, client_secret, registration_access_token, registration_client_uri, client_secret_expires_at, registered_at)
+		VALUES (?, ?, ?, ?, ?, ?) ` + c.dialect.UpsertClause([]string{"client_id"}, updateCols))
+
+	_, err := c.db.ExecContext(ctx, query,
+		creds.ClientID, creds.ClientSecret, creds.RegistrationAccessToken,
+		creds.RegistrationClientURI, creds.ClientSecretExpiresAt, creds.RegisteredAt,
+	)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// Get returns the stored credentials, or nil if none exist or the client secret has expired.
+func (c *SQLDynamicRegistrationColl) Get(ctx context.Context) (*DynamicRegistrationCredentials, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:dynamic_registration:get")
+	defer span.End()
+
+	query := c.dialect.Rebind(`SELECT client_id, client_secret, registration_access_token,
+		registration_client_uri, client_secret_expires_at, registered_at
+		FROM oidc_dynamic_registration LIMIT 1`)
+
+	var row dynamicRegistrationRow
+	if err := c.db.GetContext(ctx, &row, query); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	creds := &DynamicRegistrationCredentials{
+		ClientID:                row.ClientID,
+		ClientSecret:            row.ClientSecret,
+		RegistrationAccessToken: row.RegistrationAccessToken,
+		RegistrationClientURI:   row.RegistrationClientURI,
+		ClientSecretExpiresAt:   row.ClientSecretExpiresAt,
+		RegisteredAt:            row.RegisteredAt,
+	}
+
+	if creds.ClientSecretExpiresAt > 0 {
+		expiresAt := time.Unix(creds.ClientSecretExpiresAt, 0)
+		if time.Now().After(expiresAt) {
+			c.Service.log.Info("Dynamic registration credentials expired", "client_id", creds.ClientID, "expired_at", expiresAt)
+			return nil, nil
+		}
+	}
+
+	return creds, nil
+}

--- a/internal/apigw/db/sql_dynamic_registration_test.go
+++ b/internal/apigw/db/sql_dynamic_registration_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/SUNET/vc/pkg/testsupport/sqltest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testDynamicRegistrationStoreContract(t *testing.T, store DynamicRegistrationStore) {
+	t.Helper()
+	ctx := t.Context()
+
+	// No row yet: Get returns nil, nil (not an error).
+	got, err := store.Get(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	creds := &DynamicRegistrationCredentials{
+		ClientID:                "client-1",
+		ClientSecret:            "secret-1",
+		RegistrationAccessToken: "rat-1",
+		RegistrationClientURI:   "https://issuer.example.com/register/client-1",
+	}
+	require.NoError(t, store.Save(ctx, creds))
+
+	got, err = store.Get(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "client-1", got.ClientID)
+	assert.Equal(t, "secret-1", got.ClientSecret)
+	assert.WithinDuration(t, time.Now(), got.RegisteredAt, 5*time.Second)
+
+	// Save again (upsert path) with an already-expired secret -- Get should
+	// then report no usable credentials, mirroring the Mongo expiry check.
+	creds2 := &DynamicRegistrationCredentials{
+		ClientID:              "client-1",
+		ClientSecret:          "secret-2",
+		ClientSecretExpiresAt: time.Now().Add(-time.Hour).Unix(),
+	}
+	require.NoError(t, store.Save(ctx, creds2))
+
+	got, err = store.Get(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, got, "expired client secret should make Get report no credentials")
+}
+
+func TestSQLDynamicRegistrationColl_Postgres(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartPostgres(t)
+	defer cleanup()
+
+	testDynamicRegistrationStoreContract(t, NewSQLDynamicRegistrationColl(newTestService(t), sqlDB, dialect))
+}
+
+func TestSQLDynamicRegistrationColl_MariaDB(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartMariaDB(t)
+	defer cleanup()
+
+	testDynamicRegistrationStoreContract(t, NewSQLDynamicRegistrationColl(newTestService(t), sqlDB, dialect))
+}

--- a/internal/apigw/db/sql_identity_mapping.go
+++ b/internal/apigw/db/sql_identity_mapping.go
@@ -1,0 +1,296 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/SUNET/vc/pkg/helpers"
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sqlstore"
+
+	"github.com/jmoiron/sqlx"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// SQLIdentityMappingsColl is a SQL-backed implementation of IdentityMappingStore.
+type SQLIdentityMappingsColl struct {
+	Service *Service
+	db      *sqlx.DB
+	dialect sqlstore.Dialect
+}
+
+// NewSQLIdentityMappingsColl creates a SQL-backed IdentityMappingStore.
+func NewSQLIdentityMappingsColl(service *Service, db *sqlx.DB, dialect sqlstore.Dialect) *SQLIdentityMappingsColl {
+	return &SQLIdentityMappingsColl{Service: service, db: db, dialect: dialect}
+}
+
+type identityMappingRow struct {
+	AuthenticSource         string                           `db:"authentic_source"`
+	AuthenticSourcePersonID string                           `db:"authentic_source_person_id"`
+	Attributes              sqlstore.JSON[map[string]string] `db:"attributes"`
+	CreatedAt               time.Time                        `db:"created_at"`
+}
+
+func (row identityMappingRow) toModel() *model.IdentityMapping {
+	return &model.IdentityMapping{
+		AuthenticSource:         row.AuthenticSource,
+		AuthenticSourcePersonID: row.AuthenticSourcePersonID,
+		Attributes:              row.Attributes.V,
+		CreatedAt:               row.CreatedAt,
+	}
+}
+
+// Count returns the (possibly approximate) number of identity mappings.
+func (c *SQLIdentityMappingsColl) Count(ctx context.Context) (int64, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:identities:count")
+	defer span.End()
+
+	var count int64
+	if err := c.db.GetContext(ctx, &count, "SELECT COUNT(*) FROM identity_mappings"); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return 0, err
+	}
+	return count, nil
+}
+
+// CreateMapping creates a new identity mapping.
+func (c *SQLIdentityMappingsColl) CreateMapping(ctx context.Context, mapping *model.IdentityMapping) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:identities:createMapping")
+	defer span.End()
+
+	mapping.CreatedAt = time.Now().UTC()
+
+	query := c.dialect.Rebind(`INSERT INTO identity_mappings
+		(authentic_source, authentic_source_person_id, attributes, created_at) VALUES (?, ?, ?, ?)`)
+	_, err := c.db.ExecContext(ctx, query,
+		mapping.AuthenticSource, mapping.AuthenticSourcePersonID,
+		sqlstore.JSON[map[string]string]{V: mapping.Attributes}, mapping.CreatedAt,
+	)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// CreateMappings creates multiple identity mappings in a single statement.
+func (c *SQLIdentityMappingsColl) CreateMappings(ctx context.Context, mappings []*model.IdentityMapping) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:identities:createMappings")
+	defer span.End()
+
+	if len(mappings) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	placeholders := make([]string, 0, len(mappings))
+	args := make([]any, 0, len(mappings)*4)
+	for _, m := range mappings {
+		m.CreatedAt = now
+		placeholders = append(placeholders, "(?, ?, ?, ?)")
+		args = append(args, m.AuthenticSource, m.AuthenticSourcePersonID,
+			sqlstore.JSON[map[string]string]{V: m.Attributes}, m.CreatedAt)
+	}
+
+	query := c.dialect.Rebind(fmt.Sprintf(
+		`INSERT INTO identity_mappings (authentic_source, authentic_source_person_id, attributes, created_at) VALUES %s`,
+		strings.Join(placeholders, ", "),
+	))
+	if _, err := c.db.ExecContext(ctx, query, args...); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// EnsureMapping creates an identity mapping only if it does not already exist.
+// If a record with the same (authentic_source, authentic_source_person_id) already exists, it is left unchanged.
+func (c *SQLIdentityMappingsColl) EnsureMapping(ctx context.Context, mapping *model.IdentityMapping) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:identities:ensureMapping")
+	defer span.End()
+
+	query := c.dialect.Rebind(fmt.Sprintf(
+		`INSERT INTO identity_mappings (authentic_source, authentic_source_person_id, attributes, created_at)
+		VALUES (?, ?, ?, ?) %s`,
+		c.dialect.UpsertClause([]string{"authentic_source", "authentic_source_person_id"}, nil),
+	))
+	_, err := c.db.ExecContext(ctx, query,
+		mapping.AuthenticSource, mapping.AuthenticSourcePersonID,
+		sqlstore.JSON[map[string]string]{V: mapping.Attributes}, time.Now().UTC(),
+	)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// ResolveMapping resolves identity attributes to an authentic_source_person_id.
+func (c *SQLIdentityMappingsColl) ResolveMapping(ctx context.Context, query *ResolveMappingQuery) (string, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:identities:resolveMapping")
+	defer span.End()
+
+	if query.AuthenticSource == "" && len(query.Attributes) == 0 {
+		span.SetStatus(codes.Error, helpers.ErrNoIdentityFound.Error())
+		return "", helpers.ErrNoIdentityFound
+	}
+
+	conditions := []string{}
+	args := []any{}
+	if query.AuthenticSource != "" {
+		conditions = append(conditions, "authentic_source = ?")
+		args = append(args, query.AuthenticSource)
+	}
+	if len(query.Attributes) > 0 {
+		conditions = append(conditions, c.dialect.JSONContains("attributes"))
+		args = append(args, sqlstore.JSON[map[string]string]{V: query.Attributes})
+	}
+
+	sqlQuery := c.dialect.Rebind(fmt.Sprintf(
+		`SELECT authentic_source_person_id FROM identity_mappings WHERE %s LIMIT 1`,
+		strings.Join(conditions, " AND "),
+	))
+
+	var personID string
+	if err := c.db.GetContext(ctx, &personID, sqlQuery, args...); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Error, helpers.ErrNoIdentityFound.Error())
+			return "", helpers.ErrNoIdentityFound
+		}
+		span.SetStatus(codes.Error, err.Error())
+		return "", err
+	}
+
+	return personID, nil
+}
+
+// UpdateMapping updates the attributes of an existing identity mapping.
+func (c *SQLIdentityMappingsColl) UpdateMapping(ctx context.Context, mapping *model.IdentityMapping) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:identities:updateMapping")
+	defer span.End()
+
+	query := c.dialect.Rebind(`UPDATE identity_mappings SET attributes = ?
+		WHERE authentic_source = ? AND authentic_source_person_id = ?`)
+	result, err := c.db.ExecContext(ctx, query,
+		sqlstore.JSON[map[string]string]{V: mapping.Attributes},
+		mapping.AuthenticSource, mapping.AuthenticSourcePersonID,
+	)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	if n == 0 {
+		return helpers.ErrNoIdentityFound
+	}
+	return nil
+}
+
+// DeleteMapping deletes an identity mapping.
+func (c *SQLIdentityMappingsColl) DeleteMapping(ctx context.Context, query *DeleteMappingQuery) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:identities:deleteMapping")
+	defer span.End()
+
+	sqlQuery := c.dialect.Rebind(`DELETE FROM identity_mappings
+		WHERE authentic_source = ? AND authentic_source_person_id = ?`)
+	result, err := c.db.ExecContext(ctx, sqlQuery, query.AuthenticSource, query.AuthenticSourcePersonID)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	if n == 0 {
+		return helpers.ErrNoIdentityFound
+	}
+	return nil
+}
+
+// escapeLike escapes LIKE/ILIKE wildcard characters in a user-supplied search term.
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "%", `\%`)
+	s = strings.ReplaceAll(s, "_", `\_`)
+	return s
+}
+
+// SearchMappings returns identity mappings matching a text search or filters, with a limit.
+func (c *SQLIdentityMappingsColl) SearchMappings(ctx context.Context, query *SearchMappingsQuery) ([]*model.IdentityMapping, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:vc:sql:identities:searchMappings")
+	defer span.End()
+
+	conditions := []string{}
+	args := []any{}
+
+	if query.AuthenticSource != "" {
+		if len(query.AllowedAuthenticSources) > 0 && !slices.Contains(query.AllowedAuthenticSources, query.AuthenticSource) {
+			return []*model.IdentityMapping{}, nil
+		}
+		conditions = append(conditions, "authentic_source = ?")
+		args = append(args, query.AuthenticSource)
+	} else if len(query.AllowedAuthenticSources) > 0 {
+		placeholders := make([]string, len(query.AllowedAuthenticSources))
+		for i, src := range query.AllowedAuthenticSources {
+			placeholders[i] = "?"
+			args = append(args, src)
+		}
+		conditions = append(conditions, fmt.Sprintf("authentic_source IN (%s)", strings.Join(placeholders, ", ")))
+	}
+
+	if query.Search != "" {
+		term := "%" + escapeLike(query.Search) + "%"
+		searchCols := []string{
+			"authentic_source_person_id",
+			"authentic_source",
+			c.dialect.JSONTextExtract("attributes", "family_name"),
+			c.dialect.JSONTextExtract("attributes", "given_name"),
+			c.dialect.JSONTextExtract("attributes", "birth_date"),
+		}
+		orClauses := make([]string, len(searchCols))
+		for i, col := range searchCols {
+			orClauses[i] = c.dialect.CaseInsensitiveLike(col)
+			args = append(args, term)
+		}
+		conditions = append(conditions, "("+strings.Join(orClauses, " OR ")+")")
+	}
+
+	limit := int64(50)
+	if query.Limit > 0 && query.Limit <= 200 {
+		limit = query.Limit
+	}
+
+	whereClause := "1=1"
+	if len(conditions) > 0 {
+		whereClause = strings.Join(conditions, " AND ")
+	}
+	sqlQuery := c.dialect.Rebind(fmt.Sprintf(
+		`SELECT authentic_source, authentic_source_person_id, attributes, created_at
+		 FROM identity_mappings WHERE %s ORDER BY created_at DESC LIMIT ?`,
+		whereClause,
+	))
+	args = append(args, limit)
+
+	var rows []identityMappingRow
+	if err := c.db.SelectContext(ctx, &rows, sqlQuery, args...); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	res := make([]*model.IdentityMapping, len(rows))
+	for i, row := range rows {
+		res[i] = row.toModel()
+	}
+	return res, nil
+}

--- a/internal/apigw/db/sql_identity_mapping_test.go
+++ b/internal/apigw/db/sql_identity_mapping_test.go
@@ -1,0 +1,142 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/helpers"
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/testsupport/sqltest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testIdentityMappingStoreContract(t *testing.T, store IdentityMappingStore) {
+	t.Helper()
+	ctx := t.Context()
+
+	count, err := store.Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+
+	m1 := &model.IdentityMapping{
+		AuthenticSource:         "SUNET",
+		AuthenticSourcePersonID: "person-1",
+		Attributes: map[string]string{
+			"family_name": "Svensson",
+			"given_name":  "Magnus",
+			"birth_date":  "1970-01-01",
+		},
+	}
+	require.NoError(t, store.CreateMapping(ctx, m1))
+
+	count, err = store.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
+	// ResolveMapping by authentic_source + attributes.
+	personID, err := store.ResolveMapping(ctx, &ResolveMappingQuery{
+		AuthenticSource: "SUNET",
+		Attributes:      map[string]string{"family_name": "Svensson", "given_name": "Magnus"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "person-1", personID)
+
+	// ResolveMapping with a non-matching attribute should not find it.
+	_, err = store.ResolveMapping(ctx, &ResolveMappingQuery{
+		AuthenticSource: "SUNET",
+		Attributes:      map[string]string{"family_name": "Nomatch"},
+	})
+	assert.ErrorIs(t, err, helpers.ErrNoIdentityFound)
+
+	// EnsureMapping on an existing key must leave attributes unchanged.
+	require.NoError(t, store.EnsureMapping(ctx, &model.IdentityMapping{
+		AuthenticSource:         "SUNET",
+		AuthenticSourcePersonID: "person-1",
+		Attributes:              map[string]string{"family_name": "ShouldNotOverwrite"},
+	}))
+	personID, err = store.ResolveMapping(ctx, &ResolveMappingQuery{
+		AuthenticSource: "SUNET",
+		Attributes:      map[string]string{"family_name": "Svensson"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "person-1", personID)
+
+	// EnsureMapping on a new key creates it.
+	require.NoError(t, store.EnsureMapping(ctx, &model.IdentityMapping{
+		AuthenticSource:         "SUNET",
+		AuthenticSourcePersonID: "person-2",
+		Attributes:              map[string]string{"family_name": "Andersson"},
+	}))
+	count, err = store.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	// CreateMappings bulk insert.
+	require.NoError(t, store.CreateMappings(ctx, []*model.IdentityMapping{
+		{AuthenticSource: "OTHER", AuthenticSourcePersonID: "person-3", Attributes: map[string]string{"family_name": "Karlsson"}},
+		{AuthenticSource: "OTHER", AuthenticSourcePersonID: "person-4", Attributes: map[string]string{"family_name": "Nilsson"}},
+	}))
+	count, err = store.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), count)
+
+	// UpdateMapping.
+	require.NoError(t, store.UpdateMapping(ctx, &model.IdentityMapping{
+		AuthenticSource:         "SUNET",
+		AuthenticSourcePersonID: "person-1",
+		Attributes:              map[string]string{"family_name": "Updated"},
+	}))
+	personID, err = store.ResolveMapping(ctx, &ResolveMappingQuery{
+		AuthenticSource: "SUNET",
+		Attributes:      map[string]string{"family_name": "Updated"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "person-1", personID)
+
+	// UpdateMapping on a nonexistent key.
+	err = store.UpdateMapping(ctx, &model.IdentityMapping{AuthenticSource: "NOPE", AuthenticSourcePersonID: "nope"})
+	assert.ErrorIs(t, err, helpers.ErrNoIdentityFound)
+
+	// SearchMappings: free-text search over family_name.
+	results, err := store.SearchMappings(ctx, &SearchMappingsQuery{Search: "Karlsson"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "person-3", results[0].AuthenticSourcePersonID)
+
+	// SearchMappings: filter by authentic_source.
+	results, err = store.SearchMappings(ctx, &SearchMappingsQuery{AuthenticSource: "OTHER"})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// SearchMappings: AllowedAuthenticSources restriction blocks a disallowed source.
+	results, err = store.SearchMappings(ctx, &SearchMappingsQuery{
+		AuthenticSource:         "SUNET",
+		AllowedAuthenticSources: []string{"OTHER"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+
+	// DeleteMapping.
+	require.NoError(t, store.DeleteMapping(ctx, &DeleteMappingQuery{AuthenticSource: "SUNET", AuthenticSourcePersonID: "person-1"}))
+	count, err = store.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+
+	err = store.DeleteMapping(ctx, &DeleteMappingQuery{AuthenticSource: "SUNET", AuthenticSourcePersonID: "person-1"})
+	assert.ErrorIs(t, err, helpers.ErrNoIdentityFound)
+}
+
+func TestSQLIdentityMappingsColl_Postgres(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartPostgres(t)
+	defer cleanup()
+
+	testIdentityMappingStoreContract(t, NewSQLIdentityMappingsColl(newTestService(t), sqlDB, dialect))
+}
+
+func TestSQLIdentityMappingsColl_MariaDB(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartMariaDB(t)
+	defer cleanup()
+
+	testIdentityMappingStoreContract(t, NewSQLIdentityMappingsColl(newTestService(t), sqlDB, dialect))
+}

--- a/internal/verifier/db/service.go
+++ b/internal/verifier/db/service.go
@@ -65,6 +65,7 @@ func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.
 		collection: oidcDB.Collection("clients"),
 	}
 	if err := clientsColl.createIndex(ctx); err != nil {
+		service.disconnectMongoOnStartupError()
 		return nil, err
 	}
 	service.Clients = clientsColl
@@ -72,6 +73,19 @@ func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.
 	service.log.Info("Started")
 
 	return service, nil
+}
+
+// disconnectMongoOnStartupError disconnects the Mongo client after a
+// collection/index setup failure in New, so a failed startup doesn't leak
+// the already-open connection. Uses a fresh background context (not the
+// caller's, which may be close to its own startup deadline) so cleanup
+// still runs even if that deadline has passed.
+func (s *Service) disconnectMongoOnStartupError() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.MongoClient.Disconnect(ctx); err != nil {
+		s.log.Error(err, "failed to disconnect mongo client after startup error")
+	}
 }
 
 // NewServiceWithMocks creates a db.Service with mock implementations for testing

--- a/internal/verifier/db/service.go
+++ b/internal/verifier/db/service.go
@@ -88,7 +88,7 @@ func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logg
 	if err != nil {
 		return nil, err
 	}
-	if err := sqlstore.Migrate(db, dialect); err != nil {
+	if err := sqlstore.ApplySchema(db, dialect); err != nil {
 		return nil, err
 	}
 	service.SQLDB = db

--- a/internal/verifier/db/service.go
+++ b/internal/verifier/db/service.go
@@ -7,8 +7,10 @@ import (
 	"github.com/SUNET/vc/internal/gen/status/apiv1_status"
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/trace"
 
+	"github.com/jmoiron/sqlx"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -16,6 +18,7 @@ import (
 // Service is the database service
 type Service struct {
 	MongoClient *mongo.Client
+	SQLDB       *sqlx.DB
 	cfg         *model.Cfg
 	log         *logger.Log
 	tracer      *trace.Tracer
@@ -25,8 +28,21 @@ type Service struct {
 	Clients ClientStore
 }
 
-// New creates a new database service
+// New creates a new database service. The storage backend is selected by
+// cfg.Common.SQL.Backend: "postgres" or "mariadb" connect to the
+// corresponding relational database (via pkg/sqlstore, running schema
+// migrations at startup); anything else (including unset, the default)
+// keeps the existing MongoDB-backed behavior unchanged.
 func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
+	switch cfg.Common.SQL.Backend {
+	case "postgres", "mariadb":
+		return newSQL(ctx, cfg, tracer, log)
+	default:
+		return newMongo(ctx, cfg, tracer, log)
+	}
+}
+
+func newMongo(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
 	service := &Service{
 		log:        log.New("db"),
 		cfg:        cfg,
@@ -53,6 +69,32 @@ func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.
 	service.Clients = clientsColl
 
 	service.log.Info("Started")
+
+	return service, nil
+}
+
+func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
+	service := &Service{
+		log:        log.New("db"),
+		cfg:        cfg,
+		tracer:     tracer,
+		probeStore: &apiv1_status.StatusProbeStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	db, dialect, err := sqlstore.Connect(ctx, &cfg.Common.SQL)
+	if err != nil {
+		return nil, err
+	}
+	if err := sqlstore.Migrate(db, dialect); err != nil {
+		return nil, err
+	}
+	service.SQLDB = db
+	service.Clients = NewSQLClientColl(service, db, dialect)
+
+	service.log.Info("Started", "backend", cfg.Common.SQL.Backend)
 
 	return service, nil
 }
@@ -98,7 +140,13 @@ func (s *Service) Status(ctx context.Context) *apiv1_status.StatusProbe {
 		LastCheckedTS: timestamppb.Now(),
 	}
 
-	if err := s.MongoClient.Ping(ctx, nil); err != nil {
+	var err error
+	if s.SQLDB != nil {
+		err = s.SQLDB.PingContext(ctx)
+	} else {
+		err = s.MongoClient.Ping(ctx, nil)
+	}
+	if err != nil {
 		probe.Message = err.Error()
 		probe.Healthy = false
 	}
@@ -111,6 +159,9 @@ func (s *Service) Status(ctx context.Context) *apiv1_status.StatusProbe {
 
 // Close closes the database connection
 func (s *Service) Close(ctx context.Context) error {
+	if s.SQLDB != nil {
+		return s.SQLDB.Close()
+	}
 	if err := s.MongoClient.Disconnect(ctx); err != nil {
 		return err
 	}

--- a/internal/verifier/db/service.go
+++ b/internal/verifier/db/service.go
@@ -88,7 +88,7 @@ func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logg
 	if err != nil {
 		return nil, err
 	}
-	if err := sqlstore.ApplySchema(ctx, db, dialect); err != nil {
+	if err := sqlstore.ApplySchema(ctx, db, dialect, &cfg.Common.SQL); err != nil {
 		return nil, err
 	}
 	service.SQLDB = db

--- a/internal/verifier/db/service.go
+++ b/internal/verifier/db/service.go
@@ -22,7 +22,7 @@ type Service struct {
 	cfg         *model.Cfg
 	log         *logger.Log
 	tracer      *trace.Tracer
-	probeStore  *apiv1_status.StatusProbeStore
+	probeStore  *sqlstore.ProbeCache
 
 	// OIDC client collection, client registration
 	Clients ClientStore
@@ -43,7 +43,7 @@ func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.
 		log:         log.New("db"),
 		cfg:         cfg,
 		tracer:      tracer,
-		probeStore:  &apiv1_status.StatusProbeStore{},
+		probeStore:  &sqlstore.ProbeCache{},
 		MongoClient: conn.MongoClient,
 		SQLDB:       conn.SQLDB,
 	}

--- a/internal/verifier/db/service.go
+++ b/internal/verifier/db/service.go
@@ -88,7 +88,7 @@ func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logg
 	if err != nil {
 		return nil, err
 	}
-	if err := sqlstore.ApplySchema(db, dialect); err != nil {
+	if err := sqlstore.ApplySchema(ctx, db, dialect); err != nil {
 		return nil, err
 	}
 	service.SQLDB = db

--- a/internal/verifier/db/service.go
+++ b/internal/verifier/db/service.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Service is the database service
@@ -84,11 +83,8 @@ func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logg
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	db, dialect, err := sqlstore.Connect(ctx, &cfg.Common.SQL)
+	db, dialect, err := sqlstore.ConnectAndApplySchema(ctx, &cfg.Common.SQL)
 	if err != nil {
-		return nil, err
-	}
-	if err := sqlstore.ApplySchema(ctx, db, dialect, &cfg.Common.SQL); err != nil {
 		return nil, err
 	}
 	service.SQLDB = db
@@ -130,41 +126,16 @@ func (s *Service) Status(ctx context.Context) *apiv1_status.StatusProbe {
 	ctx, span := s.tracer.Start(ctx, "db:status")
 	defer span.End()
 
-	if time.Now().Before(s.probeStore.NextCheck.AsTime()) {
-		return s.probeStore.PreviousResult
+	ping := func(ctx context.Context) error {
+		if s.SQLDB != nil {
+			return s.SQLDB.PingContext(ctx)
+		}
+		return s.MongoClient.Ping(ctx, nil)
 	}
-	probe := &apiv1_status.StatusProbe{
-		Name:          "db",
-		Healthy:       true,
-		Message:       "OK",
-		LastCheckedTS: timestamppb.Now(),
-	}
-
-	var err error
-	if s.SQLDB != nil {
-		err = s.SQLDB.PingContext(ctx)
-	} else {
-		err = s.MongoClient.Ping(ctx, nil)
-	}
-	if err != nil {
-		probe.Message = err.Error()
-		probe.Healthy = false
-	}
-
-	s.probeStore.PreviousResult = probe
-	s.probeStore.NextCheck = timestamppb.New(time.Now().Add(10 * time.Second))
-
-	return probe
+	return sqlstore.ProbeStatus(ctx, s.probeStore, ping)
 }
 
 // Close closes the database connection
 func (s *Service) Close(ctx context.Context) error {
-	if s.SQLDB != nil {
-		return s.SQLDB.Close()
-	}
-	if err := s.MongoClient.Disconnect(ctx); err != nil {
-		return err
-	}
-	ctx.Done()
-	return nil
+	return sqlstore.CloseBackend(s.SQLDB, func() error { return s.MongoClient.Disconnect(ctx) })
 }

--- a/internal/verifier/db/service.go
+++ b/internal/verifier/db/service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/SUNET/vc/internal/gen/status/apiv1_status"
+	"github.com/SUNET/vc/pkg/dbservice"
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/sqlstore"
@@ -33,28 +34,29 @@ type Service struct {
 // migrations at startup); anything else (including unset, the default)
 // keeps the existing MongoDB-backed behavior unchanged.
 func New(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
-	switch cfg.Common.SQL.Backend {
-	case "postgres", "mariadb":
-		return newSQL(ctx, cfg, tracer, log)
-	default:
-		return newMongo(ctx, cfg, tracer, log)
+	conn, err := dbservice.Connect(ctx, cfg, tracer, "verifier:db:connect")
+	if err != nil {
+		return nil, err
 	}
-}
 
-func newMongo(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
 	service := &Service{
-		log:        log.New("db"),
-		cfg:        cfg,
-		tracer:     tracer,
-		probeStore: &apiv1_status.StatusProbeStore{},
+		log:         log.New("db"),
+		cfg:         cfg,
+		tracer:      tracer,
+		probeStore:  &apiv1_status.StatusProbeStore{},
+		MongoClient: conn.MongoClient,
+		SQLDB:       conn.SQLDB,
+	}
+
+	if conn.SQLDB != nil {
+		service.Clients = NewSQLClientColl(service, conn.SQLDB, conn.Dialect)
+
+		service.log.Info("Started", "backend", cfg.Common.SQL.Backend)
+		return service, nil
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
-
-	if err := service.connect(ctx); err != nil {
-		return nil, err
-	}
 
 	// Initialize OIDC collections
 	oidcDB := service.MongoClient.Database("verifier")
@@ -72,53 +74,12 @@ func newMongo(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *lo
 	return service, nil
 }
 
-func newSQL(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (*Service, error) {
-	service := &Service{
-		log:        log.New("db"),
-		cfg:        cfg,
-		tracer:     tracer,
-		probeStore: &apiv1_status.StatusProbeStore{},
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
-	defer cancel()
-
-	db, dialect, err := sqlstore.ConnectAndApplySchema(ctx, &cfg.Common.SQL)
-	if err != nil {
-		return nil, err
-	}
-	service.SQLDB = db
-	service.Clients = NewSQLClientColl(service, db, dialect)
-
-	service.log.Info("Started", "backend", cfg.Common.SQL.Backend)
-
-	return service, nil
-}
-
 // NewServiceWithMocks creates a db.Service with mock implementations for testing
 // This allows unit tests to inject mock ClientStore implementation
 func NewServiceWithMocks(clients ClientStore) *Service {
 	return &Service{
 		Clients: clients,
 	}
-}
-
-// connect connects to the database
-func (s *Service) connect(ctx context.Context) error {
-	ctx, span := s.tracer.Start(ctx, "verifier:db:connect")
-	defer span.End()
-
-	opts, err := s.cfg.Common.Mongo.MongoClientOptions()
-	if err != nil {
-		return err
-	}
-	client, err := mongo.Connect(opts)
-	if err != nil {
-		return err
-	}
-	s.MongoClient = client
-
-	return nil
 }
 
 // Status returns the status of the database

--- a/internal/verifier/db/service_sql_test.go
+++ b/internal/verifier/db/service_sql_test.go
@@ -3,50 +3,34 @@ package db
 import (
 	"testing"
 
-	"github.com/SUNET/vc/pkg/model"
-	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/testsupport/sqltest"
 
 	"github.com/stretchr/testify/require"
 )
 
-// testNewServiceContract exercises the real New()/newSQL() code path end to
-// end (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring).
-func testNewServiceContract(t *testing.T, svc *Service) {
-	t.Helper()
-	ctx := t.Context()
+// TestNewService exercises the real New()/newSQL() code path end to end
+// (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring)
+// against both Postgres and MariaDB.
+func TestNewService(t *testing.T) {
+	sqltest.RunPostgresAndMariaDBContract(t, "verifier-db-sql-service-test", New, func(t *testing.T, svc *Service) {
+		ctx := t.Context()
 
-	require.NotNil(t, svc.Clients)
+		require.NotNil(t, svc.Clients)
 
-	require.NoError(t, svc.Clients.Create(ctx, &Client{
-		ClientID:                "svc-test-client",
-		TokenEndpointAuthMethod: "none",
-		RedirectURIs:            []string{"https://example.com/cb"},
-		GrantTypes:              []string{"authorization_code"},
-		ResponseTypes:           []string{"code"},
-		AllowedScopes:           []string{"openid"},
-		SubjectType:             "public",
-	}))
-	got, err := svc.Clients.GetByClientID(ctx, "svc-test-client")
-	require.NoError(t, err)
-	require.NotNil(t, got)
+		require.NoError(t, svc.Clients.Create(ctx, &Client{
+			ClientID:                "svc-test-client",
+			TokenEndpointAuthMethod: "none",
+			RedirectURIs:            []string{"https://example.com/cb"},
+			GrantTypes:              []string{"authorization_code"},
+			ResponseTypes:           []string{"code"},
+			AllowedScopes:           []string{"openid"},
+			SubjectType:             "public",
+		}))
+		got, err := svc.Clients.GetByClientID(ctx, "svc-test-client")
+		require.NoError(t, err)
+		require.NotNil(t, got)
 
-	probe := svc.Status(ctx)
-	require.True(t, probe.Healthy)
-}
-
-func TestNewService_Postgres(t *testing.T) {
-	pgCfg, cleanup := sqltest.PostgresConfig(t)
-	defer cleanup()
-
-	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "postgres", Postgres: pgCfg}}}
-	testNewServiceContract(t, sqltest.NewServiceForTest(t, "verifier-db-sql-service-test", cfg, New))
-}
-
-func TestNewService_MariaDB(t *testing.T) {
-	mdbCfg, cleanup := sqltest.MariaDBConfig(t)
-	defer cleanup()
-
-	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
-	testNewServiceContract(t, sqltest.NewServiceForTest(t, "verifier-db-sql-service-test", cfg, New))
+		probe := svc.Status(ctx)
+		require.True(t, probe.Healthy)
+	})
 }

--- a/internal/verifier/db/service_sql_test.go
+++ b/internal/verifier/db/service_sql_test.go
@@ -5,27 +5,13 @@ import (
 
 	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/sqlstore"
-	"github.com/SUNET/vc/pkg/testsupport"
 	"github.com/SUNET/vc/pkg/testsupport/sqltest"
-	"github.com/SUNET/vc/pkg/testsupport/tracertest"
 
 	"github.com/stretchr/testify/require"
 )
 
-// testNewSQLService exercises the real New()/newSQL() code path end to end
-// (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring).
-func testNewSQLService(t *testing.T, cfg *model.Cfg) *Service {
-	t.Helper()
-	log := testsupport.TestLogger(t)
-	tracer := tracertest.New(t, cfg, log, "verifier-db-sql-service-test")
-
-	svc, err := New(t.Context(), cfg, tracer, log)
-	require.NoError(t, err)
-	require.NotNil(t, svc)
-	t.Cleanup(func() { _ = svc.Close(t.Context()) })
-	return svc
-}
-
+// testNewServiceContract exercises the real New()/newSQL() code path end to
+// end (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring).
 func testNewServiceContract(t *testing.T, svc *Service) {
 	t.Helper()
 	ctx := t.Context()
@@ -54,8 +40,7 @@ func TestNewService_Postgres(t *testing.T) {
 	defer cleanup()
 
 	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "postgres", Postgres: pgCfg}}}
-	svc := testNewSQLService(t, cfg)
-	testNewServiceContract(t, svc)
+	testNewServiceContract(t, sqltest.NewServiceForTest(t, "verifier-db-sql-service-test", cfg, New))
 }
 
 func TestNewService_MariaDB(t *testing.T) {
@@ -63,6 +48,5 @@ func TestNewService_MariaDB(t *testing.T) {
 	defer cleanup()
 
 	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
-	svc := testNewSQLService(t, cfg)
-	testNewServiceContract(t, svc)
+	testNewServiceContract(t, sqltest.NewServiceForTest(t, "verifier-db-sql-service-test", cfg, New))
 }

--- a/internal/verifier/db/service_sql_test.go
+++ b/internal/verifier/db/service_sql_test.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/testsupport"
+	"github.com/SUNET/vc/pkg/testsupport/sqltest"
+	"github.com/SUNET/vc/pkg/testsupport/tracertest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testNewSQLService exercises the real New()/newSQL() code path end to end
+// (config -> sqlstore.Connect -> sqlstore.Migrate -> store wiring).
+func testNewSQLService(t *testing.T, cfg *model.Cfg) *Service {
+	t.Helper()
+	log := testsupport.TestLogger(t)
+	tracer := tracertest.New(t, cfg, log, "verifier-db-sql-service-test")
+
+	svc, err := New(t.Context(), cfg, tracer, log)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	t.Cleanup(func() { _ = svc.Close(t.Context()) })
+	return svc
+}
+
+func testNewServiceContract(t *testing.T, svc *Service) {
+	t.Helper()
+	ctx := t.Context()
+
+	require.NotNil(t, svc.Clients)
+
+	require.NoError(t, svc.Clients.Create(ctx, &Client{
+		ClientID:                "svc-test-client",
+		TokenEndpointAuthMethod: "none",
+		RedirectURIs:            []string{"https://example.com/cb"},
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		AllowedScopes:           []string{"openid"},
+		SubjectType:             "public",
+	}))
+	got, err := svc.Clients.GetByClientID(ctx, "svc-test-client")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	probe := svc.Status(ctx)
+	require.True(t, probe.Healthy)
+}
+
+func TestNewService_Postgres(t *testing.T) {
+	pgCfg, cleanup := sqltest.PostgresConfig(t)
+	defer cleanup()
+
+	cfg := &model.Cfg{Common: &model.Common{SQL: model.SQL{Backend: "postgres", Postgres: pgCfg}}}
+	svc := testNewSQLService(t, cfg)
+	testNewServiceContract(t, svc)
+}
+
+func TestNewService_MariaDB(t *testing.T) {
+	mdbCfg, cleanup := sqltest.MariaDBConfig(t)
+	defer cleanup()
+
+	cfg := &model.Cfg{Common: &model.Common{SQL: model.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
+	svc := testNewSQLService(t, cfg)
+	testNewServiceContract(t, svc)
+}

--- a/internal/verifier/db/service_sql_test.go
+++ b/internal/verifier/db/service_sql_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/testsupport"
 	"github.com/SUNET/vc/pkg/testsupport/sqltest"
 	"github.com/SUNET/vc/pkg/testsupport/tracertest"
@@ -12,7 +13,7 @@ import (
 )
 
 // testNewSQLService exercises the real New()/newSQL() code path end to end
-// (config -> sqlstore.Connect -> sqlstore.Migrate -> store wiring).
+// (config -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring).
 func testNewSQLService(t *testing.T, cfg *model.Cfg) *Service {
 	t.Helper()
 	log := testsupport.TestLogger(t)
@@ -52,7 +53,7 @@ func TestNewService_Postgres(t *testing.T) {
 	pgCfg, cleanup := sqltest.PostgresConfig(t)
 	defer cleanup()
 
-	cfg := &model.Cfg{Common: &model.Common{SQL: model.SQL{Backend: "postgres", Postgres: pgCfg}}}
+	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "postgres", Postgres: pgCfg}}}
 	svc := testNewSQLService(t, cfg)
 	testNewServiceContract(t, svc)
 }
@@ -61,7 +62,7 @@ func TestNewService_MariaDB(t *testing.T) {
 	mdbCfg, cleanup := sqltest.MariaDBConfig(t)
 	defer cleanup()
 
-	cfg := &model.Cfg{Common: &model.Common{SQL: model.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
+	cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
 	svc := testNewSQLService(t, cfg)
 	testNewServiceContract(t, svc)
 }

--- a/internal/verifier/db/sql_client.go
+++ b/internal/verifier/db/sql_client.go
@@ -1,0 +1,241 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/SUNET/vc/pkg/sqlstore"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// SQLClientColl is a SQL-backed implementation of ClientStore.
+type SQLClientColl struct {
+	Service *Service
+	db      *sqlx.DB
+	dialect sqlstore.Dialect
+}
+
+// NewSQLClientColl creates a SQL-backed ClientStore.
+func NewSQLClientColl(service *Service, db *sqlx.DB, dialect sqlstore.Dialect) *SQLClientColl {
+	return &SQLClientColl{Service: service, db: db, dialect: dialect}
+}
+
+// clientRow mirrors Client field-for-field. Scalar fields are stored as
+// plain Go types (not sql.Null*): every write path always supplies a
+// concrete (possibly zero) value, so the schema's nullable columns are
+// permissive but never depended on to distinguish "unset" from "zero
+// value" -- the Go zero value already means "unset" for these fields.
+type clientRow struct {
+	ClientID                    string                  `db:"client_id"`
+	ClientSecretHash            string                  `db:"client_secret_hash"`
+	RedirectURIs                sqlstore.JSON[[]string] `db:"redirect_uris"`
+	GrantTypes                  sqlstore.JSON[[]string] `db:"grant_types"`
+	ResponseTypes               sqlstore.JSON[[]string] `db:"response_types"`
+	TokenEndpointAuthMethod     string                  `db:"token_endpoint_auth_method"`
+	AllowedScopes               sqlstore.JSON[[]string] `db:"allowed_scopes"`
+	DefaultScopes               sqlstore.JSON[[]string] `db:"default_scopes"`
+	SubjectType                 string                  `db:"subject_type"`
+	JWKSUri                     string                  `db:"jwks_uri"`
+	JWKS                        sqlstore.JSON[any]      `db:"jwks"`
+	RequirePKCE                 bool                    `db:"require_pkce"`
+	RequireCodeChallenge        bool                    `db:"require_code_challenge"`
+	ClientName                  string                  `db:"client_name"`
+	ClientURI                   string                  `db:"client_uri"`
+	LogoURI                     string                  `db:"logo_uri"`
+	Contacts                    sqlstore.JSON[[]string] `db:"contacts"`
+	TosURI                      string                  `db:"tos_uri"`
+	PolicyURI                   string                  `db:"policy_uri"`
+	SoftwareID                  string                  `db:"software_id"`
+	SoftwareVersion             string                  `db:"software_version"`
+	ApplicationType             string                  `db:"application_type"`
+	SectorIdentifierURI         string                  `db:"sector_identifier_uri"`
+	IDTokenSignedResponseAlg    string                  `db:"id_token_signed_response_alg"`
+	DefaultMaxAge               int                     `db:"default_max_age"`
+	RequireAuthTime             bool                    `db:"require_auth_time"`
+	DefaultACRValues            sqlstore.JSON[[]string] `db:"default_acr_values"`
+	InitiateLoginURI            string                  `db:"initiate_login_uri"`
+	RequestURIs                 sqlstore.JSON[[]string] `db:"request_uris"`
+	CodeChallengeMethod         string                  `db:"code_challenge_method"`
+	RegistrationAccessTokenHash string                  `db:"registration_access_token_hash"`
+	ClientIDIssuedAt            int64                   `db:"client_id_issued_at"`
+	ClientSecretExpiresAt       int64                   `db:"client_secret_expires_at"`
+}
+
+func rowFromClient(c *Client) clientRow {
+	return clientRow{
+		ClientID:                    c.ClientID,
+		ClientSecretHash:            c.ClientSecretHash,
+		RedirectURIs:                sqlstore.JSON[[]string]{V: c.RedirectURIs},
+		GrantTypes:                  sqlstore.JSON[[]string]{V: c.GrantTypes},
+		ResponseTypes:               sqlstore.JSON[[]string]{V: c.ResponseTypes},
+		TokenEndpointAuthMethod:     c.TokenEndpointAuthMethod,
+		AllowedScopes:               sqlstore.JSON[[]string]{V: c.AllowedScopes},
+		DefaultScopes:               sqlstore.JSON[[]string]{V: c.DefaultScopes},
+		SubjectType:                 c.SubjectType,
+		JWKSUri:                     c.JWKSUri,
+		JWKS:                        sqlstore.JSON[any]{V: c.JWKS},
+		RequirePKCE:                 c.RequirePKCE,
+		RequireCodeChallenge:        c.RequireCodeChallenge,
+		ClientName:                  c.ClientName,
+		ClientURI:                   c.ClientURI,
+		LogoURI:                     c.LogoURI,
+		Contacts:                    sqlstore.JSON[[]string]{V: c.Contacts},
+		TosURI:                      c.TosURI,
+		PolicyURI:                   c.PolicyURI,
+		SoftwareID:                  c.SoftwareID,
+		SoftwareVersion:             c.SoftwareVersion,
+		ApplicationType:             c.ApplicationType,
+		SectorIdentifierURI:         c.SectorIdentifierURI,
+		IDTokenSignedResponseAlg:    c.IDTokenSignedResponseAlg,
+		DefaultMaxAge:               c.DefaultMaxAge,
+		RequireAuthTime:             c.RequireAuthTime,
+		DefaultACRValues:            sqlstore.JSON[[]string]{V: c.DefaultACRValues},
+		InitiateLoginURI:            c.InitiateLoginURI,
+		RequestURIs:                 sqlstore.JSON[[]string]{V: c.RequestURIs},
+		CodeChallengeMethod:         c.CodeChallengeMethod,
+		RegistrationAccessTokenHash: c.RegistrationAccessTokenHash,
+		ClientIDIssuedAt:            c.ClientIDIssuedAt,
+		ClientSecretExpiresAt:       c.ClientSecretExpiresAt,
+	}
+}
+
+func (row clientRow) toClient() *Client {
+	return &Client{
+		ClientID:                    row.ClientID,
+		ClientSecretHash:            row.ClientSecretHash,
+		RedirectURIs:                row.RedirectURIs.V,
+		GrantTypes:                  row.GrantTypes.V,
+		ResponseTypes:               row.ResponseTypes.V,
+		TokenEndpointAuthMethod:     row.TokenEndpointAuthMethod,
+		AllowedScopes:               row.AllowedScopes.V,
+		DefaultScopes:               row.DefaultScopes.V,
+		SubjectType:                 row.SubjectType,
+		JWKSUri:                     row.JWKSUri,
+		JWKS:                        row.JWKS.V,
+		RequirePKCE:                 row.RequirePKCE,
+		RequireCodeChallenge:        row.RequireCodeChallenge,
+		ClientName:                  row.ClientName,
+		ClientURI:                   row.ClientURI,
+		LogoURI:                     row.LogoURI,
+		Contacts:                    row.Contacts.V,
+		TosURI:                      row.TosURI,
+		PolicyURI:                   row.PolicyURI,
+		SoftwareID:                  row.SoftwareID,
+		SoftwareVersion:             row.SoftwareVersion,
+		ApplicationType:             row.ApplicationType,
+		SectorIdentifierURI:         row.SectorIdentifierURI,
+		IDTokenSignedResponseAlg:    row.IDTokenSignedResponseAlg,
+		DefaultMaxAge:               row.DefaultMaxAge,
+		RequireAuthTime:             row.RequireAuthTime,
+		DefaultACRValues:            row.DefaultACRValues.V,
+		InitiateLoginURI:            row.InitiateLoginURI,
+		RequestURIs:                 row.RequestURIs.V,
+		CodeChallengeMethod:         row.CodeChallengeMethod,
+		RegistrationAccessTokenHash: row.RegistrationAccessTokenHash,
+		ClientIDIssuedAt:            row.ClientIDIssuedAt,
+		ClientSecretExpiresAt:       row.ClientSecretExpiresAt,
+	}
+}
+
+// GetByClientID retrieves a client by client ID. Returns nil, nil if not
+// found, matching the Mongo implementation.
+func (c *SQLClientColl) GetByClientID(ctx context.Context, clientID string) (*Client, error) {
+	ctx, span := c.Service.tracer.Start(ctx, "db:sql:clients:get_by_client_id")
+	defer span.End()
+
+	query := c.dialect.Rebind(`SELECT client_id, client_secret_hash, redirect_uris, grant_types, response_types,
+		token_endpoint_auth_method, allowed_scopes, default_scopes, subject_type, jwks_uri, jwks,
+		require_pkce, require_code_challenge, client_name, client_uri, logo_uri, contacts, tos_uri, policy_uri,
+		software_id, software_version, application_type, sector_identifier_uri, id_token_signed_response_alg,
+		default_max_age, require_auth_time, default_acr_values, initiate_login_uri, request_uris,
+		code_challenge_method, registration_access_token_hash, client_id_issued_at, client_secret_expires_at
+		FROM clients WHERE client_id = ?`)
+
+	var row clientRow
+	if err := c.db.GetContext(ctx, &row, query, clientID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		c.Service.log.Error(err, "Failed to get client")
+		return nil, err
+	}
+
+	return row.toClient(), nil
+}
+
+// Create creates a new client.
+func (c *SQLClientColl) Create(ctx context.Context, client *Client) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:sql:clients:create")
+	defer span.End()
+
+	row := rowFromClient(client)
+	query := c.dialect.Rebind(`INSERT INTO clients
+		(client_id, client_secret_hash, redirect_uris, grant_types, response_types,
+		 token_endpoint_auth_method, allowed_scopes, default_scopes, subject_type, jwks_uri, jwks,
+		 require_pkce, require_code_challenge, client_name, client_uri, logo_uri, contacts, tos_uri, policy_uri,
+		 software_id, software_version, application_type, sector_identifier_uri, id_token_signed_response_alg,
+		 default_max_age, require_auth_time, default_acr_values, initiate_login_uri, request_uris,
+		 code_challenge_method, registration_access_token_hash, client_id_issued_at, client_secret_expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+
+	_, err := c.db.ExecContext(ctx, query,
+		row.ClientID, row.ClientSecretHash, row.RedirectURIs, row.GrantTypes, row.ResponseTypes,
+		row.TokenEndpointAuthMethod, row.AllowedScopes, row.DefaultScopes, row.SubjectType, row.JWKSUri, row.JWKS,
+		row.RequirePKCE, row.RequireCodeChallenge, row.ClientName, row.ClientURI, row.LogoURI, row.Contacts, row.TosURI, row.PolicyURI,
+		row.SoftwareID, row.SoftwareVersion, row.ApplicationType, row.SectorIdentifierURI, row.IDTokenSignedResponseAlg,
+		row.DefaultMaxAge, row.RequireAuthTime, row.DefaultACRValues, row.InitiateLoginURI, row.RequestURIs,
+		row.CodeChallengeMethod, row.RegistrationAccessTokenHash, row.ClientIDIssuedAt, row.ClientSecretExpiresAt,
+	)
+	if err != nil {
+		c.Service.log.Error(err, "Failed to create client")
+		return err
+	}
+	return nil
+}
+
+// Update updates a client, replacing every column. Silently does nothing if
+// no client with that client_id exists, matching Mongo's ReplaceOne without upsert.
+func (c *SQLClientColl) Update(ctx context.Context, client *Client) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:sql:clients:update")
+	defer span.End()
+
+	row := rowFromClient(client)
+	query := c.dialect.Rebind(`UPDATE clients SET
+		client_secret_hash = ?, redirect_uris = ?, grant_types = ?, response_types = ?,
+		token_endpoint_auth_method = ?, allowed_scopes = ?, default_scopes = ?, subject_type = ?, jwks_uri = ?, jwks = ?,
+		require_pkce = ?, require_code_challenge = ?, client_name = ?, client_uri = ?, logo_uri = ?, contacts = ?, tos_uri = ?, policy_uri = ?,
+		software_id = ?, software_version = ?, application_type = ?, sector_identifier_uri = ?, id_token_signed_response_alg = ?,
+		default_max_age = ?, require_auth_time = ?, default_acr_values = ?, initiate_login_uri = ?, request_uris = ?,
+		code_challenge_method = ?, registration_access_token_hash = ?, client_id_issued_at = ?, client_secret_expires_at = ?
+		WHERE client_id = ?`)
+
+	_, err := c.db.ExecContext(ctx, query,
+		row.ClientSecretHash, row.RedirectURIs, row.GrantTypes, row.ResponseTypes,
+		row.TokenEndpointAuthMethod, row.AllowedScopes, row.DefaultScopes, row.SubjectType, row.JWKSUri, row.JWKS,
+		row.RequirePKCE, row.RequireCodeChallenge, row.ClientName, row.ClientURI, row.LogoURI, row.Contacts, row.TosURI, row.PolicyURI,
+		row.SoftwareID, row.SoftwareVersion, row.ApplicationType, row.SectorIdentifierURI, row.IDTokenSignedResponseAlg,
+		row.DefaultMaxAge, row.RequireAuthTime, row.DefaultACRValues, row.InitiateLoginURI, row.RequestURIs,
+		row.CodeChallengeMethod, row.RegistrationAccessTokenHash, row.ClientIDIssuedAt, row.ClientSecretExpiresAt,
+		row.ClientID,
+	)
+	if err != nil {
+		c.Service.log.Error(err, "Failed to update client")
+		return err
+	}
+	return nil
+}
+
+// Delete deletes a client.
+func (c *SQLClientColl) Delete(ctx context.Context, clientID string) error {
+	ctx, span := c.Service.tracer.Start(ctx, "db:sql:clients:delete")
+	defer span.End()
+
+	query := c.dialect.Rebind(`DELETE FROM clients WHERE client_id = ?`)
+	if _, err := c.db.ExecContext(ctx, query, clientID); err != nil {
+		c.Service.log.Error(err, "Failed to delete client")
+		return err
+	}
+	return nil
+}

--- a/internal/verifier/db/sql_client_test.go
+++ b/internal/verifier/db/sql_client_test.go
@@ -1,0 +1,115 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/testsupport"
+	"github.com/SUNET/vc/pkg/testsupport/sqltest"
+	"github.com/SUNET/vc/pkg/testsupport/tracertest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// newTestService builds a *Service suitable for exercising store
+// implementations directly (bypassing New(), which would try to connect to
+// MongoDB): only the fields the store implementations actually use
+// (tracer, log) are populated.
+func newTestService(t *testing.T) *Service {
+	t.Helper()
+	log := testsupport.TestLogger(t)
+	tracer := tracertest.New(t, nil, log, "verifier-db-test")
+	return &Service{tracer: tracer, log: log}
+}
+
+func testClientStoreContract(t *testing.T, store ClientStore) {
+	t.Helper()
+	ctx := t.Context()
+
+	// Not found: GetByClientID returns nil, nil (not an error).
+	got, err := store.GetByClientID(ctx, "client-1")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	client := &Client{
+		ClientID:                "client-1",
+		ClientSecretHash:        "hash-1",
+		RedirectURIs:            []string{"https://rp.example.com/callback"},
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "client_secret_basic",
+		AllowedScopes:           []string{"openid", "profile"},
+		SubjectType:             "public",
+		RequirePKCE:             true,
+		ClientName:              "Test RP",
+		Contacts:                []string{"admin@example.com"},
+		JWKS:                    map[string]any{"keys": []any{}},
+	}
+	require.NoError(t, store.Create(ctx, client))
+
+	got, err = store.GetByClientID(ctx, "client-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "hash-1", got.ClientSecretHash)
+	assert.Equal(t, []string{"https://rp.example.com/callback"}, got.RedirectURIs)
+	assert.Equal(t, []string{"authorization_code"}, got.GrantTypes)
+	assert.True(t, got.RequirePKCE)
+	assert.Equal(t, "Test RP", got.ClientName)
+	assert.Equal(t, []string{"admin@example.com"}, got.Contacts)
+	require.NotNil(t, got.JWKS)
+
+	// Update replaces every column.
+	client.ClientSecretHash = "hash-2"
+	client.ClientName = "Updated RP"
+	client.AllowedScopes = []string{"openid"}
+	require.NoError(t, store.Update(ctx, client))
+
+	got, err = store.GetByClientID(ctx, "client-1")
+	require.NoError(t, err)
+	assert.Equal(t, "hash-2", got.ClientSecretHash)
+	assert.Equal(t, "Updated RP", got.ClientName)
+	assert.Equal(t, []string{"openid"}, got.AllowedScopes)
+
+	// Update on a nonexistent client_id is a silent no-op (matches Mongo's
+	// ReplaceOne without upsert).
+	require.NoError(t, store.Update(ctx, &Client{ClientID: "nonexistent"}))
+
+	// Delete.
+	require.NoError(t, store.Delete(ctx, "client-1"))
+	got, err = store.GetByClientID(ctx, "client-1")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Delete of a nonexistent client_id is also a silent no-op.
+	require.NoError(t, store.Delete(ctx, "client-1"))
+}
+
+func TestSQLClientColl_Postgres(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartPostgres(t)
+	defer cleanup()
+
+	testClientStoreContract(t, NewSQLClientColl(newTestService(t), sqlDB, dialect))
+}
+
+func TestSQLClientColl_MariaDB(t *testing.T) {
+	sqlDB, dialect, cleanup := sqltest.StartMariaDB(t)
+	defer cleanup()
+
+	testClientStoreContract(t, NewSQLClientColl(newTestService(t), sqlDB, dialect))
+}
+
+func TestClientCollection_Mongo(t *testing.T) {
+	_, client, cleanup := testsupport.StartMongoContainer(t)
+	defer cleanup()
+
+	svc := &Service{MongoClient: client, tracer: tracertest.New(t, nil, testsupport.TestLogger(t), "verifier-db-mongo-test"), log: testsupport.TestLogger(t)}
+	coll := &ClientCollection{Service: svc, collection: mongoClientCollection(client)}
+	require.NoError(t, coll.createIndex(t.Context()))
+
+	testClientStoreContract(t, coll)
+}
+
+func mongoClientCollection(client *mongo.Client) *mongo.Collection {
+	return client.Database("verifier").Collection("clients")
+}

--- a/pkg/dbservice/connect.go
+++ b/pkg/dbservice/connect.go
@@ -14,6 +14,7 @@ package dbservice
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/SUNET/vc/pkg/model"
@@ -47,7 +48,19 @@ type Connection struct {
 // its own name (e.g. "apigw:db:connect" vs "verifier:db:connect") -
 // covering only the Mongo branch would silently drop startup connect/ping/
 // migration work from traces whenever a deployment runs on SQL instead.
+//
+// Returns an error up front if Common.HA.Enable is set alongside a SQL
+// backend: HA-mode caching (pkg/cache's Mongo-backed AuthContext/generic
+// caches) is wired up by each service's own cache.Service.New using this
+// same Connection's MongoClient, which is nil when the SQL backend is
+// selected - without this guard, that would surface much later as a nil
+// *mongo.Client reaching pkg/cache instead of a clear startup error.
+// Combining SQL storage with HA caching isn't supported yet.
 func Connect(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, spanName string) (*Connection, error) {
+	if isSQLBackend := cfg.Common.SQL.Backend == "postgres" || cfg.Common.SQL.Backend == "mariadb"; cfg.Common.HA.Enable && isSQLBackend {
+		return nil, fmt.Errorf("dbservice: Common.HA.Enable is not supported together with Common.SQL.Backend=%q - HA-mode caching requires a Mongo connection, which is not established when the SQL backend is selected", cfg.Common.SQL.Backend)
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, connectTimeout)
 	defer cancel()
 

--- a/pkg/dbservice/connect.go
+++ b/pkg/dbservice/connect.go
@@ -1,0 +1,74 @@
+// Package dbservice holds the one piece of db.Service setup genuinely
+// shared across every service (apigw, verifier, ...): deciding, from
+// cfg.Common.SQL.Backend, whether to connect to Mongo or to a SQL backend
+// (via pkg/sqlstore, running schema migrations), and handing back whichever
+// connection resulted. It intentionally stops there - each service's own
+// store wiring (which collections/tables it needs, what indexes/schemas
+// they use) stays in that service's own db package, not here.
+//
+// This package sits above both pkg/model and pkg/trace (it imports both),
+// which is safe: pkg/trace already imports pkg/model (for otel setup), so
+// pkg/model itself cannot import pkg/trace back - but a leaf package like
+// this one, sitting a layer above both, introduces no cycle.
+package dbservice
+
+import (
+	"context"
+	"time"
+
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sqlstore"
+	"github.com/SUNET/vc/pkg/trace"
+
+	"github.com/jmoiron/sqlx"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// connectTimeout bounds how long Connect waits for the initial
+// connection/ping/migration to complete, matching every db.Service.New this
+// replaces.
+const connectTimeout = 20 * time.Second
+
+// Connection is the result of Connect: exactly one of MongoClient or SQLDB
+// is set, matching db.Service's existing MongoClient/SQLDB field pair.
+// Dialect is nil unless SQLDB is set.
+type Connection struct {
+	MongoClient *mongo.Client
+	SQLDB       *sqlx.DB
+	Dialect     sqlstore.Dialect
+}
+
+// Connect selects a backend from cfg.Common.SQL.Backend ("postgres" or
+// "mariadb" connect to the corresponding relational database via
+// pkg/sqlstore, running schema migrations at startup; anything else,
+// including unset, keeps the default MongoDB-backed behavior) and connects
+// to it. mongoSpanName names the tracing span opened around the Mongo
+// connect call, since each caller already gives it its own name (e.g.
+// "apigw:db:connect" vs "verifier:db:connect").
+func Connect(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, mongoSpanName string) (*Connection, error) {
+	ctx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+
+	switch cfg.Common.SQL.Backend {
+	case "postgres", "mariadb":
+		db, dialect, err := sqlstore.ConnectAndApplySchema(ctx, &cfg.Common.SQL)
+		if err != nil {
+			return nil, err
+		}
+		return &Connection{SQLDB: db, Dialect: dialect}, nil
+
+	default:
+		_, span := tracer.Start(ctx, mongoSpanName)
+		defer span.End()
+
+		opts, err := cfg.Common.Mongo.MongoClientOptions()
+		if err != nil {
+			return nil, err
+		}
+		client, err := mongo.Connect(opts)
+		if err != nil {
+			return nil, err
+		}
+		return &Connection{MongoClient: client}, nil
+	}
+}

--- a/pkg/dbservice/connect.go
+++ b/pkg/dbservice/connect.go
@@ -84,6 +84,16 @@ func Connect(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, spanName
 		if err != nil {
 			return nil, err
 		}
+		// mongo.Connect doesn't itself dial the server - it constructs a
+		// client that connects lazily on first real use. Without an
+		// explicit Ping here, connectTimeout wouldn't actually bound the
+		// "connect" step as documented, and a service could start
+		// successfully even with an unreachable Mongo, only failing much
+		// later on first query.
+		if err := client.Ping(ctx, nil); err != nil {
+			_ = client.Disconnect(ctx)
+			return nil, fmt.Errorf("dbservice: ping mongo: %w", err)
+		}
 		return &Connection{MongoClient: client}, nil
 	}
 }

--- a/pkg/dbservice/connect.go
+++ b/pkg/dbservice/connect.go
@@ -91,7 +91,13 @@ func Connect(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, spanName
 		// successfully even with an unreachable Mongo, only failing much
 		// later on first query.
 		if err := client.Ping(ctx, nil); err != nil {
-			_ = client.Disconnect(ctx)
+			// ctx may already be expired (that's often exactly why Ping
+			// failed), so use a fresh context for cleanup - Disconnect must
+			// still run to release the connection even when the original
+			// deadline has passed.
+			disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = client.Disconnect(disconnectCtx)
+			disconnectCancel()
 			return nil, fmt.Errorf("dbservice: ping mongo: %w", err)
 		}
 		return &Connection{MongoClient: client}, nil

--- a/pkg/dbservice/connect.go
+++ b/pkg/dbservice/connect.go
@@ -42,12 +42,17 @@ type Connection struct {
 // "mariadb" connect to the corresponding relational database via
 // pkg/sqlstore, running schema migrations at startup; anything else,
 // including unset, keeps the default MongoDB-backed behavior) and connects
-// to it. mongoSpanName names the tracing span opened around the Mongo
-// connect call, since each caller already gives it its own name (e.g.
-// "apigw:db:connect" vs "verifier:db:connect").
-func Connect(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, mongoSpanName string) (*Connection, error) {
+// to it. spanName names the tracing span opened around the whole connect
+// call (whichever backend is selected), since each caller already gives it
+// its own name (e.g. "apigw:db:connect" vs "verifier:db:connect") -
+// covering only the Mongo branch would silently drop startup connect/ping/
+// migration work from traces whenever a deployment runs on SQL instead.
+func Connect(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, spanName string) (*Connection, error) {
 	ctx, cancel := context.WithTimeout(ctx, connectTimeout)
 	defer cancel()
+
+	ctx, span := tracer.Start(ctx, spanName)
+	defer span.End()
 
 	switch cfg.Common.SQL.Backend {
 	case "postgres", "mariadb":
@@ -58,9 +63,6 @@ func Connect(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, mongoSpa
 		return &Connection{SQLDB: db, Dialect: dialect}, nil
 
 	default:
-		_, span := tracer.Start(ctx, mongoSpanName)
-		defer span.End()
-
 		opts, err := cfg.Common.Mongo.MongoClientOptions()
 		if err != nil {
 			return nil, err

--- a/pkg/dbservice/connect_test.go
+++ b/pkg/dbservice/connect_test.go
@@ -1,0 +1,57 @@
+package dbservice
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sqlstore"
+	"github.com/SUNET/vc/pkg/testsupport"
+	"github.com/SUNET/vc/pkg/testsupport/tracertest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConnect_RejectsHAWithSQLBackend is a regression test for a real gap
+// Copilot flagged: HA-mode caching (pkg/cache's Mongo-backed AuthContext/
+// generic caches, wired up by each service's own cache.Service.New) needs a
+// *mongo.Client, but Connect never establishes one when a SQL backend is
+// selected - every service's cache setup would otherwise get a nil client
+// and fail deep inside pkg/cache instead of at startup with a clear error.
+func TestConnect_RejectsHAWithSQLBackend(t *testing.T) {
+	log := testsupport.TestLogger(t)
+	cfg := &model.Cfg{Common: &model.Common{
+		HA: model.HAConfig{Enable: true},
+		SQL: sqlstore.SQL{
+			Backend:  "postgres",
+			Postgres: &sqlstore.PostgresConfig{Host: "unused", Port: 5432, Database: "unused"},
+		},
+	}}
+	tracer := tracertest.New(t, cfg, log, "dbservice-test")
+
+	_, err := Connect(t.Context(), cfg, tracer, "test:db:connect")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Common.HA.Enable")
+	require.True(t, strings.Contains(err.Error(), "postgres"))
+}
+
+// TestConnect_HADisabledWithSQLBackendIsUnaffected confirms the guard is
+// scoped to HA.Enable specifically - it must not reject a plain SQL-backend
+// deployment (the overwhelmingly common case) before ever reaching the real
+// connection attempt.
+func TestConnect_HADisabledWithSQLBackendIsUnaffected(t *testing.T) {
+	log := testsupport.TestLogger(t)
+	cfg := &model.Cfg{Common: &model.Common{
+		SQL: sqlstore.SQL{
+			Backend:  "postgres",
+			Postgres: &sqlstore.PostgresConfig{Host: "unused", Port: 5432, Database: "unused"},
+		},
+	}}
+	tracer := tracertest.New(t, cfg, log, "dbservice-test")
+
+	_, err := Connect(t.Context(), cfg, tracer, "test:db:connect")
+	// Expected to fail (no real Postgres at "unused"), but NOT with the
+	// HA-guard error - confirms the guard didn't fire for HA.Enable=false.
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "Common.HA.Enable")
+}

--- a/pkg/sqlstore/connect.go
+++ b/pkg/sqlstore/connect.go
@@ -56,3 +56,21 @@ func Connect(ctx context.Context, cfg *SQL) (*sqlx.DB, Dialect, error) {
 		return nil, nil, fmt.Errorf("sqlstore: unsupported backend %q (expected \"postgres\" or \"mariadb\")", cfg.Backend)
 	}
 }
+
+// ConnectAndApplySchema connects (via Connect) and immediately runs schema
+// migrations (via ApplySchema) against the new connection pool, closing that
+// pool if migrations fail. Connect itself already closes on a ping failure;
+// this closes the other failure path a bare Connect+ApplySchema call pair
+// would otherwise leak the pool on, so callers get one call that's clean on
+// every failure path instead of needing to remember cleanup themselves.
+func ConnectAndApplySchema(ctx context.Context, cfg *SQL) (*sqlx.DB, Dialect, error) {
+	db, dialect, err := Connect(ctx, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := ApplySchema(ctx, db, dialect, cfg); err != nil {
+		_ = db.Close()
+		return nil, nil, err
+	}
+	return db, dialect, nil
+}

--- a/pkg/sqlstore/json.go
+++ b/pkg/sqlstore/json.go
@@ -31,6 +31,13 @@ func (j JSON[T]) Value() (driver.Value, error) {
 // Scan implements sql.Scanner.
 func (j *JSON[T]) Scan(src any) error {
 	if src == nil {
+		// A SQL NULL must reset j.V to its zero value: if this JSON[T] is
+		// reused across scans (e.g. the same row struct passed to
+		// sqlx.Get/Select in a loop), leaving j.V untouched here would leak
+		// the previous row's value into a row whose column is actually
+		// NULL.
+		var zero T
+		j.V = zero
 		return nil
 	}
 	var b []byte

--- a/pkg/sqlstore/json.go
+++ b/pkg/sqlstore/json.go
@@ -1,0 +1,46 @@
+package sqlstore
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// JSON is a generic sql.Scanner/driver.Valuer wrapper for marshaling a Go
+// value to/from a JSON/JSONB column. Neither database/sql nor sqlx do this
+// automatically for struct fields, so repository row structs use this to
+// mark which fields need JSON (de)serialization, e.g.:
+//
+//	type row struct {
+//	    UUID       string                       `db:"uuid"`
+//	    Parameters JSON[SomeParametersType]      `db:"params"`
+//	}
+type JSON[T any] struct {
+	V T
+}
+
+// Value implements driver.Valuer.
+func (j JSON[T]) Value() (driver.Value, error) {
+	b, err := json.Marshal(j.V)
+	if err != nil {
+		return nil, fmt.Errorf("sqlstore: marshal JSON column: %w", err)
+	}
+	return b, nil
+}
+
+// Scan implements sql.Scanner.
+func (j *JSON[T]) Scan(src any) error {
+	if src == nil {
+		return nil
+	}
+	var b []byte
+	switch v := src.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("sqlstore: cannot scan %T into JSON column", src)
+	}
+	return json.Unmarshal(b, &j.V)
+}

--- a/pkg/sqlstore/service.go
+++ b/pkg/sqlstore/service.go
@@ -2,6 +2,7 @@ package sqlstore
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/SUNET/vc/internal/gen/status/apiv1_status"
@@ -14,6 +15,19 @@ import (
 // call re-pings the backend.
 const probeCacheTTL = 10 * time.Second
 
+// ProbeCache guards a cached apiv1_status.StatusProbe against concurrent
+// Status() calls - a health-check/readiness endpoint is commonly hit by
+// multiple requests in flight at once, and the plain read-then-write this
+// replaces was a genuine data race under that load. Only one goroutine at a
+// time ever runs ping (see ProbeStatus): a call arriving while the cache is
+// stale but another goroutine's ping is already in flight simply waits for
+// the lock, then re-checks NextCheck and returns that fresh result rather
+// than pinging again.
+type ProbeCache struct {
+	mu    sync.Mutex
+	store apiv1_status.StatusProbeStore
+}
+
 // ProbeStatus implements the shared caching health-probe pattern every
 // db.Service.Status (apigw, verifier, ...) uses regardless of which backend
 // (Mongo or SQL) is active: ping at most once per probeCacheTTL, returning
@@ -24,9 +38,12 @@ const probeCacheTTL = 10 * time.Second
 // already opened its own tracing span around ctx (this package can't import
 // pkg/trace itself: pkg/model imports pkg/sqlstore, and pkg/trace imports
 // pkg/model, so sqlstore -> trace would be a cycle).
-func ProbeStatus(ctx context.Context, probeStore *apiv1_status.StatusProbeStore, ping func(context.Context) error) *apiv1_status.StatusProbe {
-	if time.Now().Before(probeStore.NextCheck.AsTime()) {
-		return probeStore.PreviousResult
+func ProbeStatus(ctx context.Context, cache *ProbeCache, ping func(context.Context) error) *apiv1_status.StatusProbe {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	if time.Now().Before(cache.store.NextCheck.AsTime()) {
+		return cache.store.PreviousResult
 	}
 	probe := &apiv1_status.StatusProbe{
 		Name:          "db",
@@ -39,8 +56,8 @@ func ProbeStatus(ctx context.Context, probeStore *apiv1_status.StatusProbeStore,
 		probe.Healthy = false
 	}
 
-	probeStore.PreviousResult = probe
-	probeStore.NextCheck = timestamppb.New(time.Now().Add(probeCacheTTL))
+	cache.store.PreviousResult = probe
+	cache.store.NextCheck = timestamppb.New(time.Now().Add(probeCacheTTL))
 
 	return probe
 }

--- a/pkg/sqlstore/service.go
+++ b/pkg/sqlstore/service.go
@@ -1,0 +1,57 @@
+package sqlstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/SUNET/vc/internal/gen/status/apiv1_status"
+
+	"github.com/jmoiron/sqlx"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// probeCacheTTL is how long a Status probe result is cached before the next
+// call re-pings the backend.
+const probeCacheTTL = 10 * time.Second
+
+// ProbeStatus implements the shared caching health-probe pattern every
+// db.Service.Status (apigw, verifier, ...) uses regardless of which backend
+// (Mongo or SQL) is active: ping at most once per probeCacheTTL, returning
+// the cached apiv1_status.StatusProbe otherwise. ping is the caller's own
+// backend-specific ping call (e.g. *sqlx.DB.PingContext, or a closure over
+// *mongo.Client.Ping) - this package deliberately doesn't import the mongo
+// driver just to express "the other branch". The caller is expected to have
+// already opened its own tracing span around ctx (this package can't import
+// pkg/trace itself: pkg/model imports pkg/sqlstore, and pkg/trace imports
+// pkg/model, so sqlstore -> trace would be a cycle).
+func ProbeStatus(ctx context.Context, probeStore *apiv1_status.StatusProbeStore, ping func(context.Context) error) *apiv1_status.StatusProbe {
+	if time.Now().Before(probeStore.NextCheck.AsTime()) {
+		return probeStore.PreviousResult
+	}
+	probe := &apiv1_status.StatusProbe{
+		Name:          "db",
+		Healthy:       true,
+		Message:       "OK",
+		LastCheckedTS: timestamppb.Now(),
+	}
+	if err := ping(ctx); err != nil {
+		probe.Message = err.Error()
+		probe.Healthy = false
+	}
+
+	probeStore.PreviousResult = probe
+	probeStore.NextCheck = timestamppb.New(time.Now().Add(probeCacheTTL))
+
+	return probe
+}
+
+// CloseBackend closes whichever backend connection is actually active:
+// sqlDB if non-nil (the SQL backend), otherwise closeMongo - the caller's
+// own Mongo disconnect call, passed as a thunk so this package doesn't need
+// to import the mongo driver just for this one alternative path.
+func CloseBackend(sqlDB *sqlx.DB, closeMongo func() error) error {
+	if sqlDB != nil {
+		return sqlDB.Close()
+	}
+	return closeMongo()
+}

--- a/pkg/sqlstore/service_test.go
+++ b/pkg/sqlstore/service_test.go
@@ -1,0 +1,45 @@
+package sqlstore
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProbeStatus_ConcurrentCallsSafe is a regression test for a real data
+// race Copilot flagged on PR #587: ProbeStatus's cached NextCheck/
+// PreviousResult fields were read and written with no synchronization, so
+// concurrent Status() calls (e.g. overlapping health-check/readiness
+// requests) raced. Run with -race, this reliably caught the bug before
+// ProbeCache added its mutex.
+func TestProbeStatus_ConcurrentCallsSafe(t *testing.T) {
+	cache := &ProbeCache{}
+	var pingCount atomic.Int64
+	ping := func(ctx context.Context) error {
+		pingCount.Add(1)
+		return nil
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			probe := ProbeStatus(t.Context(), cache, ping)
+			assert.NotNil(t, probe)
+			assert.True(t, probe.Healthy)
+		}()
+	}
+	wg.Wait()
+
+	// ProbeCache's mutex serializes the whole check-then-ping-then-cache
+	// sequence, so exactly one of these 50 concurrent calls actually pings -
+	// every other one blocks on the lock and then sees an already-fresh
+	// cache once it acquires it.
+	require.Equal(t, int64(1), pingCount.Load())
+}

--- a/pkg/testsupport/sqltest/service.go
+++ b/pkg/testsupport/sqltest/service.go
@@ -39,7 +39,10 @@ func NewServiceForTest[S Closer](t *testing.T, tracerName string, cfg *model.Cfg
 	svc, err := newFn(t.Context(), cfg, tracer, log)
 	require.NoError(t, err)
 	require.NotNil(t, svc)
-	t.Cleanup(func() { _ = svc.Close(t.Context()) })
+	// t.Cleanup-registered functions run after the testing package cancels
+	// t.Context(), so Close must use a fresh context here - not t.Context()
+	// again, which would already be done for by the time this runs.
+	t.Cleanup(func() { _ = svc.Close(context.Background()) })
 	return svc
 }
 

--- a/pkg/testsupport/sqltest/service.go
+++ b/pkg/testsupport/sqltest/service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/testsupport"
 	"github.com/SUNET/vc/pkg/testsupport/tracertest"
 	"github.com/SUNET/vc/pkg/trace"
@@ -40,4 +41,27 @@ func NewServiceForTest[S Closer](t *testing.T, tracerName string, cfg *model.Cfg
 	require.NotNil(t, svc)
 	t.Cleanup(func() { _ = svc.Close(t.Context()) })
 	return svc
+}
+
+// RunPostgresAndMariaDBContract runs newFn (a db package's own New()) against
+// both a fresh Postgres and a fresh MariaDB testcontainer, as subtests named
+// "Postgres"/"MariaDB", calling checkFn against each resulting service. This
+// is the shared two-backend contract-test shape every db.Service's SQL test
+// uses; callers keep their own checkFn with package-specific assertions.
+func RunPostgresAndMariaDBContract[S Closer](t *testing.T, tracerName string, newFn NewServiceFunc[S], checkFn func(*testing.T, S)) {
+	t.Helper()
+
+	t.Run("Postgres", func(t *testing.T) {
+		pgCfg, cleanup := PostgresConfig(t)
+		defer cleanup()
+		cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "postgres", Postgres: pgCfg}}}
+		checkFn(t, NewServiceForTest(t, tracerName, cfg, newFn))
+	})
+
+	t.Run("MariaDB", func(t *testing.T) {
+		mdbCfg, cleanup := MariaDBConfig(t)
+		defer cleanup()
+		cfg := &model.Cfg{Common: &model.Common{SQL: sqlstore.SQL{Backend: "mariadb", MariaDB: mdbCfg}}}
+		checkFn(t, NewServiceForTest(t, tracerName, cfg, newFn))
+	})
 }

--- a/pkg/testsupport/sqltest/service.go
+++ b/pkg/testsupport/sqltest/service.go
@@ -1,0 +1,43 @@
+package sqltest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SUNET/vc/pkg/logger"
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/testsupport"
+	"github.com/SUNET/vc/pkg/testsupport/tracertest"
+	"github.com/SUNET/vc/pkg/trace"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Closer is satisfied by every db.Service (apigw, verifier, ...): each has
+// its own concrete Service type, but all share this one method shape.
+type Closer interface {
+	Close(context.Context) error
+}
+
+// NewServiceFunc matches a db package's own New(ctx, cfg, tracer, log)
+// constructor - every db.Service package has one with this exact signature.
+type NewServiceFunc[S Closer] func(ctx context.Context, cfg *model.Cfg, tracer *trace.Tracer, log *logger.Log) (S, error)
+
+// NewServiceForTest builds a *logger.Log and *trace.Tracer, calls newFn to
+// exercise a db package's real New()/newSQL() code path end to end (config
+// -> sqlstore.Connect -> sqlstore.ApplySchema -> store wiring) against cfg,
+// and registers svc.Close on t.Cleanup. This is the one piece of setup
+// every db.Service's SQL contract test shares - callers still build cfg
+// themselves (via PostgresConfig/MariaDBConfig below) and still write their
+// own package-specific assertions against the returned service.
+func NewServiceForTest[S Closer](t *testing.T, tracerName string, cfg *model.Cfg, newFn NewServiceFunc[S]) S {
+	t.Helper()
+	log := testsupport.TestLogger(t)
+	tracer := tracertest.New(t, cfg, log, tracerName)
+
+	svc, err := newFn(t.Context(), cfg, tracer, log)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	t.Cleanup(func() { _ = svc.Close(t.Context()) })
+	return svc
+}

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -1,14 +1,13 @@
 // Package sqltest provides shared Postgres/MariaDB testcontainer helpers,
-// pre-migrated and ready to use, for repository-level SQL store tests.
+// pre-migrated and ready to use, for repository-level SQL store tests, plus
+// NewServiceForTest (service.go) - the shared "build cfg, call a db
+// package's New(), register Close on cleanup" harness every db.Service's
+// SQL contract test uses.
 //
 // It lives in its own leaf package, separate from pkg/testsupport itself,
 // matching pkg/testsupport/tracertest and pkg/testsupport/cachetest: those
 // two exist to avoid import cycles through packages that still depend on
-// pkg/model. pkg/sqlstore itself has no such dependency (SQL/PostgresConfig/
-// MariaDBConfig moved from pkg/model into pkg/sqlstore precisely to avoid
-// depending on pkg/model at all), so this package could safely be folded
-// back into pkg/testsupport directly -- kept separate here anyway, for now,
-// to match its siblings' layout rather than as a cycle requirement.
+// pkg/model, which this package now also imports (for NewServiceForTest).
 package sqltest
 
 import (

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -58,7 +58,7 @@ func StartPostgres(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 		t.Fatalf("ping postgres: %v", err)
 	}
 
-	if err := sqlstore.Migrate(db, sqlstore.PostgresDialect); err != nil {
+	if err := sqlstore.ApplySchema(db, sqlstore.PostgresDialect); err != nil {
 		_ = db.Close()
 		_ = ctr.Terminate(ctx)
 		t.Fatalf("migrate postgres: %v", err)
@@ -103,7 +103,7 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 		t.Fatalf("ping mariadb: %v", err)
 	}
 
-	if err := sqlstore.Migrate(db, sqlstore.MariaDBDialect); err != nil {
+	if err := sqlstore.ApplySchema(db, sqlstore.MariaDBDialect); err != nil {
 		_ = db.Close()
 		_ = ctr.Terminate(ctx)
 		t.Fatalf("migrate mariadb: %v", err)

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -54,6 +54,14 @@ func containerHostPort(t *testing.T, ctr testcontainers.Container, ctx context.C
 // StartPostgres spins up a throwaway, fully-migrated Postgres container and
 // returns a connected *sqlx.DB, its Dialect, and a cleanup function. Skips
 // the calling test if Docker is not available.
+//
+// The returned cleanup closure always terminates the container via
+// context.Background(), not the ctx used for setup: ctx is t.Context(),
+// which the testing package cancels once the test is done, and the whole
+// point of Terminate is to run reliably during teardown - a caller that
+// registers cleanup via t.Cleanup (rather than a bare defer) could
+// otherwise have it run against an already-canceled context and silently
+// fail to terminate, leaking the container.
 func StartPostgres(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 	t.Helper()
 	if !testsupport.IsDockerAvailable() {
@@ -91,7 +99,7 @@ func StartPostgres(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 
 	cleanup := func() {
 		_ = db.Close()
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 	}
 	return db, sqlstore.PostgresDialect, cleanup
 }
@@ -152,7 +160,7 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 
 	cleanup := func() {
 		_ = db.Close()
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 	}
 	return db, sqlstore.MariaDBDialect, cleanup
 }
@@ -185,7 +193,7 @@ func PostgresConfig(t *testing.T) (*sqlstore.PostgresConfig, func()) {
 		MaxOpenConns: 5,
 		MaxIdleConns: 2,
 	}
-	return cfg, func() { _ = ctr.Terminate(ctx) }
+	return cfg, func() { _ = ctr.Terminate(context.Background()) }
 }
 
 // MariaDBConfig spins up a throwaway, unmigrated MariaDB container and
@@ -215,5 +223,5 @@ func MariaDBConfig(t *testing.T) (*sqlstore.MariaDBConfig, func()) {
 		MaxOpenConns: 5,
 		MaxIdleConns: 2,
 	}
-	return cfg, func() { _ = ctr.Terminate(ctx) }
+	return cfg, func() { _ = ctr.Terminate(context.Background()) }
 }

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -58,7 +58,7 @@ func StartPostgres(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 		t.Fatalf("ping postgres: %v", err)
 	}
 
-	if err := sqlstore.ApplySchema(ctx, db, sqlstore.PostgresDialect); err != nil {
+	if err := sqlstore.ApplySchema(ctx, db, sqlstore.PostgresDialect, nil); err != nil {
 		_ = db.Close()
 		_ = ctr.Terminate(ctx)
 		t.Fatalf("migrate postgres: %v", err)
@@ -86,7 +86,11 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 		t.Fatalf("start mariadb container: %v", err)
 	}
 
-	connStr, err := ctr.ConnectionString(ctx, "multiStatements=true", "parseTime=true")
+	// Deliberately NOT multiStatements=true here: ApplySchema now opens its
+	// own dedicated migration connection with that enabled (see
+	// MariaDBConfig.MigrationDSN) rather than needing it on the
+	// application's own pool.
+	connStr, err := ctr.ConnectionString(ctx, "parseTime=true")
 	if err != nil {
 		_ = ctr.Terminate(ctx)
 		t.Fatalf("mariadb connection string: %v", err)
@@ -103,7 +107,36 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 		t.Fatalf("ping mariadb: %v", err)
 	}
 
-	if err := sqlstore.ApplySchema(ctx, db, sqlstore.MariaDBDialect); err != nil {
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		_ = db.Close()
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("mariadb host: %v", err)
+	}
+	port, err := ctr.MappedPort(ctx, "3306/tcp")
+	if err != nil {
+		_ = db.Close()
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("mariadb mapped port: %v", err)
+	}
+	portNum, err := strconv.Atoi(port.Port())
+	if err != nil {
+		_ = db.Close()
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("mariadb port: %v", err)
+	}
+	cfg := &sqlstore.SQL{
+		Backend: "mariadb",
+		MariaDB: &sqlstore.MariaDBConfig{
+			Host:     host,
+			Port:     portNum,
+			User:     "test",
+			Password: "test",
+			Database: "test",
+		},
+	}
+
+	if err := sqlstore.ApplySchema(ctx, db, sqlstore.MariaDBDialect, cfg); err != nil {
 		_ = db.Close()
 		_ = ctr.Terminate(ctx)
 		t.Fatalf("migrate mariadb: %v", err)

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -58,7 +58,7 @@ func StartPostgres(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 		t.Fatalf("ping postgres: %v", err)
 	}
 
-	if err := sqlstore.ApplySchema(db, sqlstore.PostgresDialect); err != nil {
+	if err := sqlstore.ApplySchema(ctx, db, sqlstore.PostgresDialect); err != nil {
 		_ = db.Close()
 		_ = ctr.Terminate(ctx)
 		t.Fatalf("migrate postgres: %v", err)
@@ -103,7 +103,7 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 		t.Fatalf("ping mariadb: %v", err)
 	}
 
-	if err := sqlstore.ApplySchema(db, sqlstore.MariaDBDialect); err != nil {
+	if err := sqlstore.ApplySchema(ctx, db, sqlstore.MariaDBDialect); err != nil {
 		_ = db.Close()
 		_ = ctr.Terminate(ctx)
 		t.Fatalf("migrate mariadb: %v", err)

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -11,8 +11,10 @@
 package sqltest
 
 import (
+	"strconv"
 	"testing"
 
+	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/testsupport"
 
@@ -112,4 +114,93 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 		_ = ctr.Terminate(ctx)
 	}
 	return db, sqlstore.MariaDBDialect, cleanup
+}
+
+// PostgresConfig spins up a throwaway, unmigrated Postgres container and
+// returns a *model.PostgresConfig pointing at it (for exercising the real
+// sqlstore.Connect/db.New code path, as opposed to StartPostgres's
+// already-opened *sqlx.DB) and a cleanup function.
+func PostgresConfig(t *testing.T) (*model.PostgresConfig, func()) {
+	t.Helper()
+	if !testsupport.IsDockerAvailable() {
+		t.Skip("Skipping test: Docker is not available")
+	}
+	ctx := t.Context()
+
+	ctr, err := postgres.Run(ctx, "postgres:16", postgres.BasicWaitStrategies())
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("postgres host: %v", err)
+	}
+	port, err := ctr.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("postgres mapped port: %v", err)
+	}
+	portNum, err := strconv.Atoi(port.Port())
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("postgres port: %v", err)
+	}
+
+	cfg := &model.PostgresConfig{
+		Host:         host,
+		Port:         portNum,
+		User:         "postgres",
+		Password:     "postgres",
+		Database:     "postgres",
+		SSLMode:      "disable",
+		MaxOpenConns: 5,
+		MaxIdleConns: 2,
+	}
+	return cfg, func() { _ = ctr.Terminate(ctx) }
+}
+
+// MariaDBConfig spins up a throwaway, unmigrated MariaDB container and
+// returns a *model.MariaDBConfig pointing at it (for exercising the real
+// sqlstore.Connect/db.New code path, as opposed to StartMariaDB's
+// already-opened *sqlx.DB) and a cleanup function.
+func MariaDBConfig(t *testing.T) (*model.MariaDBConfig, func()) {
+	t.Helper()
+	if !testsupport.IsDockerAvailable() {
+		t.Skip("Skipping test: Docker is not available")
+	}
+	ctx := t.Context()
+
+	ctr, err := mariadb.Run(ctx, "mariadb:11")
+	if err != nil {
+		t.Fatalf("start mariadb container: %v", err)
+	}
+
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("mariadb host: %v", err)
+	}
+	port, err := ctr.MappedPort(ctx, "3306/tcp")
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("mariadb mapped port: %v", err)
+	}
+	portNum, err := strconv.Atoi(port.Port())
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("mariadb port: %v", err)
+	}
+
+	cfg := &model.MariaDBConfig{
+		Host:         host,
+		Port:         portNum,
+		User:         "test",
+		Password:     "test",
+		Database:     "test",
+		MaxOpenConns: 5,
+		MaxIdleConns: 2,
+	}
+	return cfg, func() { _ = ctr.Terminate(ctx) }
 }

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -11,6 +11,7 @@
 package sqltest
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
@@ -18,12 +19,37 @@ import (
 	"github.com/SUNET/vc/pkg/testsupport"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mariadb"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
+
+// containerHostPort resolves ctr's host and mapped port for portSpec (e.g.
+// "5432/tcp") as a (host, int port) pair, terminating ctr and failing the
+// test on any error - shared by every StartXxx/XxxConfig helper below, all
+// of which otherwise repeated this exact host/port/strconv.Atoi sequence.
+func containerHostPort(t *testing.T, ctr testcontainers.Container, ctx context.Context, portSpec, label string) (string, int) {
+	t.Helper()
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("%s host: %v", label, err)
+	}
+	port, err := ctr.MappedPort(ctx, portSpec)
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("%s mapped port: %v", label, err)
+	}
+	portNum, err := strconv.Atoi(port.Port())
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("%s port: %v", label, err)
+	}
+	return host, portNum
+}
 
 // StartPostgres spins up a throwaway, fully-migrated Postgres container and
 // returns a connected *sqlx.DB, its Dialect, and a cleanup function. Skips
@@ -106,24 +132,7 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 		t.Fatalf("ping mariadb: %v", err)
 	}
 
-	host, err := ctr.Host(ctx)
-	if err != nil {
-		_ = db.Close()
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("mariadb host: %v", err)
-	}
-	port, err := ctr.MappedPort(ctx, "3306/tcp")
-	if err != nil {
-		_ = db.Close()
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("mariadb mapped port: %v", err)
-	}
-	portNum, err := strconv.Atoi(port.Port())
-	if err != nil {
-		_ = db.Close()
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("mariadb port: %v", err)
-	}
+	host, portNum := containerHostPort(t, ctr, ctx, "3306/tcp", "mariadb")
 	cfg := &sqlstore.SQL{
 		Backend: "mariadb",
 		MariaDB: &sqlstore.MariaDBConfig{
@@ -164,21 +173,7 @@ func PostgresConfig(t *testing.T) (*sqlstore.PostgresConfig, func()) {
 		t.Fatalf("start postgres container: %v", err)
 	}
 
-	host, err := ctr.Host(ctx)
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("postgres host: %v", err)
-	}
-	port, err := ctr.MappedPort(ctx, "5432/tcp")
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("postgres mapped port: %v", err)
-	}
-	portNum, err := strconv.Atoi(port.Port())
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("postgres port: %v", err)
-	}
+	host, portNum := containerHostPort(t, ctr, ctx, "5432/tcp", "postgres")
 
 	cfg := &sqlstore.PostgresConfig{
 		Host:         host,
@@ -209,21 +204,7 @@ func MariaDBConfig(t *testing.T) (*sqlstore.MariaDBConfig, func()) {
 		t.Fatalf("start mariadb container: %v", err)
 	}
 
-	host, err := ctr.Host(ctx)
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("mariadb host: %v", err)
-	}
-	port, err := ctr.MappedPort(ctx, "3306/tcp")
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("mariadb mapped port: %v", err)
-	}
-	portNum, err := strconv.Atoi(port.Port())
-	if err != nil {
-		_ = ctr.Terminate(ctx)
-		t.Fatalf("mariadb port: %v", err)
-	}
+	host, portNum := containerHostPort(t, ctr, ctx, "3306/tcp", "mariadb")
 
 	cfg := &sqlstore.MariaDBConfig{
 		Host:         host,

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -1,0 +1,115 @@
+// Package sqltest provides shared Postgres/MariaDB testcontainer helpers,
+// pre-migrated and ready to use, for repository-level SQL store tests.
+//
+// It lives in its own leaf package, separate from pkg/testsupport itself,
+// for the same reason as pkg/testsupport/tracertest: pkg/sqlstore depends
+// on pkg/model, which in turn depends on packages (e.g. pkg/mdoc) that
+// import pkg/cache, and pkg/cache's own tests already import
+// pkg/testsupport. Adding a pkg/sqlstore dependency to pkg/testsupport
+// itself would create an import cycle; keeping it here, imported only by
+// packages that don't sit on that cycle, avoids the problem.
+package sqltest
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/sqlstore"
+	"github.com/SUNET/vc/pkg/testsupport"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/testcontainers/testcontainers-go/modules/mariadb"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// StartPostgres spins up a throwaway, fully-migrated Postgres container and
+// returns a connected *sqlx.DB, its Dialect, and a cleanup function. Skips
+// the calling test if Docker is not available.
+func StartPostgres(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
+	t.Helper()
+	if !testsupport.IsDockerAvailable() {
+		t.Skip("Skipping test: Docker is not available")
+	}
+	ctx := t.Context()
+
+	ctr, err := postgres.Run(ctx, "postgres:16", postgres.BasicWaitStrategies())
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("postgres connection string: %v", err)
+	}
+
+	db, err := sqlx.Open(sqlstore.PostgresDialect.DriverName(), connStr)
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("open postgres: %v", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("ping postgres: %v", err)
+	}
+
+	if err := sqlstore.Migrate(db, sqlstore.PostgresDialect); err != nil {
+		_ = db.Close()
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("migrate postgres: %v", err)
+	}
+
+	cleanup := func() {
+		_ = db.Close()
+		_ = ctr.Terminate(ctx)
+	}
+	return db, sqlstore.PostgresDialect, cleanup
+}
+
+// StartMariaDB spins up a throwaway, fully-migrated MariaDB container and
+// returns a connected *sqlx.DB, its Dialect, and a cleanup function. Skips
+// the calling test if Docker is not available.
+func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
+	t.Helper()
+	if !testsupport.IsDockerAvailable() {
+		t.Skip("Skipping test: Docker is not available")
+	}
+	ctx := t.Context()
+
+	ctr, err := mariadb.Run(ctx, "mariadb:11")
+	if err != nil {
+		t.Fatalf("start mariadb container: %v", err)
+	}
+
+	connStr, err := ctr.ConnectionString(ctx, "multiStatements=true", "parseTime=true")
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("mariadb connection string: %v", err)
+	}
+
+	db, err := sqlx.Open(sqlstore.MariaDBDialect.DriverName(), connStr)
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("open mariadb: %v", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("ping mariadb: %v", err)
+	}
+
+	if err := sqlstore.Migrate(db, sqlstore.MariaDBDialect); err != nil {
+		_ = db.Close()
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("migrate mariadb: %v", err)
+	}
+
+	cleanup := func() {
+		_ = db.Close()
+		_ = ctr.Terminate(ctx)
+	}
+	return db, sqlstore.MariaDBDialect, cleanup
+}

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -31,21 +31,27 @@ import (
 // "5432/tcp") as a (host, int port) pair, terminating ctr and failing the
 // test on any error - shared by every StartXxx/XxxConfig helper below, all
 // of which otherwise repeated this exact host/port/strconv.Atoi sequence.
+//
+// Terminate always uses context.Background(), not ctx: ctx is t.Context(),
+// which the testing package can cancel mid-call (e.g. on a test timeout),
+// and Terminate should reliably clean up the container regardless of why
+// this function is failing - matching every other cleanup path in this
+// package.
 func containerHostPort(t *testing.T, ctr testcontainers.Container, ctx context.Context, portSpec, label string) (string, int) {
 	t.Helper()
 	host, err := ctr.Host(ctx)
 	if err != nil {
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("%s host: %v", label, err)
 	}
 	port, err := ctr.MappedPort(ctx, portSpec)
 	if err != nil {
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("%s mapped port: %v", label, err)
 	}
 	portNum, err := strconv.Atoi(port.Port())
 	if err != nil {
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("%s port: %v", label, err)
 	}
 	return host, portNum
@@ -76,24 +82,24 @@ func StartPostgres(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 
 	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("postgres connection string: %v", err)
 	}
 
 	db, err := sqlx.Open(sqlstore.PostgresDialect.DriverName(), connStr)
 	if err != nil {
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("open postgres: %v", err)
 	}
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("ping postgres: %v", err)
 	}
 
 	if err := sqlstore.ApplySchema(ctx, db, sqlstore.PostgresDialect, nil); err != nil {
 		_ = db.Close()
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("migrate postgres: %v", err)
 	}
 
@@ -125,18 +131,18 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 	// application's own pool.
 	connStr, err := ctr.ConnectionString(ctx, "parseTime=true")
 	if err != nil {
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("mariadb connection string: %v", err)
 	}
 
 	db, err := sqlx.Open(sqlstore.MariaDBDialect.DriverName(), connStr)
 	if err != nil {
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("open mariadb: %v", err)
 	}
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("ping mariadb: %v", err)
 	}
 
@@ -154,7 +160,7 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 
 	if err := sqlstore.ApplySchema(ctx, db, sqlstore.MariaDBDialect, cfg); err != nil {
 		_ = db.Close()
-		_ = ctr.Terminate(ctx)
+		_ = ctr.Terminate(context.Background())
 		t.Fatalf("migrate mariadb: %v", err)
 	}
 

--- a/pkg/testsupport/sqltest/sqltest.go
+++ b/pkg/testsupport/sqltest/sqltest.go
@@ -2,19 +2,19 @@
 // pre-migrated and ready to use, for repository-level SQL store tests.
 //
 // It lives in its own leaf package, separate from pkg/testsupport itself,
-// for the same reason as pkg/testsupport/tracertest: pkg/sqlstore depends
-// on pkg/model, which in turn depends on packages (e.g. pkg/mdoc) that
-// import pkg/cache, and pkg/cache's own tests already import
-// pkg/testsupport. Adding a pkg/sqlstore dependency to pkg/testsupport
-// itself would create an import cycle; keeping it here, imported only by
-// packages that don't sit on that cycle, avoids the problem.
+// matching pkg/testsupport/tracertest and pkg/testsupport/cachetest: those
+// two exist to avoid import cycles through packages that still depend on
+// pkg/model. pkg/sqlstore itself has no such dependency (SQL/PostgresConfig/
+// MariaDBConfig moved from pkg/model into pkg/sqlstore precisely to avoid
+// depending on pkg/model at all), so this package could safely be folded
+// back into pkg/testsupport directly -- kept separate here anyway, for now,
+// to match its siblings' layout rather than as a cycle requirement.
 package sqltest
 
 import (
 	"strconv"
 	"testing"
 
-	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/testsupport"
 
@@ -117,10 +117,10 @@ func StartMariaDB(t *testing.T) (*sqlx.DB, sqlstore.Dialect, func()) {
 }
 
 // PostgresConfig spins up a throwaway, unmigrated Postgres container and
-// returns a *model.PostgresConfig pointing at it (for exercising the real
+// returns a *sqlstore.PostgresConfig pointing at it (for exercising the real
 // sqlstore.Connect/db.New code path, as opposed to StartPostgres's
 // already-opened *sqlx.DB) and a cleanup function.
-func PostgresConfig(t *testing.T) (*model.PostgresConfig, func()) {
+func PostgresConfig(t *testing.T) (*sqlstore.PostgresConfig, func()) {
 	t.Helper()
 	if !testsupport.IsDockerAvailable() {
 		t.Skip("Skipping test: Docker is not available")
@@ -148,7 +148,7 @@ func PostgresConfig(t *testing.T) (*model.PostgresConfig, func()) {
 		t.Fatalf("postgres port: %v", err)
 	}
 
-	cfg := &model.PostgresConfig{
+	cfg := &sqlstore.PostgresConfig{
 		Host:         host,
 		Port:         portNum,
 		User:         "postgres",
@@ -162,10 +162,10 @@ func PostgresConfig(t *testing.T) (*model.PostgresConfig, func()) {
 }
 
 // MariaDBConfig spins up a throwaway, unmigrated MariaDB container and
-// returns a *model.MariaDBConfig pointing at it (for exercising the real
+// returns a *sqlstore.MariaDBConfig pointing at it (for exercising the real
 // sqlstore.Connect/db.New code path, as opposed to StartMariaDB's
 // already-opened *sqlx.DB) and a cleanup function.
-func MariaDBConfig(t *testing.T) (*model.MariaDBConfig, func()) {
+func MariaDBConfig(t *testing.T) (*sqlstore.MariaDBConfig, func()) {
 	t.Helper()
 	if !testsupport.IsDockerAvailable() {
 		t.Skip("Skipping test: Docker is not available")
@@ -193,7 +193,7 @@ func MariaDBConfig(t *testing.T) (*model.MariaDBConfig, func()) {
 		t.Fatalf("mariadb port: %v", err)
 	}
 
-	cfg := &model.MariaDBConfig{
+	cfg := &sqlstore.MariaDBConfig{
 		Host:         host,
 		Port:         portNum,
 		User:         "test",


### PR DESCRIPTION
Adds a relational (Postgres/MariaDB) implementation of verifier's `ClientStore`, selected via `Common.SQL.Backend`, on top of the `pkg/sqlstore` foundations merged in #571.

Stacked on #586 (apigw SQL stores) — this diff includes #586's commits until it merges; verifier's own contribution is `17aeb6574` (SQL implementation of ClientStore + Backend switch wiring) plus the follow-up commits adapting to `ApplySchema`'s parameter changes.

Recreated against current `main` (was previously stacked as fork PR [sirosfoundation/vc#27](https://github.com/sirosfoundation/vc/pull/27) on `feature/apigw-sql-store`'s pre-rebase tip) — same content, rebased onto the now-rebased apigw branch, all tests re-verified against real Postgres/MariaDB/Mongo testcontainers post-rebase.

## Summary
- `sql_client.go`: `ClientStore` implementation, both Postgres and MariaDB dialects, via `pkg/sqlstore`'s `Dialect` abstraction.
- `db.Service.New` wires `Common.SQL.Backend` to select Mongo (default, unchanged) vs Postgres vs MariaDB.
- Contract tests for `ClientStore` against all three backends via testcontainers.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite; only the known pre-existing, unrelated `TestIssuerMetadata_Generate_VCTMDisplay_PartialRendering` failure)
- [x] Mongo + Postgres + MariaDB contract tests for ClientStore, real testcontainers