### PR TITLE
fix(verifier): offer both vct identifiers in the UI's DCQL query

### DIFF
--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -43,7 +43,11 @@ type UICredentialInfo struct {
 	// vct_values is an acceptable-value list by design (OpenID4VP DCQL), so
 	// emitting both satisfies either wallet instead of picking a winner and
 	// silently breaking the other.
-	VCTValues  []string                        `json:"vct_values"`
+	// omitempty: mso_mdoc scopes get no list, and a nil slice would otherwise
+	// serialize as "vct_values": null, which the UI's schema rejects (it accepts
+	// an optional array, not null) - breaking /ui/metadata parsing for any
+	// configuration that contains an mdoc credential.
+	VCTValues  []string                        `json:"vct_values,omitempty"`
 	Attributes map[string]map[string][]*string `json:"attributes"`
 }
 

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -18,8 +18,32 @@ import (
 
 // UICredentialInfo is a sanitized view of a credential for the UI.
 type UICredentialInfo struct {
-	Format     string                          `json:"format"`
-	VCT        string                          `json:"vct"`
+	Format string `json:"format"`
+	// VCT is the credential's own type identifier - the value
+	// BuildCredentialWithSigner embeds as the credential's "vct" claim. Kept
+	// as the single display identifier for the UI's credential picker.
+	VCT string `json:"vct"`
+	// VCTValues is every identifier a wallet might legitimately match this
+	// credential type by, for use as DCQL meta.vct_values.
+	//
+	// Both forms have to be offered, because deployed wallets disagree about
+	// which one identifies a credential, and each behaviour is live-verified
+	// in this repo:
+	//
+	//   - The EUDI reference wallet (multipaz) matches the ISSUER METADATA's
+	//     declared vct - our published type-metadata URL. Offer.kt sets
+	//     SdJwtVcFormat(vct = configuration.type) and DcqlRequestProcessor
+	//     filters on that tag before ever parsing the credential body. See
+	//     the finding-18 note in internal/apigw/apiv1/handlers_verifier.go.
+	//
+	//   - Other wallets (e.g. wwWallet/wallet-frontend) match the credential's
+	//     own embedded "vct" claim, i.e. VCTM.VCT. See the finding-16 note on
+	//     VCTIdentifiersForScopes in pkg/model/config.go.
+	//
+	// vct_values is an acceptable-value list by design (OpenID4VP DCQL), so
+	// emitting both satisfies either wallet instead of picking a winner and
+	// silently breaking the other.
+	VCTValues  []string                        `json:"vct_values"`
 	Attributes map[string]map[string][]*string `json:"attributes"`
 }
 
@@ -56,6 +80,34 @@ type UIMetadataReply struct {
 	// attempts the native W3C Digital Credentials API when an operator has
 	// opted in, rather than always trying it regardless of server config.
 	DCAPIEnabled bool `json:"dc_api_enabled"`
+}
+
+// vctIdentifiersFor returns every identifier a wallet might match this
+// credential type by, most-specific first: the credential's own embedded vct
+// (VCTM.VCT), then the published type-metadata URL. Duplicates are collapsed,
+// which is what happens for a VCTM file with no "vct" field - ResolveVCTUrls
+// back-fills VCTM.VCT from the URL, so both are the same string.
+//
+// Returns nil for mso_mdoc scopes: they have no vct at all, and DCQL
+// constrains them with doctype_value instead.
+func vctIdentifiersFor(constructor *model.CredentialMetadata) []string {
+	if constructor == nil {
+		return nil
+	}
+	var out []string
+	seen := make(map[string]bool, 2)
+	add := func(v string) {
+		if v == "" || seen[v] {
+			return
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	if vctm := constructor.GetVCTM(); vctm != nil {
+		add(vctm.VCT)
+	}
+	add(constructor.GetVCTURL())
+	return out
 }
 
 func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
@@ -96,9 +148,12 @@ func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
 			info.VCT = v
 		} else if mddl := constructor.GetMDDL(); mddl != nil {
 			// mso_mdoc scopes have no VCTM/VCTURL — the doctype is the
-			// closest equivalent identifier.
+			// closest equivalent identifier. There is no vct_values for
+			// mdoc (the DCQL constraint is doctype_value), so leave the
+			// list empty and let the UI fall back to the single value.
 			info.VCT = mddl.DocType
 		}
+		info.VCTValues = vctIdentifiersFor(constructor)
 		reply.Credentials[scope] = info
 	}
 
@@ -136,14 +191,11 @@ func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
 				// Resolve format and VCT from credential_metadata
 				if meta != nil {
 					uiCred.Format = meta.Format
-					// VCTM.VCT first, for the same reason as UICredentialInfo
-					// above: vct_values is matched against the credential's
-					// vct claim, which comes from the VCTM, not from where
-					// the VCTM happens to be served.
-					if vctm := meta.GetVCTM(); vctm != nil && vctm.VCT != "" {
-						uiCred.Meta.VCTValues = []string{vctm.VCT}
-					} else if v := meta.GetVCTURL(); v != "" {
-						uiCred.Meta.VCTValues = []string{v}
+					// Both identifiers, for the reason documented on
+					// UICredentialInfo.VCTValues: wallets disagree about
+					// which one names a credential type.
+					if vs := vctIdentifiersFor(meta); len(vs) > 0 {
+						uiCred.Meta.VCTValues = vs
 					}
 				}
 

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -43,10 +43,12 @@ type UICredentialInfo struct {
 	// vct_values is an acceptable-value list by design (OpenID4VP DCQL), so
 	// emitting both satisfies either wallet instead of picking a winner and
 	// silently breaking the other.
-	// omitempty: mso_mdoc scopes get no list, and a nil slice would otherwise
-	// serialize as "vct_values": null, which the UI's schema rejects (it accepts
-	// an optional array, not null) - breaking /ui/metadata parsing for any
-	// configuration that contains an mdoc credential.
+	// omitempty: mso_mdoc scopes get no list (they're identified by doctype,
+	// not vct), so this drops the field entirely for them rather than
+	// emitting a meaningless "vct_values": null. The UI's schema tolerates
+	// either form - it declares vct_values as nullish and falls back to
+	// [vct] for both absent and null - so this is about not sending noise
+	// for mdoc credentials, not about satisfying a parsing constraint.
 	VCTValues  []string                        `json:"vct_values,omitempty"`
 	Attributes map[string]map[string][]*string `json:"attributes"`
 }

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -70,10 +70,30 @@ func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
 			Format:     constructor.Format,
 			Attributes: constructor.GetAttributes(),
 		}
-		if v := constructor.GetVCTURL(); v != "" {
-			info.VCT = v
-		} else if vctm := constructor.GetVCTM(); vctm != nil {
+		// VCTM.VCT, not VCTURL: the credential's own vct claim is built from
+		// the VCTM's vct field (BuildCredentialWithSigner -> body["vct"] =
+		// vctm.VCT), so that is the value a wallet matches a DCQL query
+		// against. VCTURL is where the VCTM document is *served* from, which
+		// ResolveVCTUrls derives as apigwPublicURL + /type-metadata/{scope}
+		// and deliberately keeps distinct from the identifier ("VCTM.VCT [is]
+		// left unchanged — the served VCTM document preserves the original
+		// VCT identifier from the VCTM file (e.g. a URN)").
+		//
+		// Preferring the URL made the UI advertise, and query for, a type
+		// identifier no credential ever carries: a PID issued by this very
+		// stack has vct "urn:eudi:pid:arf-1.8:1" while the UI asked for
+		// "https://<apigw>/type-metadata/pid_1_8", so every presentation
+		// started from the UI failed with "No credentials match DCQL query".
+		// The VCTM.VCT branch below was also unreachable in practice, since
+		// ResolveVCTUrls requires a non-empty VCTURL for every VCTM scope.
+		//
+		// Falling back to VCTURL still covers a VCTM file with no vct field:
+		// ResolveVCTUrls back-fills VCTM.VCT from the URL in that case, so
+		// both branches agree and the identifier stays dereferenceable.
+		if vctm := constructor.GetVCTM(); vctm != nil && vctm.VCT != "" {
 			info.VCT = vctm.VCT
+		} else if v := constructor.GetVCTURL(); v != "" {
+			info.VCT = v
 		} else if mddl := constructor.GetMDDL(); mddl != nil {
 			// mso_mdoc scopes have no VCTM/VCTURL — the doctype is the
 			// closest equivalent identifier.
@@ -116,10 +136,14 @@ func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
 				// Resolve format and VCT from credential_metadata
 				if meta != nil {
 					uiCred.Format = meta.Format
-					if v := meta.GetVCTURL(); v != "" {
-						uiCred.Meta.VCTValues = []string{v}
-					} else if vctm := meta.GetVCTM(); vctm != nil {
+					// VCTM.VCT first, for the same reason as UICredentialInfo
+					// above: vct_values is matched against the credential's
+					// vct claim, which comes from the VCTM, not from where
+					// the VCTM happens to be served.
+					if vctm := meta.GetVCTM(); vctm != nil && vctm.VCT != "" {
 						uiCred.Meta.VCTValues = []string{vctm.VCT}
+					} else if v := meta.GetVCTURL(); v != "" {
+						uiCred.Meta.VCTValues = []string{v}
 					}
 				}
 

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -158,6 +158,16 @@ func TestUIMetadata_MsoMdocScope(t *testing.T) {
 	require.True(t, ok, "mdl scope should be present")
 	assert.Equal(t, "org.iso.18013.5.1.mDL", info.VCT, "VCT should fall back to the MDDL doctype")
 	assert.NotEmpty(t, info.Attributes, "Attributes should be derived from the MDDL schema, not left empty")
+	assert.Empty(t, info.VCTValues,
+		"mso_mdoc has no vct - DCQL constrains it with doctype_value instead")
+
+	// The field must be OMITTED, not serialized as null: the UI's schema takes
+	// an optional array, so a null would fail validation and break
+	// /ui/metadata parsing for every configuration containing an mdoc.
+	encoded, err := json.Marshal(info)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "vct_values",
+		"vct_values must be omitted entirely for mso_mdoc, not emitted as null")
 }
 
 // TestUIMetadataPresetValidationsPerScope verifies that validations are attached

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -987,6 +987,12 @@ func TestUIMetadataOffersBothVCTIdentifiers(t *testing.T) {
 		Verifier: &model.Verifier{
 			Presets: map[string]model.VerificationPreset{
 				"PID": {"pid": nil},
+				// Its own preset, not folded into "PID": the preset path
+				// resolves vct_values independently of reply.Credentials, so
+				// without a preset covering this scope Meta.VCTValues could
+				// regress for a back-filled VCTM while the credential-info
+				// assertions still passed.
+				"NOVCT": {"novct": nil},
 			},
 		},
 	}
@@ -1027,6 +1033,17 @@ func TestUIMetadataOffersBothVCTIdentifiers(t *testing.T) {
 			[]string{"urn:eudi:pid:1", "https://apigw.example/type-metadata/pid"},
 			preset.Credentials[0].Meta.VCTValues,
 			"DCQL meta.vct_values is an acceptable-value list, so both forms belong in it")
+	})
+
+	t.Run("preset vct_values also collapse for a back-filled VCTM", func(t *testing.T) {
+		preset := reply.Presets["NOVCT"]
+		require.NotNil(t, preset)
+		require.Len(t, preset.Credentials, 1)
+		assert.Equal(t,
+			[]string{"https://apigw.example/type-metadata/novct"},
+			preset.Credentials[0].Meta.VCTValues,
+			"the preset path resolves vct_values separately from reply.Credentials, "+
+				"so it needs its own coverage of the de-duplicated case")
 	})
 
 	t.Run("collapses to one value when the VCTM had no vct", func(t *testing.T) {

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -950,7 +950,7 @@ func applyPerScopeValidations(scopes []string, validations map[string][]openid4v
 // advertised https://apigw.example/type-metadata/pid for a credential whose
 // vct is urn:eudi:pid:1, so every presentation started from the UI matched
 // nothing.
-func TestUIMetadataPrefersVCTMOverVCTURL(t *testing.T) {
+func TestUIMetadataOffersBothVCTIdentifiers(t *testing.T) {
 	ctx := t.Context()
 
 	cfg := &model.Cfg{
@@ -992,16 +992,29 @@ func TestUIMetadataPrefersVCTMOverVCTURL(t *testing.T) {
 			"the identifier a wallet matches against is the VCTM's vct, not where the VCTM is served")
 	})
 
-	t.Run("preset vct_values use the VCTM vct", func(t *testing.T) {
+	t.Run("credential info offers both identifiers, VCTM vct first", func(t *testing.T) {
+		assert.Equal(t,
+			[]string{"urn:eudi:pid:1", "https://apigw.example/type-metadata/pid"},
+			reply.Credentials["pid"].VCTValues,
+			"wallets disagree on which identifier names a credential type: multipaz "+
+				"matches the metadata URL, wwWallet the credential's own vct - so offer both")
+	})
+
+	t.Run("preset vct_values offer both identifiers", func(t *testing.T) {
 		preset := reply.Presets["PID"]
 		require.NotNil(t, preset)
 		require.Len(t, preset.Credentials, 1)
-		assert.Equal(t, []string{"urn:eudi:pid:1"}, preset.Credentials[0].Meta.VCTValues,
-			"DCQL meta.vct_values is matched against the credential's vct claim")
+		assert.Equal(t,
+			[]string{"urn:eudi:pid:1", "https://apigw.example/type-metadata/pid"},
+			preset.Credentials[0].Meta.VCTValues,
+			"DCQL meta.vct_values is an acceptable-value list, so both forms belong in it")
 	})
 
 	t.Run("falls back to the URL when the VCTM has no vct", func(t *testing.T) {
 		assert.Equal(t, "https://apigw.example/type-metadata/novct", reply.Credentials["novct"].VCT,
 			"a VCTM with no vct still needs a usable identifier")
+		assert.Equal(t, []string{"https://apigw.example/type-metadata/novct"},
+			reply.Credentials["novct"].VCTValues,
+			"ResolveVCTUrls back-fills VCTM.VCT from the URL, so the two collapse to one value")
 	})
 }

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -966,19 +966,20 @@ func TestUIMetadataOffersBothVCTIdentifiers(t *testing.T) {
 	cfg := &model.Cfg{
 		Common: &model.Common{
 			CredentialMetadata: map[string]*model.CredentialMetadata{
-				// Both set, as they always are in production.
+				// VCTURL is deliberately NOT hand-set: ResolveVCTUrls below
+				// derives it exactly as production does, so this fixture
+				// exercises the real code path rather than a hand-built
+				// approximation of it.
 				"pid": {
 					Format:       "dc+sd-jwt",
 					VCTMFilePath: "/path/to/vctm",
-					VCTURL:       "https://apigw.example/type-metadata/pid",
 					VCTM:         &sdjwtvc.VCTM{VCT: "urn:eudi:pid:1"},
 				},
 				// A VCTM file with no vct: ResolveVCTUrls back-fills VCTM.VCT
-				// from the URL, so both agree and the URL is still correct.
+				// from the derived URL, so the two collapse to one value.
 				"novct": {
 					Format:       "dc+sd-jwt",
 					VCTMFilePath: "/path/to/novct",
-					VCTURL:       "https://apigw.example/type-metadata/novct",
 					VCTM:         &sdjwtvc.VCTM{VCT: ""},
 				},
 			},
@@ -989,6 +990,14 @@ func TestUIMetadataOffersBothVCTIdentifiers(t *testing.T) {
 			},
 		},
 	}
+
+	// Resolve as the server does at startup: this is what populates VCTURL and
+	// back-fills an empty VCTM.VCT from it. Without this the "novct" case would
+	// only prove the URL fallback and never reach the de-duplication branch.
+	require.NoError(t, cfg.ResolveVCTUrls("https://apigw.example"))
+	require.Equal(t, "https://apigw.example/type-metadata/novct",
+		cfg.Common.CredentialMetadata["novct"].GetVCTM().VCT,
+		"precondition: ResolveVCTUrls should have back-filled the empty vct from the URL")
 
 	client, _ := CreateTestClientWithMock(cfg)
 	client.cfg = cfg
@@ -1020,11 +1029,12 @@ func TestUIMetadataOffersBothVCTIdentifiers(t *testing.T) {
 			"DCQL meta.vct_values is an acceptable-value list, so both forms belong in it")
 	})
 
-	t.Run("falls back to the URL when the VCTM has no vct", func(t *testing.T) {
+	t.Run("collapses to one value when the VCTM had no vct", func(t *testing.T) {
 		assert.Equal(t, "https://apigw.example/type-metadata/novct", reply.Credentials["novct"].VCT,
 			"a VCTM with no vct still needs a usable identifier")
 		assert.Equal(t, []string{"https://apigw.example/type-metadata/novct"},
 			reply.Credentials["novct"].VCTValues,
-			"ResolveVCTUrls back-fills VCTM.VCT from the URL, so the two collapse to one value")
+			"ResolveVCTUrls back-filled VCTM.VCT from the URL, so the two are the same "+
+				"string and must be de-duplicated rather than listed twice")
 	})
 }

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -161,9 +161,11 @@ func TestUIMetadata_MsoMdocScope(t *testing.T) {
 	assert.Empty(t, info.VCTValues,
 		"mso_mdoc has no vct - DCQL constrains it with doctype_value instead")
 
-	// The field must be OMITTED, not serialized as null: the UI's schema takes
-	// an optional array, so a null would fail validation and break
-	// /ui/metadata parsing for every configuration containing an mdoc.
+	// The field must be OMITTED, not serialized as null. Either form would
+	// parse - the UI's schema declares vct_values as nullish and falls back
+	// to [vct] for both absent and null - so this asserts wire-format
+	// cleanliness: an mdoc credential is identified by doctype, and has no
+	// business emitting a vct_values key at all.
 	encoded, err := json.Marshal(info)
 	require.NoError(t, err)
 	assert.NotContains(t, string(encoded), "vct_values",

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -932,3 +932,76 @@ func applyPerScopeValidations(scopes []string, validations map[string][]openid4v
 	}
 	return nil
 }
+
+// TestUIMetadataPrefersVCTMOverVCTURL pins the identifier the UI advertises and
+// queries for to the VCTM's own vct, not the URL the VCTM is served from.
+//
+// These are different things and must not be conflated: a credential's vct
+// claim is built from the VCTM (BuildCredentialWithSigner sets
+// body["vct"] = vctm.VCT), so that is what a wallet matches a DCQL
+// meta.vct_values against, whereas VCTURL is a location ResolveVCTUrls derives
+// as apigwPublicURL + /type-metadata/{scope}.
+//
+// The existing TestUIMetadata already asserts "VCT should be populated from
+// VCTM", but could not catch this: it builds CredentialMetadata directly and
+// never sets VCTURL, so the empty-URL path was the only one exercised. In
+// production ResolveVCTUrls guarantees VCTURL is non-empty for every
+// VCTM-backed scope, which is exactly the case that regressed - the UI
+// advertised https://apigw.example/type-metadata/pid for a credential whose
+// vct is urn:eudi:pid:1, so every presentation started from the UI matched
+// nothing.
+func TestUIMetadataPrefersVCTMOverVCTURL(t *testing.T) {
+	ctx := t.Context()
+
+	cfg := &model.Cfg{
+		Common: &model.Common{
+			CredentialMetadata: map[string]*model.CredentialMetadata{
+				// Both set, as they always are in production.
+				"pid": {
+					Format:       "dc+sd-jwt",
+					VCTMFilePath: "/path/to/vctm",
+					VCTURL:       "https://apigw.example/type-metadata/pid",
+					VCTM:         &sdjwtvc.VCTM{VCT: "urn:eudi:pid:1"},
+				},
+				// A VCTM file with no vct: ResolveVCTUrls back-fills VCTM.VCT
+				// from the URL, so both agree and the URL is still correct.
+				"novct": {
+					Format:       "dc+sd-jwt",
+					VCTMFilePath: "/path/to/novct",
+					VCTURL:       "https://apigw.example/type-metadata/novct",
+					VCTM:         &sdjwtvc.VCTM{VCT: ""},
+				},
+			},
+		},
+		Verifier: &model.Verifier{
+			Presets: map[string]model.VerificationPreset{
+				"PID": {"pid": nil},
+			},
+		},
+	}
+
+	client, _ := CreateTestClientWithMock(cfg)
+	client.cfg = cfg
+
+	reply, err := client.UIMetadata(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, reply)
+
+	t.Run("credential info uses the VCTM vct", func(t *testing.T) {
+		assert.Equal(t, "urn:eudi:pid:1", reply.Credentials["pid"].VCT,
+			"the identifier a wallet matches against is the VCTM's vct, not where the VCTM is served")
+	})
+
+	t.Run("preset vct_values use the VCTM vct", func(t *testing.T) {
+		preset := reply.Presets["PID"]
+		require.NotNil(t, preset)
+		require.Len(t, preset.Credentials, 1)
+		assert.Equal(t, []string{"urn:eudi:pid:1"}, preset.Credentials[0].Meta.VCTValues,
+			"DCQL meta.vct_values is matched against the credential's vct claim")
+	})
+
+	t.Run("falls back to the URL when the VCTM has no vct", func(t *testing.T) {
+		assert.Equal(t, "https://apigw.example/type-metadata/novct", reply.Credentials["novct"].VCT,
+			"a VCTM with no vct still needs a usable identifier")
+	})
+}

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -943,23 +943,28 @@ func applyPerScopeValidations(scopes []string, validations map[string][]openid4v
 	return nil
 }
 
-// TestUIMetadataPrefersVCTMOverVCTURL pins the identifier the UI advertises and
-// queries for to the VCTM's own vct, not the URL the VCTM is served from.
+// TestUIMetadataOffersBothVCTIdentifiers pins the UI to advertising BOTH
+// identifiers a wallet might match a credential type by: the VCTM's own vct
+// first, then the URL the VCTM is served from.
 //
-// These are different things and must not be conflated: a credential's vct
-// claim is built from the VCTM (BuildCredentialWithSigner sets
-// body["vct"] = vctm.VCT), so that is what a wallet matches a DCQL
-// meta.vct_values against, whereas VCTURL is a location ResolveVCTUrls derives
-// as apigwPublicURL + /type-metadata/{scope}.
+// Both are needed, because deployed wallets disagree about which one names a
+// credential type, and each behaviour is live-verified in this repo. The EUDI
+// reference wallet (multipaz) matches the issuer metadata's declared vct - the
+// type-metadata URL - per the finding-18 note in
+// internal/apigw/apiv1/handlers_verifier.go. Other wallets match the
+// credential's own vct claim, built from the VCTM (BuildCredentialWithSigner
+// sets body["vct"] = vctm.VCT), per the finding-16 note on
+// VCTIdentifiersForScopes in pkg/model/config.go. DCQL's meta.vct_values is an
+// acceptable-value list, so emitting both satisfies either wallet.
 //
 // The existing TestUIMetadata already asserts "VCT should be populated from
-// VCTM", but could not catch this: it builds CredentialMetadata directly and
-// never sets VCTURL, so the empty-URL path was the only one exercised. In
-// production ResolveVCTUrls guarantees VCTURL is non-empty for every
-// VCTM-backed scope, which is exactly the case that regressed - the UI
-// advertised https://apigw.example/type-metadata/pid for a credential whose
-// vct is urn:eudi:pid:1, so every presentation started from the UI matched
-// nothing.
+// VCTM", but could not catch the original regression: it builds
+// CredentialMetadata directly and never sets VCTURL, so the empty-URL path was
+// the only one exercised. In production ResolveVCTUrls guarantees VCTURL is
+// non-empty for every VCTM-backed scope, which is exactly the case that
+// regressed - the UI advertised only https://apigw.example/type-metadata/pid
+// for a credential whose vct is urn:eudi:pid:1, so presentations started from
+// the UI matched nothing in wallets of the second kind.
 func TestUIMetadataOffersBothVCTIdentifiers(t *testing.T) {
 	ctx := t.Context()
 

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -368,7 +368,12 @@ Alpine.data("app", () => ({
             // Carried through so the custom-credential flow builds the same
             // multi-value vct_values the presets do; without it this path
             // silently falls back to [vct] and only presets interoperate.
-            vct_values: chosenCredential.vct_values,
+            //
+            // ?? undefined normalizes the schema's legacy null (accepted so a
+            // server that emits the field without omitempty doesn't break the
+            // page) to the absent form this object's type declares, keeping
+            // the strict checkJs contract consistent.
+            vct_values: chosenCredential.vct_values ?? undefined,
             claims,
             claimTree: buildClaimTree(claims),
         }

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -11,9 +11,10 @@ import {
 const credentialAttributesSchema = v.object({
     format: v.string(),
     vct: v.string(),
-    // Optional so an older server that only sends "vct" still validates; the
-    // query builder falls back to [vct] when this is absent.
-    vct_values: v.optional(v.array(v.string())),
+    // nullish, not optional: absent for an older server that only sends "vct",
+    // and null for one that emits the field without omitempty. The query
+    // builder falls back to [vct] in both cases.
+    vct_values: v.nullish(v.array(v.string())),
     attributes: v.record(
         v.string(),
         v.record(
@@ -223,7 +224,7 @@ Alpine.data("app", () => ({
     /** @type {boolean} Whether the server has opted in to native DC API attempts. */
     dcApiEnabled: false,
 
-     /** @type {{ id: string; format: string; vct: string; claims: Record<string, (string|null)[]>; claimTree: ClaimNode[]; } | null} */
+     /** @type {{ id: string; format: string; vct: string; vct_values?: string[]; claims: Record<string, (string|null)[]>; claimTree: ClaimNode[]; } | null} */
     credentialAttributes: null,
 
     /** 
@@ -364,6 +365,10 @@ Alpine.data("app", () => ({
             id: credential,
             format: chosenCredential.format,
             vct: chosenCredential.vct,
+            // Carried through so the custom-credential flow builds the same
+            // multi-value vct_values the presets do; without it this path
+            // silently falls back to [vct] and only presets interoperate.
+            vct_values: chosenCredential.vct_values,
             claims,
             claimTree: buildClaimTree(claims),
         }

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -11,6 +11,9 @@ import {
 const credentialAttributesSchema = v.object({
     format: v.string(),
     vct: v.string(),
+    // Optional so an older server that only sends "vct" still validates; the
+    // query builder falls back to [vct] when this is absent.
+    vct_values: v.optional(v.array(v.string())),
     attributes: v.record(
         v.string(),
         v.record(
@@ -436,9 +439,20 @@ Alpine.data("app", () => ({
         // vct_values for an mdoc credential matches nothing on the wallet
         // side (no mdoc credential has a vct), so the request always comes
         // back empty.
+        // vct_values carries EVERY identifier a wallet might match this
+        // credential type by, not just one: the EUDI reference wallet
+        // (multipaz) matches the issuer metadata's declared vct (our
+        // type-metadata URL), while others (wwWallet) match the credential's
+        // own embedded vct claim. DCQL treats vct_values as an
+        // acceptable-value list, so sending both satisfies either wallet.
+        // Falls back to the single vct for an older server that doesn't
+        // send the list.
+        const vctValues = this.credentialAttributes.vct_values?.length
+            ? this.credentialAttributes.vct_values
+            : [this.credentialAttributes.vct];
         const meta = this.credentialAttributes.format === "mso_mdoc"
             ? { doctype_value: this.credentialAttributes.vct }
-            : { vct_values: [this.credentialAttributes.vct] };
+            : { vct_values: vctValues };
 
         /** @satisfies {DCQLQueryCredential} */
         const credential = {


### PR DESCRIPTION
> **Approach revised after review** — see "Why both" below. The original commit preferred `VCTM.VCT` over `VCTURL`; that fixed one wallet and would have regressed another. It now offers **both**.

## Problem

A presentation started from the verifier's own UI fails in some wallets with **"No credentials match DCQL query"**, because the UI puts a single identifier in `meta.vct_values` and it isn't the one that wallet matches on.

`UIMetadata` resolved both `UICredentialInfo.VCT` and `UIPresetCredential.Meta.VCTValues` from `GetVCTURL()` only. For a PID whose VCTM declares `urn:eudi:pid:arf-1.8:1`, the UI asked for `https://<apigw>/type-metadata/pid_1_8`.

## Why both, rather than swapping

This repo already contains live-verified evidence for **both** behaviours, from **different wallets** — which is why simply swapping the precedence would trade one broken wallet for another:

- **finding 18** (`internal/apigw/apiv1/handlers_verifier.go`): the EUDI reference wallet (multipaz) matches the **issuer metadata's** declared vct — the published type-metadata URL. `Offer.kt` sets `SdJwtVcFormat(vct = configuration.type)`, and `DcqlRequestProcessor.candidateDocumentsForQuery` filters on that tag *before* parsing the credential body. That endpoint deliberately still sends URLs, and this PR does not change it.
- **finding 16** (`VCTIdentifiersForScopes`, `pkg/model/config.go`): URL-based DCQL *"never matched any real issued credential — confirmed live"*. That matches wwWallet/wallet-frontend, which reads the credential's own `vct` claim (set by `BuildCredentialWithSigner` → `body["vct"] = vctm.VCT`).

Neither finding is wrong. DCQL's `meta.vct_values` is an **acceptable-value list**, so the UI now emits both — the credential's own vct first, then the type-metadata URL — and each wallet matches on whichever it uses. This also addresses the review's consistency concern, since the issuer-metadata URL remains advertised.

## Changes

- `UICredentialInfo` gains `vct_values` alongside the existing single `vct`, which stays as the picker's display identifier.
- Presets emit the same list.
- The UI (`presentation-definition.js`) sends the list when present, falling back to `[vct]` for an older server.
- `mso_mdoc` scopes get no list — they have no vct, and DCQL constrains them with `doctype_value`.

## Verification

- New `TestUIMetadataOffersBothVCTIdentifiers`: both identifiers in order, for the credential picker *and* presets, plus the no-`vct` case where `ResolveVCTUrls` back-fills `VCTM.VCT` from the URL and the two collapse to one value.
- `go build ./...` clean; `internal/verifier/...` tests pass.
- Live against a running stack: the UI serves both identifiers for every sd-jwt scope and none for `mso_mdoc`, and a presentation started from the verifier UI now **completes** against a wallet-held PID, where it previously always failed.
