### PR TITLE
fix(verifier): constrain mso_mdoc presets by doctype_value, not vct_values

### DIFF
--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -69,8 +69,14 @@ type UIPresetCredential struct {
 }
 
 // UIPresetMeta holds credential metadata for the preset.
+//
+// Which field applies depends on the credential's format (OpenID4VP 1.0
+// 6.4.1): vct_values for sd-jwt credentials, doctype_value for mso_mdoc.
+// They are mutually exclusive, hence omitempty on both - sending an empty
+// vct_values alongside a doctype, or vice versa, is a malformed query.
 type UIPresetMeta struct {
-	VCTValues []string `json:"vct_values"`
+	VCTValues    []string `json:"vct_values,omitempty"`
+	DoctypeValue string   `json:"doctype_value,omitempty"`
 }
 
 // UIPresetClaim is a claim path within a preset credential.
@@ -190,17 +196,25 @@ func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
 				}
 
 				uiCred := UIPresetCredential{
-					ID:   scope,
-					Meta: UIPresetMeta{VCTValues: []string{}},
+					ID: scope,
 				}
 
-				// Resolve format and VCT from credential_metadata
+				// Resolve format and the type constraint from
+				// credential_metadata. An mso_mdoc credential has no vct at
+				// all - DCQL constrains it by doctype_value instead
+				// (OpenID4VP 1.0 6.4.1) - so a preset over an mdoc scope was
+				// previously emitted with an empty vct_values and no doctype,
+				// which matches nothing in any wallet.
 				if meta != nil {
 					uiCred.Format = meta.Format
-					// Both identifiers, for the reason documented on
-					// UICredentialInfo.VCTValues: wallets disagree about
-					// which one names a credential type.
-					if vs := vctIdentifiersFor(meta); len(vs) > 0 {
+					if mddl := meta.GetMDDL(); mddl != nil && mddl.DocType != "" {
+						uiCred.Meta.DoctypeValue = mddl.DocType
+					} else if vs := vctIdentifiersFor(meta); len(vs) > 0 {
+						// Both identifiers, for the reason documented on
+						// UICredentialInfo.VCTValues: wallets disagree about
+						// which one names a credential type. Only reached for
+						// non-mdoc credentials - an mdoc is constrained by
+						// doctype_value above and has no vct to offer.
 						uiCred.Meta.VCTValues = vs
 					}
 				}

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -1062,3 +1062,73 @@ func TestUIMetadataOffersBothVCTIdentifiers(t *testing.T) {
 				"string and must be de-duplicated rather than listed twice")
 	})
 }
