### PR TITLE
cache: add Redis-backed Cache[V] and RateLimitCounter implementations

### DIFF
--- a/pkg/cache/generic_redis.go
+++ b/pkg/cache/generic_redis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -57,6 +58,14 @@ func NewRedisCache[V any](client redis.UniversalClient, collection string, ttl t
 	}
 	if collection == "" {
 		return nil, fmt.Errorf("redis cache: collection cannot be empty")
+	}
+	// Len() scans "<collection>:*" as a glob pattern - a collection name
+	// containing glob metacharacters would make that pattern match keys
+	// outside this cache's own namespace (or scan far more broadly than
+	// intended), silently breaking the per-collection isolation every
+	// other method relies on.
+	if strings.ContainsAny(collection, "*?[]\\") {
+		return nil, fmt.Errorf("redis cache: collection %q must not contain glob metacharacters (*?[]\\)", collection)
 	}
 	if log == nil {
 		log = nopLogger{}

--- a/pkg/cache/generic_redis.go
+++ b/pkg/cache/generic_redis.go
@@ -117,6 +117,16 @@ func (r *RedisCache[V]) SetWithTTL(ctx context.Context, key string, value V, ttl
 }
 
 func (r *RedisCache[V]) setWithTTL(ctx context.Context, key string, value V, ttl time.Duration, op string) {
+	// Redis's SET treats a non-positive expiration as "no expiration" -
+	// the opposite of MongoCache's SetWithTTL(ttl<=0), which shifts
+	// created_at so far into the past that the document is already
+	// expired under the collection's TTL index. Clamp to the smallest
+	// representable TTL instead, so a non-positive ttl still expires
+	// (near-)immediately here too, rather than caching permanently.
+	if ttl <= 0 {
+		ttl = time.Millisecond
+	}
+
 	data, err := json.Marshal(value)
 	if err != nil {
 		r.log.Error(err, logPrefix+op+" marshal failed", "cache", r.collection, "key", key)

--- a/pkg/cache/generic_redis.go
+++ b/pkg/cache/generic_redis.go
@@ -154,6 +154,16 @@ func (r *RedisCache[V]) SetNXWithTTL(ctx context.Context, key string, value V, t
 }
 
 func (r *RedisCache[V]) setNXWithTTL(ctx context.Context, key string, value V, ttl time.Duration) (bool, error) {
+	// Same clamp as setWithTTL: a non-positive ttl reaching Redis's SETNX
+	// means "no expiration" rather than "expire immediately". Without
+	// this, SetNX() (which passes r.ttl straight through) would silently
+	// create permanent keys whenever the cache's own default ttl is
+	// non-positive, inconsistent with Set()/SetWithTTL() on this same
+	// cache instance.
+	if ttl <= 0 {
+		ttl = time.Millisecond
+	}
+
 	data, err := json.Marshal(value)
 	if err != nil {
 		return false, fmt.Errorf("redis cache setnx marshal failed (cache=%s): %w", r.collection, err)

--- a/pkg/cache/generic_redis.go
+++ b/pkg/cache/generic_redis.go
@@ -15,7 +15,12 @@ import (
 // identifiable in shared logs alongside MongoCache/MemoryCache.
 const logPrefix = "redis cache "
 
-// RedisCache is a generic cache backed by Redis. Values are JSON-encoded
+// RedisCache is a generic cache backed by Redis or any RESP-protocol
+// server compatible with it (e.g. Valkey, the open-source Redis fork
+// maintained under the Linux Foundation) - this implementation only ever
+// issues standard GET/SET/DEL/GETDEL/SCAN/SETNX commands through
+// redis.UniversalClient, none of which are Redis-specific. Values are
+// JSON-encoded
 // before storage (matching MongoCache's approach), which allows interface
 // types (e.g. jwk.Key) to round-trip correctly via a custom decoder. Unlike
 // MongoCache, which approximates per-entry TTL by shifting created_at under

--- a/pkg/cache/generic_redis.go
+++ b/pkg/cache/generic_redis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -187,22 +188,47 @@ func (r *RedisCache[V]) GetAndDelete(ctx context.Context, key string) (V, bool) 
 // over this cache's own keys, not the whole Redis keyspace. Like
 // MongoCache.Len (EstimatedDocumentCount), this is an approximate,
 // informational count, not a value to build correctness on.
+//
+// On a *redis.ClusterClient, a single SCAN only walks the node it's sent
+// to, not the whole cluster - keys live on whichever shard they hash to.
+// Fan out via ForEachMaster and sum, so this stays a whole-cache count
+// under either topology.
 func (r *RedisCache[V]) Len() int {
 	ctx := context.Background()
 	pattern := r.collection + ":*"
+
+	if cc, ok := r.client.(*redis.ClusterClient); ok {
+		var total atomic.Int64
+		if err := cc.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
+			n, err := scanCount(ctx, master, pattern)
+			total.Add(int64(n))
+			return err
+		}); err != nil {
+			r.log.Error(err, "redis cache len failed", "cache", r.collection)
+		}
+		return int(total.Load())
+	}
+
+	n, err := scanCount(ctx, r.client, pattern)
+	if err != nil {
+		r.log.Error(err, "redis cache len failed", "cache", r.collection)
+	}
+	return n
+}
+
+// scanCount counts keys matching pattern on a single node via SCAN.
+func scanCount(ctx context.Context, client redis.UniversalClient, pattern string) (int, error) {
 	var count int
 	var cursor uint64
 	for {
-		keys, next, err := r.client.Scan(ctx, cursor, pattern, 1000).Result()
+		keys, next, err := client.Scan(ctx, cursor, pattern, 1000).Result()
 		if err != nil {
-			r.log.Error(err, "redis cache len failed", "cache", r.collection)
-			return count
+			return count, err
 		}
 		count += len(keys)
 		cursor = next
 		if cursor == 0 {
-			break
+			return count, nil
 		}
 	}
-	return count
 }

--- a/pkg/cache/generic_redis.go
+++ b/pkg/cache/generic_redis.go
@@ -50,6 +50,9 @@ func NewRedisCache[V any](client redis.UniversalClient, collection string, ttl t
 	if client == nil {
 		return nil, fmt.Errorf("redis client cannot be nil")
 	}
+	if collection == "" {
+		return nil, fmt.Errorf("redis cache: collection cannot be empty")
+	}
 	if log == nil {
 		log = nopLogger{}
 	}

--- a/pkg/cache/generic_redis.go
+++ b/pkg/cache/generic_redis.go
@@ -197,7 +197,10 @@ func (r *RedisCache[V]) GetAndDelete(ctx context.Context, key string) (V, bool) 
 // MATCH pattern scoped to this cache's collection prefix - an O(n) walk
 // over this cache's own keys, not the whole Redis keyspace. Like
 // MongoCache.Len (EstimatedDocumentCount), this is an approximate,
-// informational count, not a value to build correctness on.
+// informational count, not a value to build correctness on. On any scan
+// error, returns 0 rather than a partial count - matching
+// MongoCache.Len, and avoiding misleading a caller with an undercount
+// that looks like a real (if approximate) answer.
 //
 // On a *redis.ClusterClient, a single SCAN only walks the node it's sent
 // to, not the whole cluster - keys live on whichever shard they hash to.
@@ -211,10 +214,14 @@ func (r *RedisCache[V]) Len() int {
 		var total atomic.Int64
 		if err := cc.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
 			n, err := scanCount(ctx, master, pattern)
+			if err != nil {
+				return err
+			}
 			total.Add(int64(n))
-			return err
+			return nil
 		}); err != nil {
 			r.log.Error(err, "redis cache len failed", "cache", r.collection)
+			return 0
 		}
 		return int(total.Load())
 	}
@@ -222,6 +229,7 @@ func (r *RedisCache[V]) Len() int {
 	n, err := scanCount(ctx, r.client, pattern)
 	if err != nil {
 		r.log.Error(err, "redis cache len failed", "cache", r.collection)
+		return 0
 	}
 	return n
 }

--- a/pkg/cache/generic_redis.go
+++ b/pkg/cache/generic_redis.go
@@ -10,6 +10,10 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// logPrefix prefixes every RedisCache log message so the backend is
+// identifiable in shared logs alongside MongoCache/MemoryCache.
+const logPrefix = "redis cache "
+
 // RedisCache is a generic cache backed by Redis. Values are JSON-encoded
 // before storage (matching MongoCache's approach), which allows interface
 // types (e.g. jwk.Key) to round-trip correctly via a custom decoder. Unlike
@@ -78,7 +82,7 @@ func (r *RedisCache[V]) decodeValue(data []byte, op, key string) (V, bool) {
 	}
 	if err != nil {
 		r.log.Error(
-			err, "redis cache "+op+": failed to unmarshal JSON value",
+			err, logPrefix+op+": failed to unmarshal JSON value",
 			"cache", r.collection, "key", key,
 		)
 		var zero V
@@ -114,11 +118,11 @@ func (r *RedisCache[V]) SetWithTTL(ctx context.Context, key string, value V, ttl
 func (r *RedisCache[V]) setWithTTL(ctx context.Context, key string, value V, ttl time.Duration, op string) {
 	data, err := json.Marshal(value)
 	if err != nil {
-		r.log.Error(err, "redis cache "+op+" marshal failed", "cache", r.collection, "key", key)
+		r.log.Error(err, logPrefix+op+" marshal failed", "cache", r.collection, "key", key)
 		return
 	}
 	if err := r.client.Set(ctx, r.namespacedKey(key), data, ttl).Err(); err != nil {
-		r.log.Error(err, "redis cache "+op+" failed", "cache", r.collection, "key", key)
+		r.log.Error(err, logPrefix+op+" failed", "cache", r.collection, "key", key)
 	}
 }
 

--- a/pkg/cache/generic_redis.go
+++ b/pkg/cache/generic_redis.go
@@ -1,0 +1,204 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisCache is a generic cache backed by Redis. Values are JSON-encoded
+// before storage (matching MongoCache's approach), which allows interface
+// types (e.g. jwk.Key) to round-trip correctly via a custom decoder. Unlike
+// MongoCache, which approximates per-entry TTL by shifting created_at under
+// a collection-wide TTL index, Redis has native per-key expiration (EXPIRE),
+// so every TTL here is exact, not approximated.
+//
+// Keys are namespaced by collection ("<collection>:<key>") so multiple
+// caches can safely share one Redis database/keyspace.
+type RedisCache[V any] struct {
+	client     redis.UniversalClient
+	collection string
+	ttl        time.Duration // default TTL for Set/SetNX
+	log        Logger
+	decode     func([]byte) (V, error) // optional custom JSON decoder
+}
+
+// RedisCacheOption configures optional behaviour for RedisCache.
+type RedisCacheOption[V any] func(*RedisCache[V])
+
+// WithRedisDecoder supplies a custom JSON decoder for V - use this for
+// interface types (e.g. jwk.Key) where json.Unmarshal cannot infer the
+// concrete type. Mirrors generic_mongo.go's WithDecoder.
+func WithRedisDecoder[V any](fn func([]byte) (V, error)) RedisCacheOption[V] {
+	return func(r *RedisCache[V]) { r.decode = fn }
+}
+
+// NewRedisCache creates a new Redis-backed generic cache. client may be a
+// *redis.Client (single node) or *redis.ClusterClient (cluster mode) - both
+// satisfy redis.UniversalClient, so callers can switch topology without any
+// change here. If log is nil, operational errors are silently discarded.
+func NewRedisCache[V any](client redis.UniversalClient, collection string, ttl time.Duration, log Logger, opts ...RedisCacheOption[V]) (*RedisCache[V], error) {
+	if client == nil {
+		return nil, fmt.Errorf("redis client cannot be nil")
+	}
+	if log == nil {
+		log = nopLogger{}
+	}
+
+	r := &RedisCache[V]{
+		client:     client,
+		collection: collection,
+		ttl:        ttl,
+		log:        log,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r, nil
+}
+
+// namespacedKey prefixes key with this cache's collection so distinct
+// RedisCache instances sharing one Redis database/keyspace never collide.
+func (r *RedisCache[V]) namespacedKey(key string) string {
+	return r.collection + ":" + key
+}
+
+// decodeValue unmarshals JSON bytes into V using the configured decoder.
+func (r *RedisCache[V]) decodeValue(data []byte, op, key string) (V, bool) {
+	var v V
+	var err error
+	if r.decode != nil {
+		v, err = r.decode(data)
+	} else {
+		err = json.Unmarshal(data, &v)
+	}
+	if err != nil {
+		r.log.Error(
+			err, "redis cache "+op+": failed to unmarshal JSON value",
+			"cache", r.collection, "key", key,
+		)
+		var zero V
+		return zero, false
+	}
+	return v, true
+}
+
+// Get retrieves a value by key.
+func (r *RedisCache[V]) Get(ctx context.Context, key string) (V, bool) {
+	data, err := r.client.Get(ctx, r.namespacedKey(key)).Bytes()
+	if err != nil {
+		var zero V
+		if errors.Is(err, redis.Nil) {
+			return zero, false
+		}
+		r.log.Error(err, "redis cache get: operational error treated as miss", "cache", r.collection, "key", key)
+		return zero, false
+	}
+	return r.decodeValue(data, "get", key)
+}
+
+// Set stores a value with the default TTL configured at creation time.
+func (r *RedisCache[V]) Set(ctx context.Context, key string, value V) {
+	r.setWithTTL(ctx, key, value, r.ttl, "set")
+}
+
+// SetWithTTL stores a value with a custom TTL, overriding the default.
+func (r *RedisCache[V]) SetWithTTL(ctx context.Context, key string, value V, ttl time.Duration) {
+	r.setWithTTL(ctx, key, value, ttl, "setwithttl")
+}
+
+func (r *RedisCache[V]) setWithTTL(ctx context.Context, key string, value V, ttl time.Duration, op string) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		r.log.Error(err, "redis cache "+op+" marshal failed", "cache", r.collection, "key", key)
+		return
+	}
+	if err := r.client.Set(ctx, r.namespacedKey(key), data, ttl).Err(); err != nil {
+		r.log.Error(err, "redis cache "+op+" failed", "cache", r.collection, "key", key)
+	}
+}
+
+// SetNX stores a value only if the key does not already exist (atomic).
+// Returns true if the value was set, false if the key already existed.
+func (r *RedisCache[V]) SetNX(ctx context.Context, key string, value V) (bool, error) {
+	return r.setNXWithTTL(ctx, key, value, r.ttl)
+}
+
+// SetNXWithTTL stores a value only if the key does not already exist
+// (atomic), using a custom TTL instead of the default.
+// If ttl <= 0, falls back to SetNX (default TTL).
+func (r *RedisCache[V]) SetNXWithTTL(ctx context.Context, key string, value V, ttl time.Duration) (bool, error) {
+	if ttl <= 0 {
+		return r.SetNX(ctx, key, value)
+	}
+	return r.setNXWithTTL(ctx, key, value, ttl)
+}
+
+func (r *RedisCache[V]) setNXWithTTL(ctx context.Context, key string, value V, ttl time.Duration) (bool, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return false, fmt.Errorf("redis cache setnx marshal failed (cache=%s): %w", r.collection, err)
+	}
+	// SET key value NX EX ttl is a single atomic Redis command - no
+	// insert-and-catch-duplicate-key dance needed (unlike MongoCache's
+	// SetNX, which relies on a unique index and a duplicate-key error).
+	ok, err := r.client.SetNX(ctx, r.namespacedKey(key), data, ttl).Result()
+	if err != nil {
+		return false, fmt.Errorf("redis cache setnx failed (cache=%s): %w", r.collection, err)
+	}
+	return ok, nil
+}
+
+// Delete removes a value by key.
+func (r *RedisCache[V]) Delete(ctx context.Context, key string) {
+	if err := r.client.Del(ctx, r.namespacedKey(key)).Err(); err != nil {
+		r.log.Error(err, "redis cache delete failed", "cache", r.collection, "key", key)
+	}
+}
+
+// GetAndDelete atomically retrieves and removes a value by key.
+func (r *RedisCache[V]) GetAndDelete(ctx context.Context, key string) (V, bool) {
+	// GETDEL is a single atomic Redis command (Redis 6.2+), unlike
+	// MongoCache's FindOneAndDelete equivalent, which needs no such
+	// version caveat on the Mongo side.
+	data, err := r.client.GetDel(ctx, r.namespacedKey(key)).Bytes()
+	if err != nil {
+		var zero V
+		if errors.Is(err, redis.Nil) {
+			return zero, false
+		}
+		r.log.Error(err, "redis cache get-and-delete: operational error treated as miss", "cache", r.collection, "key", key)
+		return zero, false
+	}
+	return r.decodeValue(data, "get-and-delete", key)
+}
+
+// Len returns the number of items currently in this cache. Implemented via
+// SCAN (not KEYS, which blocks the server on large keyspaces) with a
+// MATCH pattern scoped to this cache's collection prefix - an O(n) walk
+// over this cache's own keys, not the whole Redis keyspace. Like
+// MongoCache.Len (EstimatedDocumentCount), this is an approximate,
+// informational count, not a value to build correctness on.
+func (r *RedisCache[V]) Len() int {
+	ctx := context.Background()
+	pattern := r.collection + ":*"
+	var count int
+	var cursor uint64
+	for {
+		keys, next, err := r.client.Scan(ctx, cursor, pattern, 1000).Result()
+		if err != nil {
+			r.log.Error(err, "redis cache len failed", "cache", r.collection)
+			return count
+		}
+		count += len(keys)
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return count
+}

--- a/pkg/cache/generic_redis_test.go
+++ b/pkg/cache/generic_redis_test.go
@@ -126,6 +126,14 @@ func TestRedisCache_NilClient(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestRedisCache_EmptyCollection(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	_, err := NewRedisCache[string](client, "", 5*time.Minute, nil)
+	assert.Error(t, err, "an empty collection breaks key namespacing and widens Len()'s scan pattern, so it must be rejected")
+}
+
 func TestRedisCache_JWKKey(t *testing.T) {
 	client, cleanup := startRedisContainer(t)
 	defer cleanup()

--- a/pkg/cache/generic_redis_test.go
+++ b/pkg/cache/generic_redis_test.go
@@ -2,10 +2,6 @@ package cache
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -140,20 +136,13 @@ func TestRedisCache_JWKKey(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	key, err := jwk.Import(raw)
-	require.NoError(t, err)
+	key := newTestECJWKKey(t)
 
 	c.Set(ctx, "k1", key)
 	got, ok := c.Get(ctx, "k1")
 	require.True(t, ok, "expected jwk.Key to round-trip through RedisCache")
 
-	origJSON, err := json.Marshal(key)
-	require.NoError(t, err)
-	gotJSON, err := json.Marshal(got)
-	require.NoError(t, err)
-	assert.JSONEq(t, string(origJSON), string(gotJSON))
+	assertSameJWKKey(t, key, got)
 }
 
 // TestRedisCache_KeysNamespacedByCollection confirms two RedisCache

--- a/pkg/cache/generic_redis_test.go
+++ b/pkg/cache/generic_redis_test.go
@@ -202,7 +202,14 @@ func TestRedisCache_KeysNamespacedByCollection(t *testing.T) {
 // TestRedisCache_TTLExpiration confirms Redis's native per-key TTL (not
 // MongoCache's created_at-shift approximation) actually expires entries.
 func TestRedisCache_TTLExpiration(t *testing.T) {
-	client, cleanup := startRedisContainer(t)
+	testCacheTTLExpiration(t, startRedisContainer)
+}
+
+// testCacheTTLExpiration is shared by the Redis and Valkey variants above/
+// below - the assertion is backend-agnostic, only the container differs.
+func testCacheTTLExpiration(t *testing.T, startContainer func(*testing.T) (redis.UniversalClient, func())) {
+	t.Helper()
+	client, cleanup := startContainer(t)
 	defer cleanup()
 
 	ctx := t.Context()
@@ -283,18 +290,5 @@ func TestValkeyCache_String(t *testing.T) {
 // TestValkeyCache_TTLExpiration confirms Valkey actually expires keys via
 // native per-key EXPIRE, matching TestRedisCache_TTLExpiration.
 func TestValkeyCache_TTLExpiration(t *testing.T) {
-	client, cleanup := startValkeyContainer(t)
-	defer cleanup()
-
-	ctx := t.Context()
-	c, err := NewRedisCache[string](client, "cache_ttl", 200*time.Millisecond, nil)
-	require.NoError(t, err)
-
-	c.Set(ctx, "expiring", "value")
-	_, ok := c.Get(ctx, "expiring")
-	require.True(t, ok, "value should be present immediately after Set")
-
-	time.Sleep(400 * time.Millisecond)
-	_, ok = c.Get(ctx, "expiring")
-	assert.False(t, ok, "value should have expired")
+	testCacheTTLExpiration(t, startValkeyContainer)
 }

--- a/pkg/cache/generic_redis_test.go
+++ b/pkg/cache/generic_redis_test.go
@@ -17,33 +17,54 @@ import (
 // Mirrors startMongoContainer's shape for this package's other backends.
 func startRedisContainer(t *testing.T) (redis.UniversalClient, func()) {
 	t.Helper()
+	return startRedisCompatibleContainer(t, "redis:7")
+}
+
+// startValkeyContainer spins up a throwaway Valkey (the open-source Redis
+// fork maintained under the Linux Foundation) via the same testcontainers
+// module used for Redis. Valkey speaks the same RESP protocol and exposes
+// the same port/startup log line Redis does, so no dedicated
+// testcontainers module is needed - only the image differs. Its tests
+// exist to prove RedisCache/RedisRateLimitCounter genuinely work against
+// Valkey, not just Redis, since nothing else in this package would catch
+// a protocol divergence.
+func startValkeyContainer(t *testing.T) (redis.UniversalClient, func()) {
+	t.Helper()
+	return startRedisCompatibleContainer(t, "valkey/valkey:8")
+}
+
+// startRedisCompatibleContainer spins up img (any RESP-protocol server
+// exposing the standard Redis port 6379) via testcontainers and returns a
+// connected redis.UniversalClient plus a cleanup function.
+func startRedisCompatibleContainer(t *testing.T, img string) (redis.UniversalClient, func()) {
+	t.Helper()
 	if !isDockerAvailable() {
 		t.Skip("Skipping test: Docker is not available")
 	}
 	ctx := t.Context()
 
-	container, err := tcredis.Run(ctx, "redis:7")
+	container, err := tcredis.Run(ctx, img)
 	if err != nil {
-		t.Fatalf("start redis container: %v", err)
+		t.Fatalf("start %s container: %v", img, err)
 	}
 
 	connStr, err := container.ConnectionString(ctx)
 	if err != nil {
 		_ = container.Terminate(context.Background())
-		t.Fatalf("redis connection string: %v", err)
+		t.Fatalf("%s connection string: %v", img, err)
 	}
 
 	opts, err := redis.ParseURL(connStr)
 	if err != nil {
 		_ = container.Terminate(context.Background())
-		t.Fatalf("parse redis url: %v", err)
+		t.Fatalf("parse %s url: %v", img, err)
 	}
 	client := redis.NewClient(opts)
 
 	if err := client.Ping(ctx).Err(); err != nil {
 		_ = client.Close()
 		_ = container.Terminate(context.Background())
-		t.Fatalf("ping redis: %v", err)
+		t.Fatalf("ping %s: %v", img, err)
 	}
 
 	cleanup := func() {
@@ -239,4 +260,41 @@ func TestRedisCache_SetNX_NonPositiveDefaultTTLExpiresImmediately(t *testing.T) 
 	time.Sleep(50 * time.Millisecond)
 	_, ok = c.Get(ctx, "zero-default-ttl")
 	assert.False(t, ok, "SetNX must not cache the value permanently when the cache's default ttl is non-positive")
+}
+
+// --- RedisCache-against-Valkey tests (require Docker) ---
+//
+// RedisCache talks to its backend only through redis.UniversalClient's
+// RESP commands (GET/SET/DEL/GETDEL/SCAN/SETNX+EX), with no
+// Redis-specific behavior beyond that protocol surface. These tests run
+// the same contract/TTL assertions used above against a real Valkey
+// server to confirm that's actually true, rather than assuming
+// wire-compatibility from Valkey's project description.
+
+func TestValkeyCache_String(t *testing.T) {
+	client, cleanup := startValkeyContainer(t)
+	defer cleanup()
+
+	c, err := NewRedisCache[string](client, "cache_string", 10*time.Minute, nil)
+	require.NoError(t, err)
+	runGenericCacheContractTests(t, c, "hello", "world")
+}
+
+// TestValkeyCache_TTLExpiration confirms Valkey actually expires keys via
+// native per-key EXPIRE, matching TestRedisCache_TTLExpiration.
+func TestValkeyCache_TTLExpiration(t *testing.T) {
+	client, cleanup := startValkeyContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	c, err := NewRedisCache[string](client, "cache_ttl", 200*time.Millisecond, nil)
+	require.NoError(t, err)
+
+	c.Set(ctx, "expiring", "value")
+	_, ok := c.Get(ctx, "expiring")
+	require.True(t, ok, "value should be present immediately after Set")
+
+	time.Sleep(400 * time.Millisecond)
+	_, ok = c.Get(ctx, "expiring")
+	assert.False(t, ok, "value should have expired")
 }

--- a/pkg/cache/generic_redis_test.go
+++ b/pkg/cache/generic_redis_test.go
@@ -188,3 +188,26 @@ func TestRedisCache_TTLExpiration(t *testing.T) {
 	_, ok = c.Get(ctx, "expiring")
 	assert.False(t, ok, "value should have expired")
 }
+
+// TestRedisCache_SetWithTTL_NonPositiveExpiresImmediately confirms a
+// non-positive TTL doesn't cache permanently (Redis's own SET treats
+// ttl<=0 as "no expiration"), matching MongoCache.SetWithTTL(ttl<=0)'s
+// effectively-immediate expiry.
+func TestRedisCache_SetWithTTL_NonPositiveExpiresImmediately(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	c, err := NewRedisCache[string](client, "cache_ttl_nonpositive", 10*time.Minute, nil)
+	require.NoError(t, err)
+
+	c.SetWithTTL(ctx, "zero-ttl", "value", 0)
+	time.Sleep(50 * time.Millisecond)
+	_, ok := c.Get(ctx, "zero-ttl")
+	assert.False(t, ok, "a zero TTL must not cache the value permanently")
+
+	c.SetWithTTL(ctx, "negative-ttl", "value", -time.Second)
+	time.Sleep(50 * time.Millisecond)
+	_, ok = c.Get(ctx, "negative-ttl")
+	assert.False(t, ok, "a negative TTL must not cache the value permanently")
+}

--- a/pkg/cache/generic_redis_test.go
+++ b/pkg/cache/generic_redis_test.go
@@ -155,6 +155,20 @@ func TestRedisCache_EmptyCollection(t *testing.T) {
 	assert.Error(t, err, "an empty collection breaks key namespacing and widens Len()'s scan pattern, so it must be rejected")
 }
 
+// TestRedisCache_CollectionWithGlobMetacharacters confirms a collection
+// name containing SCAN glob metacharacters is rejected, since Len()'s
+// "<collection>:*" MATCH pattern would otherwise match keys outside this
+// cache's own namespace.
+func TestRedisCache_CollectionWithGlobMetacharacters(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	for _, collection := range []string{"cache*", "cache?", "cache[a]", `cache\x`} {
+		_, err := NewRedisCache[string](client, collection, 5*time.Minute, nil)
+		assert.Error(t, err, "collection %q contains a glob metacharacter and must be rejected", collection)
+	}
+}
+
 func TestRedisCache_JWKKey(t *testing.T) {
 	client, cleanup := startRedisContainer(t)
 	defer cleanup()

--- a/pkg/cache/generic_redis_test.go
+++ b/pkg/cache/generic_redis_test.go
@@ -1,0 +1,201 @@
+package cache
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
+)
+
+// startRedisContainer spins up a throwaway Redis via testcontainers and
+// returns a connected redis.UniversalClient plus a cleanup function.
+// Mirrors startMongoContainer's shape for this package's other backends.
+func startRedisContainer(t *testing.T) (redis.UniversalClient, func()) {
+	t.Helper()
+	if !isDockerAvailable() {
+		t.Skip("Skipping test: Docker is not available")
+	}
+	ctx := t.Context()
+
+	container, err := tcredis.Run(ctx, "redis:7")
+	if err != nil {
+		t.Fatalf("start redis container: %v", err)
+	}
+
+	connStr, err := container.ConnectionString(ctx)
+	if err != nil {
+		_ = container.Terminate(context.Background())
+		t.Fatalf("redis connection string: %v", err)
+	}
+
+	opts, err := redis.ParseURL(connStr)
+	if err != nil {
+		_ = container.Terminate(context.Background())
+		t.Fatalf("parse redis url: %v", err)
+	}
+	client := redis.NewClient(opts)
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		_ = container.Terminate(context.Background())
+		t.Fatalf("ping redis: %v", err)
+	}
+
+	cleanup := func() {
+		_ = client.Close()
+		_ = container.Terminate(context.Background())
+	}
+	return client, cleanup
+}
+
+// Redis compile-time checks
+var (
+	_ Cache[string]     = (*RedisCache[string])(nil)
+	_ Cache[bool]       = (*RedisCache[bool])(nil)
+	_ Cache[int]        = (*RedisCache[int])(nil)
+	_ Cache[testStruct] = (*RedisCache[testStruct])(nil)
+)
+
+// --- RedisCache tests (require Docker) ---
+
+func TestRedisCache_String(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	c, err := NewRedisCache[string](client, "cache_string", 10*time.Minute, nil)
+	require.NoError(t, err)
+	runGenericCacheContractTests(t, c, "hello", "world")
+}
+
+func TestRedisCache_Bool(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	c, err := NewRedisCache[bool](client, "cache_bool", 10*time.Minute, nil)
+	require.NoError(t, err)
+	runGenericCacheContractTests(t, c, true, false)
+}
+
+func TestRedisCache_Int(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	c, err := NewRedisCache[int](client, "cache_int", 10*time.Minute, nil)
+	require.NoError(t, err)
+	runGenericCacheContractTests(t, c, 42, 99)
+}
+
+func TestRedisCache_Struct(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	c, err := NewRedisCache[testStruct](client, "cache_struct", 10*time.Minute, nil)
+	require.NoError(t, err)
+	runGenericCacheContractTests(
+		t, c,
+		testStruct{Name: "alice", Value: 1},
+		testStruct{Name: "bob", Value: 2},
+	)
+}
+
+func TestRedisCache_Bytes(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	c, err := NewRedisCache[[]byte](client, "cache_bytes", 10*time.Minute, nil)
+	require.NoError(t, err)
+
+	c.Set(ctx, "bin", []byte{0x01, 0x02})
+	got, ok := c.Get(ctx, "bin")
+	require.True(t, ok)
+	assert.Equal(t, []byte{0x01, 0x02}, got)
+
+	c.Delete(ctx, "bin")
+	_, ok = c.Get(ctx, "bin")
+	assert.False(t, ok)
+}
+
+func TestRedisCache_NilClient(t *testing.T) {
+	_, err := NewRedisCache[string](nil, "col", 5*time.Minute, nil)
+	assert.Error(t, err)
+}
+
+func TestRedisCache_JWKKey(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	c, err := NewRedisCache[jwk.Key](client, "cache_jwk", 10*time.Minute, nil, WithRedisDecoder(func(data []byte) (jwk.Key, error) {
+		return jwk.ParseKey(data)
+	}))
+	require.NoError(t, err)
+
+	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	key, err := jwk.Import(raw)
+	require.NoError(t, err)
+
+	c.Set(ctx, "k1", key)
+	got, ok := c.Get(ctx, "k1")
+	require.True(t, ok, "expected jwk.Key to round-trip through RedisCache")
+
+	origJSON, err := json.Marshal(key)
+	require.NoError(t, err)
+	gotJSON, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(origJSON), string(gotJSON))
+}
+
+// TestRedisCache_KeysNamespacedByCollection confirms two RedisCache
+// instances sharing one Redis client/keyspace don't collide, even when
+// given the same user-facing key.
+func TestRedisCache_KeysNamespacedByCollection(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	a, err := NewRedisCache[string](client, "cache_a", 10*time.Minute, nil)
+	require.NoError(t, err)
+	b, err := NewRedisCache[string](client, "cache_b", 10*time.Minute, nil)
+	require.NoError(t, err)
+
+	a.Set(ctx, "shared-key", "from-a")
+	b.Set(ctx, "shared-key", "from-b")
+
+	gotA, ok := a.Get(ctx, "shared-key")
+	require.True(t, ok)
+	assert.Equal(t, "from-a", gotA)
+
+	gotB, ok := b.Get(ctx, "shared-key")
+	require.True(t, ok)
+	assert.Equal(t, "from-b", gotB)
+}
+
+// TestRedisCache_TTLExpiration confirms Redis's native per-key TTL (not
+// MongoCache's created_at-shift approximation) actually expires entries.
+func TestRedisCache_TTLExpiration(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	c, err := NewRedisCache[string](client, "cache_ttl", 200*time.Millisecond, nil)
+	require.NoError(t, err)
+
+	c.Set(ctx, "expiring", "value")
+	_, ok := c.Get(ctx, "expiring")
+	require.True(t, ok, "value should be present immediately after Set")
+
+	time.Sleep(400 * time.Millisecond)
+	_, ok = c.Get(ctx, "expiring")
+	assert.False(t, ok, "value should have expired")
+}

--- a/pkg/cache/generic_redis_test.go
+++ b/pkg/cache/generic_redis_test.go
@@ -211,3 +211,24 @@ func TestRedisCache_SetWithTTL_NonPositiveExpiresImmediately(t *testing.T) {
 	_, ok = c.Get(ctx, "negative-ttl")
 	assert.False(t, ok, "a negative TTL must not cache the value permanently")
 }
+
+// TestRedisCache_SetNX_NonPositiveDefaultTTLExpiresImmediately confirms
+// SetNX() - which passes the cache's own default ttl straight through -
+// doesn't create a permanent key when that default ttl is non-positive,
+// matching setWithTTL's clamp.
+func TestRedisCache_SetNX_NonPositiveDefaultTTLExpiresImmediately(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	c, err := NewRedisCache[string](client, "cache_setnx_nonpositive", 0, nil)
+	require.NoError(t, err)
+
+	ok, err := c.SetNX(ctx, "zero-default-ttl", "value")
+	require.NoError(t, err)
+	require.True(t, ok, "key didn't exist yet, so SetNX must report it was set")
+
+	time.Sleep(50 * time.Millisecond)
+	_, ok = c.Get(ctx, "zero-default-ttl")
+	assert.False(t, ok, "SetNX must not cache the value permanently when the cache's default ttl is non-positive")
+}

--- a/pkg/cache/generic_test.go
+++ b/pkg/cache/generic_test.go
@@ -15,6 +15,29 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
+// newTestECJWKKey generates a fresh EC P-256 jwk.Key for cache round-trip
+// tests. Shared by every backend's JWKKey test.
+func newTestECJWKKey(t *testing.T) jwk.Key {
+	t.Helper()
+	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	key, err := jwk.Import(raw)
+	require.NoError(t, err)
+	return key
+}
+
+// assertSameJWKKey asserts two jwk.Key values serialize identically, used to
+// confirm a key survived a cache round-trip. Shared by every backend's
+// JWKKey test.
+func assertSameJWKKey(t *testing.T, want, got jwk.Key) {
+	t.Helper()
+	wantJSON, err := json.Marshal(want)
+	require.NoError(t, err)
+	gotJSON, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(wantJSON), string(gotJSON))
+}
+
 // runGenericCacheContractTests runs the shared contract tests that every
 // Cache[V] implementation must satisfy. Reused for both memory and mongo.
 func runGenericCacheContractTests[V comparable](t *testing.T, c Cache[V], val1, val2 V) {
@@ -340,22 +363,13 @@ func TestMongoCache_JWKKey(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	// Generate a fresh EC key
-	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	key, err := jwk.Import(raw)
-	require.NoError(t, err)
+	key := newTestECJWKKey(t)
 
 	c.Set(ctx, "k1", key)
 	got, ok := c.Get(ctx, "k1")
 	require.True(t, ok, "expected jwk.Key to round-trip through MongoCache")
 
-	// Verify the key material survived by comparing JSON serializations
-	origJSON, err := json.Marshal(key)
-	require.NoError(t, err)
-	gotJSON, err := json.Marshal(got)
-	require.NoError(t, err)
-	assert.JSONEq(t, string(origJSON), string(gotJSON))
+	assertSameJWKKey(t, key, got)
 }
 
 func TestMongoCache_SetWithTTL_ShorterThanDefault(t *testing.T) {

--- a/pkg/cache/redis_ratelimit.go
+++ b/pkg/cache/redis_ratelimit.go
@@ -1,0 +1,85 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisRateLimitCounter is a Redis-backed sliding-window rate limit counter.
+// It mirrors MongoRateLimitCounter's algorithm exactly (two fixed
+// sub-windows per key, weighted to approximate a sliding window), but the
+// current sub-window's counter is incremented via Redis's native atomic
+// INCR rather than a MongoDB FindOneAndUpdate upsert - the "insert or
+// update" case Mongo needs an upsert for is simply INCR's normal behavior
+// on a nonexistent key.
+type RedisRateLimitCounter struct {
+	client redis.UniversalClient
+	log    Logger
+}
+
+// NewRedisRateLimitCounter creates a new Redis-backed rate limit counter.
+func NewRedisRateLimitCounter(client redis.UniversalClient, log Logger) (*RedisRateLimitCounter, error) {
+	if client == nil {
+		return nil, fmt.Errorf("redis client cannot be nil")
+	}
+	if log == nil {
+		log = nopLogger{}
+	}
+	return &RedisRateLimitCounter{client: client, log: log}, nil
+}
+
+// IncrementWithTTL atomically increments the current sub-window's counter
+// and returns the sliding-window estimate.
+func (r *RedisRateLimitCounter) IncrementWithTTL(ctx context.Context, key string, window time.Duration) (int64, error) {
+	now := time.Now()
+	windowSecs := int64(window.Seconds())
+	if windowSecs <= 0 {
+		windowSecs = 60
+	}
+	currWindowID := now.Unix() / windowSecs
+	prevWindowID := currWindowID - 1
+
+	currKey := fmt.Sprintf("%s:%d", key, currWindowID)
+	prevKey := fmt.Sprintf("%s:%d", key, prevWindowID)
+
+	// INCR atomically creates currKey at 1 (if absent) or increments it.
+	// Since INCR is atomic, exactly one caller ever observes the return
+	// value 1 for a given key even under concurrent access - that caller,
+	// and only that caller, sets the TTL, so a fresh key can't end up
+	// without one (a raced double-EXPIRE would be harmless anyway; this
+	// just avoids resetting the TTL on every increment).
+	currCount, err := r.client.Incr(ctx, currKey).Result()
+	if err != nil {
+		return 0, fmt.Errorf("rate limit increment failed (key=%s): %w", currKey, err)
+	}
+	if currCount == 1 {
+		// Covers current + previous window, matching MongoRateLimitCounter's
+		// 120s TTL index for its default ~60s window.
+		if err := r.client.Expire(ctx, currKey, 2*window).Err(); err != nil {
+			r.log.Error(err, "rate limit: failed to set TTL on fresh window key", "key", currKey)
+		}
+	}
+
+	// Read the previous window's count (read-only - already finalized).
+	var prevCount int64
+	prevVal, err := r.client.Get(ctx, prevKey).Int64()
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			return 0, fmt.Errorf("rate limit prev read failed (key=%s): %w", prevKey, err)
+		}
+	} else {
+		prevCount = prevVal
+	}
+
+	// Sliding window estimate.
+	elapsedInWindow := now.Unix() % windowSecs
+	prevWeight := 1.0 - float64(elapsedInWindow)/float64(windowSecs)
+	estimate := int64(math.Ceil(float64(prevCount)*prevWeight)) + currCount
+
+	return estimate, nil
+}

--- a/pkg/cache/redis_ratelimit.go
+++ b/pkg/cache/redis_ratelimit.go
@@ -46,6 +46,9 @@ func NewRedisRateLimitCounter(client redis.UniversalClient, prefix string, log L
 	if client == nil {
 		return nil, fmt.Errorf("redis client cannot be nil")
 	}
+	if prefix == "" {
+		return nil, fmt.Errorf("redis rate limit counter: prefix cannot be empty")
+	}
 	if log == nil {
 		log = nopLogger{}
 	}

--- a/pkg/cache/redis_ratelimit.go
+++ b/pkg/cache/redis_ratelimit.go
@@ -23,8 +23,12 @@ end
 return count
 `)
 
-// RedisRateLimitCounter is a Redis-backed sliding-window rate limit counter.
-// It mirrors MongoRateLimitCounter's algorithm exactly (two fixed
+// RedisRateLimitCounter is a Redis-backed sliding-window rate limit
+// counter. It also works unmodified against Valkey and other
+// RESP-compatible servers, since its only backend-specific operation -
+// incrWithTTLScript - is a plain Lua script run via EVAL, a standard RESP
+// command Valkey executes identically. It mirrors MongoRateLimitCounter's
+// algorithm exactly (two fixed
 // sub-windows per key, weighted to approximate a sliding window), but the
 // current sub-window's counter is incremented via Redis's native atomic
 // INCR rather than a MongoDB FindOneAndUpdate upsert - the "insert or

--- a/pkg/cache/redis_ratelimit.go
+++ b/pkg/cache/redis_ratelimit.go
@@ -10,6 +10,19 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// incrWithTTLScript atomically increments a counter and, only on the
+// increment that creates the key (count==1), sets its TTL - as a single
+// Lua script, so there's no window between INCR and EXPIRE where a crash
+// could leave the key permanently un-expiring. Redis executes scripts
+// atomically, so this replaces INCR + a conditional, separate EXPIRE call.
+var incrWithTTLScript = redis.NewScript(`
+local count = redis.call("INCR", KEYS[1])
+if count == 1 then
+	redis.call("EXPIRE", KEYS[1], ARGV[1])
+end
+return count
+`)
+
 // RedisRateLimitCounter is a Redis-backed sliding-window rate limit counter.
 // It mirrors MongoRateLimitCounter's algorithm exactly (two fixed
 // sub-windows per key, weighted to approximate a sliding window), but the
@@ -47,28 +60,16 @@ func (r *RedisRateLimitCounter) IncrementWithTTL(ctx context.Context, key string
 	currKey := fmt.Sprintf("%s:%d", key, currWindowID)
 	prevKey := fmt.Sprintf("%s:%d", key, prevWindowID)
 
-	// INCR atomically creates currKey at 1 (if absent) or increments it.
-	// Since INCR is atomic, exactly one caller ever observes the return
-	// value 1 for a given key even under concurrent access - that caller,
-	// and only that caller, sets the TTL, so a fresh key can't end up
-	// without one (a raced double-EXPIRE would be harmless anyway; this
-	// just avoids resetting the TTL on every increment).
-	currCount, err := r.client.Incr(ctx, currKey).Result()
+	// Atomically increment and, only on the increment that creates the key,
+	// set its TTL - covers current + previous window, matching
+	// MongoRateLimitCounter's 120s TTL index for its default ~60s window.
+	// Derived from the normalized windowSecs (not the raw window param) so
+	// a zero/negative/sub-second window - which falls back to the 60s
+	// default above - gets a TTL consistent with that same 60s bucketing.
+	ttlSecs := 2 * windowSecs
+	currCount, err := incrWithTTLScript.Run(ctx, r.client, []string{currKey}, ttlSecs).Int64()
 	if err != nil {
 		return 0, fmt.Errorf("rate limit increment failed (key=%s): %w", currKey, err)
-	}
-	if currCount == 1 {
-		// Covers current + previous window, matching MongoRateLimitCounter's
-		// 120s TTL index for its default ~60s window. Derived from the
-		// normalized windowSecs (not the raw window param) so a zero/
-		// negative/sub-second window - which falls back to the 60s default
-		// above - gets a TTL consistent with that same 60s bucketing,
-		// instead of a mismatched (or zero/negative, which Redis treats as
-		// "delete immediately") duration from the raw window.
-		ttl := 2 * time.Duration(windowSecs) * time.Second
-		if err := r.client.Expire(ctx, currKey, ttl).Err(); err != nil {
-			r.log.Error(err, "rate limit: failed to set TTL on fresh window key", "key", currKey)
-		}
 	}
 
 	// Read the previous window's count (read-only - already finalized).

--- a/pkg/cache/redis_ratelimit.go
+++ b/pkg/cache/redis_ratelimit.go
@@ -32,18 +32,24 @@ return count
 // on a nonexistent key.
 type RedisRateLimitCounter struct {
 	client redis.UniversalClient
+	prefix string
 	log    Logger
 }
 
 // NewRedisRateLimitCounter creates a new Redis-backed rate limit counter.
-func NewRedisRateLimitCounter(client redis.UniversalClient, log Logger) (*RedisRateLimitCounter, error) {
+// prefix namespaces every key this counter writes ("<prefix>:<key>:<windowID>")
+// so it can't collide with unrelated keys in a shared Redis
+// keyspace/instance - Mongo gets this isolation for free from its
+// collection; Redis has no such boundary, so RedisRateLimitCounter needs
+// one explicitly, same as RedisCache's collection.
+func NewRedisRateLimitCounter(client redis.UniversalClient, prefix string, log Logger) (*RedisRateLimitCounter, error) {
 	if client == nil {
 		return nil, fmt.Errorf("redis client cannot be nil")
 	}
 	if log == nil {
 		log = nopLogger{}
 	}
-	return &RedisRateLimitCounter{client: client, log: log}, nil
+	return &RedisRateLimitCounter{client: client, prefix: prefix, log: log}, nil
 }
 
 // IncrementWithTTL atomically increments the current sub-window's counter
@@ -57,8 +63,8 @@ func (r *RedisRateLimitCounter) IncrementWithTTL(ctx context.Context, key string
 	currWindowID := now.Unix() / windowSecs
 	prevWindowID := currWindowID - 1
 
-	currKey := fmt.Sprintf("%s:%d", key, currWindowID)
-	prevKey := fmt.Sprintf("%s:%d", key, prevWindowID)
+	currKey := fmt.Sprintf("%s:%s:%d", r.prefix, key, currWindowID)
+	prevKey := fmt.Sprintf("%s:%s:%d", r.prefix, key, prevWindowID)
 
 	// Atomically increment and, only on the increment that creates the key,
 	// set its TTL - covers current + previous window, matching

--- a/pkg/cache/redis_ratelimit.go
+++ b/pkg/cache/redis_ratelimit.go
@@ -59,8 +59,14 @@ func (r *RedisRateLimitCounter) IncrementWithTTL(ctx context.Context, key string
 	}
 	if currCount == 1 {
 		// Covers current + previous window, matching MongoRateLimitCounter's
-		// 120s TTL index for its default ~60s window.
-		if err := r.client.Expire(ctx, currKey, 2*window).Err(); err != nil {
+		// 120s TTL index for its default ~60s window. Derived from the
+		// normalized windowSecs (not the raw window param) so a zero/
+		// negative/sub-second window - which falls back to the 60s default
+		// above - gets a TTL consistent with that same 60s bucketing,
+		// instead of a mismatched (or zero/negative, which Redis treats as
+		// "delete immediately") duration from the raw window.
+		ttl := 2 * time.Duration(windowSecs) * time.Second
+		if err := r.client.Expire(ctx, currKey, ttl).Err(); err != nil {
 			r.log.Error(err, "rate limit: failed to set TTL on fresh window key", "key", currKey)
 		}
 	}

--- a/pkg/cache/redis_ratelimit_test.go
+++ b/pkg/cache/redis_ratelimit_test.go
@@ -111,3 +111,53 @@ func TestRedisRateLimitCounter_TTLSetOnFreshWindowKey(t *testing.T) {
 	}
 	assert.Greater(t, ttl, time.Duration(0), "fresh window key must have a TTL set")
 }
+
+// --- RedisRateLimitCounter-against-Valkey tests (require Docker) ---
+//
+// IncrementWithTTL's correctness hinges on Valkey executing incrWithTTLScript
+// (a Lua script run via EVAL) atomically, the same way Redis does. These
+// tests confirm that against a real Valkey server.
+
+func TestValkeyRateLimitCounter_FirstIncrement(t *testing.T) {
+	client, cleanup := startValkeyContainer(t)
+	defer cleanup()
+
+	rl, err := NewRedisRateLimitCounter(client, "ratelimit_test", nil)
+	require.NoError(t, err)
+
+	count, err := rl.IncrementWithTTL(t.Context(), "test-key", time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "first increment in a fresh window should report exactly 1")
+}
+
+// TestValkeyRateLimitCounter_TTLSetOnFreshWindowKey mirrors
+// TestRedisRateLimitCounter_TTLSetOnFreshWindowKey, confirming the Lua
+// script's conditional EXPIRE call actually takes effect on Valkey.
+func TestValkeyRateLimitCounter_TTLSetOnFreshWindowKey(t *testing.T) {
+	client, cleanup := startValkeyContainer(t)
+	defer cleanup()
+
+	rl, err := NewRedisRateLimitCounter(client, "ratelimit_test", nil)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	window := time.Minute
+	before := time.Now()
+	_, err = rl.IncrementWithTTL(ctx, "ttl-check", window)
+	require.NoError(t, err)
+	after := time.Now()
+
+	windowSecs := int64(window.Seconds())
+	candidates := []int64{before.Unix() / windowSecs, after.Unix() / windowSecs}
+
+	var ttl time.Duration
+	for _, id := range candidates {
+		key := "ratelimit_test:ttl-check:" + strconv.FormatInt(id, 10)
+		v, err := client.TTL(ctx, key).Result()
+		require.NoError(t, err)
+		if v > ttl {
+			ttl = v
+		}
+	}
+	assert.Greater(t, ttl, time.Duration(0), "fresh window key must have a TTL set")
+}

--- a/pkg/cache/redis_ratelimit_test.go
+++ b/pkg/cache/redis_ratelimit_test.go
@@ -13,7 +13,7 @@ import (
 var _ RateLimitCounter = (*RedisRateLimitCounter)(nil)
 
 func TestRedisRateLimitCounter_NilClient(t *testing.T) {
-	_, err := NewRedisRateLimitCounter(nil, nil)
+	_, err := NewRedisRateLimitCounter(nil, "ratelimit_test", nil)
 	assert.Error(t, err)
 }
 
@@ -21,7 +21,7 @@ func TestRedisRateLimitCounter_FirstIncrement(t *testing.T) {
 	client, cleanup := startRedisContainer(t)
 	defer cleanup()
 
-	rl, err := NewRedisRateLimitCounter(client, nil)
+	rl, err := NewRedisRateLimitCounter(client, "ratelimit_test", nil)
 	require.NoError(t, err)
 
 	count, err := rl.IncrementWithTTL(t.Context(), "test-key", time.Minute)
@@ -33,7 +33,7 @@ func TestRedisRateLimitCounter_MultipleIncrementsInSameWindow(t *testing.T) {
 	client, cleanup := startRedisContainer(t)
 	defer cleanup()
 
-	rl, err := NewRedisRateLimitCounter(client, nil)
+	rl, err := NewRedisRateLimitCounter(client, "ratelimit_test", nil)
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -52,7 +52,7 @@ func TestRedisRateLimitCounter_IndependentKeys(t *testing.T) {
 	client, cleanup := startRedisContainer(t)
 	defer cleanup()
 
-	rl, err := NewRedisRateLimitCounter(client, nil)
+	rl, err := NewRedisRateLimitCounter(client, "ratelimit_test", nil)
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -73,7 +73,7 @@ func TestRedisRateLimitCounter_TTLSetOnFreshWindowKey(t *testing.T) {
 	client, cleanup := startRedisContainer(t)
 	defer cleanup()
 
-	rl, err := NewRedisRateLimitCounter(client, nil)
+	rl, err := NewRedisRateLimitCounter(client, "ratelimit_test", nil)
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -94,7 +94,7 @@ func TestRedisRateLimitCounter_TTLSetOnFreshWindowKey(t *testing.T) {
 
 	var ttl time.Duration
 	for _, id := range candidates {
-		key := "ttl-check:" + strconv.FormatInt(id, 10)
+		key := "ratelimit_test:ttl-check:" + strconv.FormatInt(id, 10)
 		v, err := client.TTL(ctx, key).Result()
 		require.NoError(t, err)
 		if v > ttl {

--- a/pkg/cache/redis_ratelimit_test.go
+++ b/pkg/cache/redis_ratelimit_test.go
@@ -78,10 +78,15 @@ func TestRedisRateLimitCounter_TTLSetOnFreshWindowKey(t *testing.T) {
 
 	ctx := t.Context()
 	window := time.Minute
+	// Captured immediately before the call (matching IncrementWithTTL's own
+	// now := time.Now()), not after, so a window boundary crossed during the
+	// call can't make this compute a different windowID than the one the
+	// increment actually wrote to.
+	before := time.Now()
 	_, err = rl.IncrementWithTTL(ctx, "ttl-check", window)
 	require.NoError(t, err)
 
-	currWindowID := time.Now().Unix() / int64(window.Seconds())
+	currWindowID := before.Unix() / int64(window.Seconds())
 	key := "ttl-check:" + strconv.FormatInt(currWindowID, 10)
 	ttl, err := client.TTL(ctx, key).Result()
 	require.NoError(t, err)

--- a/pkg/cache/redis_ratelimit_test.go
+++ b/pkg/cache/redis_ratelimit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -78,7 +79,15 @@ func TestRedisRateLimitCounter_IndependentKeys(t *testing.T) {
 // TTL (rather than living forever), matching MongoRateLimitCounter's
 // TTL-indexed cleanup.
 func TestRedisRateLimitCounter_TTLSetOnFreshWindowKey(t *testing.T) {
-	client, cleanup := startRedisContainer(t)
+	testRateLimitTTLSetOnFreshWindowKey(t, startRedisContainer)
+}
+
+// testRateLimitTTLSetOnFreshWindowKey is shared by the Redis and Valkey
+// variants above/below - the assertion is backend-agnostic, only the
+// container differs.
+func testRateLimitTTLSetOnFreshWindowKey(t *testing.T, startContainer func(*testing.T) (redis.UniversalClient, func())) {
+	t.Helper()
+	client, cleanup := startContainer(t)
 	defer cleanup()
 
 	rl, err := NewRedisRateLimitCounter(client, "ratelimit_test", nil)
@@ -134,30 +143,5 @@ func TestValkeyRateLimitCounter_FirstIncrement(t *testing.T) {
 // TestRedisRateLimitCounter_TTLSetOnFreshWindowKey, confirming the Lua
 // script's conditional EXPIRE call actually takes effect on Valkey.
 func TestValkeyRateLimitCounter_TTLSetOnFreshWindowKey(t *testing.T) {
-	client, cleanup := startValkeyContainer(t)
-	defer cleanup()
-
-	rl, err := NewRedisRateLimitCounter(client, "ratelimit_test", nil)
-	require.NoError(t, err)
-
-	ctx := t.Context()
-	window := time.Minute
-	before := time.Now()
-	_, err = rl.IncrementWithTTL(ctx, "ttl-check", window)
-	require.NoError(t, err)
-	after := time.Now()
-
-	windowSecs := int64(window.Seconds())
-	candidates := []int64{before.Unix() / windowSecs, after.Unix() / windowSecs}
-
-	var ttl time.Duration
-	for _, id := range candidates {
-		key := "ratelimit_test:ttl-check:" + strconv.FormatInt(id, 10)
-		v, err := client.TTL(ctx, key).Result()
-		require.NoError(t, err)
-		if v > ttl {
-			ttl = v
-		}
-	}
-	assert.Greater(t, ttl, time.Duration(0), "fresh window key must have a TTL set")
+	testRateLimitTTLSetOnFreshWindowKey(t, startValkeyContainer)
 }

--- a/pkg/cache/redis_ratelimit_test.go
+++ b/pkg/cache/redis_ratelimit_test.go
@@ -17,6 +17,14 @@ func TestRedisRateLimitCounter_NilClient(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestRedisRateLimitCounter_EmptyPrefix(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	_, err := NewRedisRateLimitCounter(client, "", nil)
+	assert.Error(t, err, "an empty prefix defeats the whole point of namespacing keys, so it must be rejected")
+}
+
 func TestRedisRateLimitCounter_FirstIncrement(t *testing.T) {
 	client, cleanup := startRedisContainer(t)
 	defer cleanup()

--- a/pkg/cache/redis_ratelimit_test.go
+++ b/pkg/cache/redis_ratelimit_test.go
@@ -46,9 +46,14 @@ func TestRedisRateLimitCounter_MultipleIncrementsInSameWindow(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := t.Context()
+	// A much larger-than-necessary window keeps the whole loop safely
+	// inside a single sub-window - with time.Minute, a run starting close
+	// to a minute boundary could cross into the next window mid-loop and
+	// make the final estimate != 5 even though nothing is actually wrong.
+	const window = time.Hour
 	var last int64
 	for range 5 {
-		count, err := rl.IncrementWithTTL(ctx, "test-key-multi", time.Minute)
+		count, err := rl.IncrementWithTTL(ctx, "test-key-multi", window)
 		require.NoError(t, err)
 		last = count
 	}

--- a/pkg/cache/redis_ratelimit_test.go
+++ b/pkg/cache/redis_ratelimit_test.go
@@ -1,0 +1,89 @@
+package cache
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time check.
+var _ RateLimitCounter = (*RedisRateLimitCounter)(nil)
+
+func TestRedisRateLimitCounter_NilClient(t *testing.T) {
+	_, err := NewRedisRateLimitCounter(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestRedisRateLimitCounter_FirstIncrement(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	rl, err := NewRedisRateLimitCounter(client, nil)
+	require.NoError(t, err)
+
+	count, err := rl.IncrementWithTTL(t.Context(), "test-key", time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "first increment in a fresh window should report exactly 1")
+}
+
+func TestRedisRateLimitCounter_MultipleIncrementsInSameWindow(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	rl, err := NewRedisRateLimitCounter(client, nil)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	var last int64
+	for range 5 {
+		count, err := rl.IncrementWithTTL(ctx, "test-key-multi", time.Minute)
+		require.NoError(t, err)
+		last = count
+	}
+	// All 5 calls land in the same current sub-window (no previous-window
+	// contribution yet), so the final estimate must be exactly 5.
+	assert.Equal(t, int64(5), last)
+}
+
+func TestRedisRateLimitCounter_IndependentKeys(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	rl, err := NewRedisRateLimitCounter(client, nil)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	countA, err := rl.IncrementWithTTL(ctx, "key-a", time.Minute)
+	require.NoError(t, err)
+	countB, err := rl.IncrementWithTTL(ctx, "key-b", time.Minute)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), countA)
+	assert.Equal(t, int64(1), countB, "a distinct key must not share the other key's window count")
+}
+
+// TestRedisRateLimitCounter_TTLSetOnFreshWindowKey confirms the underlying
+// Redis key created by the first increment in a window actually carries a
+// TTL (rather than living forever), matching MongoRateLimitCounter's
+// TTL-indexed cleanup.
+func TestRedisRateLimitCounter_TTLSetOnFreshWindowKey(t *testing.T) {
+	client, cleanup := startRedisContainer(t)
+	defer cleanup()
+
+	rl, err := NewRedisRateLimitCounter(client, nil)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	window := time.Minute
+	_, err = rl.IncrementWithTTL(ctx, "ttl-check", window)
+	require.NoError(t, err)
+
+	currWindowID := time.Now().Unix() / int64(window.Seconds())
+	key := "ttl-check:" + strconv.FormatInt(currWindowID, 10)
+	ttl, err := client.TTL(ctx, key).Result()
+	require.NoError(t, err)
+	assert.Greater(t, ttl, time.Duration(0), "fresh window key must have a TTL set")
+}

--- a/pkg/cache/redis_ratelimit_test.go
+++ b/pkg/cache/redis_ratelimit_test.go
@@ -78,17 +78,28 @@ func TestRedisRateLimitCounter_TTLSetOnFreshWindowKey(t *testing.T) {
 
 	ctx := t.Context()
 	window := time.Minute
-	// Captured immediately before the call (matching IncrementWithTTL's own
-	// now := time.Now()), not after, so a window boundary crossed during the
-	// call can't make this compute a different windowID than the one the
-	// increment actually wrote to.
+	// IncrementWithTTL computes its own windowID from an internal
+	// time.Now(), taken after this call starts - bracket it with a
+	// before/after pair and check both candidate window keys, since a
+	// boundary crossed between "before" and that internal call would
+	// otherwise make this look up a different (empty) key and fail
+	// spuriously even though the real key got its TTL correctly.
 	before := time.Now()
 	_, err = rl.IncrementWithTTL(ctx, "ttl-check", window)
 	require.NoError(t, err)
+	after := time.Now()
 
-	currWindowID := before.Unix() / int64(window.Seconds())
-	key := "ttl-check:" + strconv.FormatInt(currWindowID, 10)
-	ttl, err := client.TTL(ctx, key).Result()
-	require.NoError(t, err)
+	windowSecs := int64(window.Seconds())
+	candidates := []int64{before.Unix() / windowSecs, after.Unix() / windowSecs}
+
+	var ttl time.Duration
+	for _, id := range candidates {
+		key := "ttl-check:" + strconv.FormatInt(id, 10)
+		v, err := client.TTL(ctx, key).Result()
+		require.NoError(t, err)
+		if v > ttl {
+			ttl = v
+		}
+	}
 	assert.Greater(t, ttl, time.Duration(0), "fresh window key must have a TTL set")
 }


### PR DESCRIPTION
## Summary

Follow-up to #593 (vendor: add redis and testcontainers-redis dependencies, merged), now rebased onto main so this PR is source-only and well under Copilot's review size limit. Replaces #592, which bundled vendor+source and got skipped by Copilot for exceeding 20,000 changed lines.

Adds a Redis-backed implementation of the existing `pkg/cache` interfaces, as an alternative to the current MongoDB-backed implementation. This is **Phase 1** of a plan to decouple caching from the Mongo-vs-SQL datastore backend choice — deployments running the SQL datastore backend currently cannot use HA-mode caching at all, since it hard-requires a `*mongo.Client` (see `dbservice.Connect`'s fail-fast guard added in #586/#587).

## What's included

- `pkg/cache/generic_redis.go` — `RedisCache[V any]`, implementing the existing `Cache[V]` interface (`Get/Set/SetWithTTL/SetNX/SetNXWithTTL/Delete/GetAndDelete/Len`). Values are JSON-encoded, matching `MongoCache`'s approach (including a `WithRedisDecoder` option for interface types like `jwk.Key`, mirroring `generic_mongo.go`'s `WithDecoder`).
- `pkg/cache/redis_ratelimit.go` — `RedisRateLimitCounter`, implementing the existing `RateLimitCounter` interface. Mirrors `MongoRateLimitCounter`'s exact two-sub-window sliding-window algorithm, but uses Redis's atomic `INCR` for the current window instead of Mongo's upsert-based `FindOneAndUpdate`.
- Tests for both, run against real Redis via `testcontainers-go/modules/redis`, reusing the existing shared `runGenericCacheContractTests` contract-test helper already used by the Memory/Mongo implementations.

Design notes vs. the Mongo implementation:
- Redis gives native per-key TTL (`EXPIRE`), so expiration is exact rather than `MongoCache`'s collection-wide-TTL-index-with-shifted-`created_at` approximation.
- `SetNX`/`SetNXWithTTL` use a single atomic `SET key val NX EX ttl` command, rather than Mongo's insert-and-catch-duplicate-key-error pattern.
- `GetAndDelete` uses Redis 6.2+'s atomic `GETDEL`.
- `Len()` uses `SCAN ... MATCH` (not `KEYS`, which blocks the server) — an approximate, informational count, same caveat as `MongoCache.Len`'s `EstimatedDocumentCount`.
- Built on `redis.UniversalClient`, so a single node (`*redis.Client`) or a cluster (`*redis.ClusterClient`) both work with zero code changes — satisfies the "maybe a Redis cluster" case for MongoDB-disabled deployments.

## Explicitly NOT included (deferred to later PRs)

- `AuthContextStore`'s Redis implementation (needs Lua-scripted compare-and-swap operations for its multi-step methods) and a `SharedSecrets` Redis equivalent.
- Wiring into `pkg/cache/factory.go` / `pkg/model` config (a `Common.HA.Backend` selector, `RedisConfig`, relaxing the HA+SQL-backend fail-fast guard added in #586/#587) — this PR only adds the implementations, it does not make them reachable via config yet.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race -count=1 ./pkg/cache/...` — all pass against real Redis testcontainers
- [x] `make gen-config-docs` — zero drift