+
+// TestUIMetadataPresetMsoMdocUsesDoctypeValue pins the DCQL type constraint a
+// preset emits per format. An mso_mdoc credential has no vct at all, so
+// OpenID4VP 1.0 6.4.1 constrains it with doctype_value; a preset that sends an
+// empty vct_values and no doctype matches nothing in any wallet.
+func TestUIMetadataPresetMsoMdocUsesDoctypeValue(t *testing.T) {
+	ctx := t.Context()
+
+	schema := &mdoc.MDDLSchema{
+		Format:  "mso_mdoc",
+		DocType: "org.iso.18013.5.1.mDL",
+		Claims: map[string]mdoc.NamespaceClaims{
+			"org.iso.18013.5.1": {
+				"family_name": {Mandatory: true, ValueType: "tstr"},
+			},
+		},
+	}
+
+	cfg := &model.Cfg{
+		Common: &model.Common{
+			CredentialMetadata: map[string]*model.CredentialMetadata{
+				"mdl": {
+					Format:     "mso_mdoc",
+					MDDL:       schema,
+					Attributes: schema.Attributes(),
+				},
+				"pid": {
+					Format:       "dc+sd-jwt",
+					VCTMFilePath: "/path/to/vctm",
+					VCTURL:       "https://apigw.example/type-metadata/pid",
+					VCTM:         &sdjwtvc.VCTM{VCT: "urn:eudi:pid:1"},
+				},
+			},
+		},
+		Verifier: &model.Verifier{
+			Presets: map[string]model.VerificationPreset{
+				"MDL": {"mdl": nil},
+				"PID": {"pid": nil},
+			},
+		},
+	}
+
+	client, _ := CreateTestClientWithMock(cfg)
+	client.cfg = cfg
+
+	reply, err := client.UIMetadata(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, reply)
+
+	t.Run("mdoc preset constrains by doctype_value", func(t *testing.T) {
+		preset := reply.Presets["MDL"]
+		require.NotNil(t, preset)
+		require.Len(t, preset.Credentials, 1)
+		meta := preset.Credentials[0].Meta
+		assert.Equal(t, "org.iso.18013.5.1.mDL", meta.DoctypeValue,
+			"mso_mdoc has no vct - DCQL constrains it by doctype (OpenID4VP 1.0 6.4.1)")
+		assert.Empty(t, meta.VCTValues,
+			"sending vct_values for an mdoc credential matches nothing; it must be omitted")
+	})
+
+	t.Run("sd-jwt preset still constrains by vct_values", func(t *testing.T) {
+		preset := reply.Presets["PID"]
+		require.NotNil(t, preset)
+		require.Len(t, preset.Credentials, 1)
+		meta := preset.Credentials[0].Meta
+		assert.NotEmpty(t, meta.VCTValues, "sd-jwt credentials are still matched by vct")
+		assert.Empty(t, meta.DoctypeValue,
+			"doctype_value is meaningless for sd-jwt and must not be sent")
+	})
+}

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -99,8 +99,14 @@ const metadataResponseSchema = v.object({
         credentials: v.array(v.object({
             id: v.string(),
             format: v.string(),
+            // vct_values (sd-jwt) and doctype_value (mso_mdoc) are mutually
+            // exclusive and both optional: which one applies depends on the
+            // credential's format (OpenID4VP 1.0 6.4.1). Declaring only
+            // vct_values here meant an mdoc preset's doctype_value was
+            // silently stripped by the schema before reaching the query.
             meta: v.object({
-                vct_values: v.array(v.string()),
+                vct_values: v.optional(v.array(v.string())),
+                doctype_value: v.optional(v.string()),
             }),
             claims: v.optional(v.array(v.object({
                 path: v.array(v.nullable(v.string())),


### PR DESCRIPTION
## Problem

A verification preset over an `mso_mdoc` scope produces a DCQL query that cannot match anything, in any wallet.

An mso_mdoc credential has no `vct` at all — OpenID4VP 1.0 §6.4.1 constrains it with `meta.doctype_value`. But `UIPresetMeta` only had `vct_values`, and the preset path resolved it from `GetVCTURL()` / `GetVCTM()`. Both are empty for an mdoc scope (`ResolveVCTUrls` skips constructors with no VCTM, and `GetVCTM()` is nil), so the preset went out as:

```json
{ "id": "mdl", "format": "mso_mdoc", "meta": { "vct_values": [] } }
```

The **non-preset** path already handles this correctly — it sends `doctype_value` for `mso_mdoc`, with a comment spelling out why — so only presets were affected.

## Changes

- `UIPresetMeta` gains `DoctypeValue`. Both fields are `omitempty`: which one applies depends on the credential's format and they're mutually exclusive, so emitting an empty `vct_values` beside a doctype (or vice versa) is itself malformed.
- The preset path checks `GetMDDL()` first and sets the doctype for mdoc scopes, leaving the existing vct resolution untouched for sd-jwt.
- The client's **preset** schema declared only `vct_values`, so a `doctype_value` would have been silently stripped by validation before reaching the query even once the server sent it. Both are optional there now. (The general `dcqlQueryCredentialSchema` already allowed both.)

## Verification

- New `TestUIMetadataPresetMsoMdocUsesDoctypeValue` covers both formats: mdoc gets a doctype and **no** `vct_values`; sd-jwt keeps `vct_values` and gets **no** doctype.
- The test was checked to fail against the old behaviour *with the struct field present* — `expected "org.iso.18013.5.1.mDL", got ""` — rather than merely failing to compile, so it genuinely pins the behaviour.
- `go build ./...` clean; full `internal/verifier/...` suite passes.

## Relationship to #596

Found while reviewing #596, and deliberately **not** folded into it: I verified this bug is byte-identical on unmodified `upstream/main`, so it's pre-existing and independent of that change.

Both touch `UIMetadata`'s preset block, so whichever merges second will need a trivial rebase. This branch is cut from `upstream/main` and does not depend on #596.
