### PR TITLE
ci: compile and test the zknative cgo path

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,10 +75,25 @@ jobs:
       - name: Resolve the zk-cred-longfellow revision
         id: crate
         run: |
-          sha=$(git ls-remote https://github.com/sirosfoundation/zk-cred-longfellow.git \
-                  "${ZK_CRED_LONGFELLOW_REF:-main}" | cut -f1)
-          if [ -z "$sha" ]; then
-            echo "::error::could not resolve zk-cred-longfellow ref"
+          set -euo pipefail
+          repo=https://github.com/sirosfoundation/zk-cred-longfellow.git
+          ref="${ZK_CRED_LONGFELLOW_REF:-main}"
+          if printf '%s' "$ref" | grep -Eiq '^[0-9a-f]{40}$'; then
+            # The Makefile accepts a raw commit SHA (and pinning the ref to
+            # one is the intended direction), but `git ls-remote` does not
+            # resolve a SHA - it would return nothing. Use it as-is.
+            sha="$ref"
+          else
+            refs=$(git ls-remote "$repo" "$ref")
+            # An annotated tag resolves to two lines; the peeled "^{}" entry
+            # is the commit `git checkout FETCH_HEAD` actually lands on.
+            sha=$(printf '%s\n' "$refs" | awk '$2 ~ /\^\{\}$/ { print $1; exit }')
+            [ -n "$sha" ] || sha=$(printf '%s\n' "$refs" | awk 'NR==1 { print $1 }')
+          fi
+          # Also guarantees a single-line value, so GITHUB_OUTPUT cannot be
+          # corrupted by an unexpected ls-remote result.
+          if ! printf '%s' "$sha" | grep -Eiq '^[0-9a-f]{40}$'; then
+            echo "::error::could not resolve zk-cred-longfellow ref '$ref'"
             exit 1
           fi
           echo "sha=$sha" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,3 +41,62 @@ jobs:
             echo "::error::docs/CONFIGURATION.md is out of date. Run 'make gen-config-docs' and commit the result."
             exit 1
           fi
+  # The zknative build tag gates pkg/mdoc's cgo path onto
+  # zk-cred-longfellow's C ABI. Until this job existed, neither that cgo
+  # code nor any of its four tagged test files was ever compiled by CI —
+  # so a change to the crate's ABI, or to the Go wrapper, could only be
+  # discovered by hand on a developer machine.
+  #
+  # The live-service tests already skip cleanly when
+  # https://zk-circuits.fly.dev is unreachable (6fe7e96a and its sibling
+  # guard), so a catalog outage cannot redden this job.
+  zknative:
+    name: Native ZK verification (cgo)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Install Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: "**/*.sum"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # zk-cred-longfellow is fetched and built from source by
+      # `make zk-native-lib`, which is a release-mode Rust build — cache it
+      # on the resolved crate revision so only the first run after a bump
+      # pays for it.
+      - name: Resolve the zk-cred-longfellow revision
+        id: crate
+        run: |
+          sha=$(git ls-remote https://github.com/sirosfoundation/zk-cred-longfellow.git \
+                  "${ZK_CRED_LONGFELLOW_REF:-main}" | cut -f1)
+          if [ -z "$sha" ]; then
+            echo "::error::could not resolve zk-cred-longfellow ref"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the built C ABI library
+        uses: actions/cache@v4
+        with:
+          path: |
+            third_party/zk-cred-longfellow
+            third_party/.zk-cred-longfellow-src/target
+          key: zk-cred-longfellow-${{ runner.os }}-${{ steps.crate.outputs.sha }}
+
+      - name: Build the native library
+        run: make zk-native-lib
+
+      - name: Run the zknative-tagged tests
+        run: make test-zknative
+
+      # Compiling the tests is not the same as compiling the binary that
+      # ships: build-verifier-zknative exercises the link step the tests
+      # never reach.
+      - name: Build the verifier with the tag
+        run: make build-verifier-zknative

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,9 @@ jobs:
           cache-dependency-path: "**/*.sum"
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to a commit SHA: "stable" is a mutable branch ref, so an
+        # unpinned use is a moving third-party dependency in the build.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       # zk-cred-longfellow is fetched and built from source by
       # `make zk-native-lib`, which is a release-mode Rust build — cache it
@@ -82,7 +84,7 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Cache the built C ABI library
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             third_party/zk-cred-longfellow


### PR DESCRIPTION
## What

Adds a CI job that sets the `zknative` build tag, so `pkg/mdoc`'s cgo path onto `zk-cred-longfellow`'s C ABI is actually compiled and tested.

## Why

Until now CI never set the tag. That means **neither `zk_native_cgo.go` nor any of its four tagged test files was ever compiled by CI** — an ABI change in the crate, or a mistake in the Go wrapper, could only be discovered by hand on a developer machine. The tests themselves already exist and are real; nothing was running them.

This came out of an architectural review of whether to keep integrating the ZK crates via cgo or extract a companion service. The conclusion was to keep cgo — but it also found that the deployment/CI gap, not the integration style, is the actual blocker. This closes the CI half of that.

## What the job does

1. `make zk-native-lib` — fetch and release-build the crate's `go-cabi` target
2. `make test-zknative` — run the four tagged test packages
3. `make build-verifier-zknative` — link the tagged binary

Step 3 is not redundant: compiling tests does not exercise the link step the shipped binary takes.

## Cost

`zk-cred-longfellow` is built from source, so the staged library and the crate's `target/` are cached on the **resolved crate SHA**. Only the first run after a crate bump pays the Rust build cost.

## Flakiness

The live-service tests already skip cleanly when `zk-circuits.fly.dev` is unreachable (6fe7e96a and its sibling guard), so a catalog outage cannot redden this job.

## Verification

Run end to end locally against this branch:

- library builds and stages
- all four tagged packages pass, including `TestVerifyWithPPID_RealLiveCircuitAndGoldenProof` against the live catalog
- `vc_verifier-zknative` links

## Not in this PR

Two adjacent items from the same review, deliberately left out:

- **`ZK_CRED_LONGFELLOW_REF` still defaults to `main`** (Makefile:48), so CI tests a moving target. Pinning it to a tag or SHA is a separate change with its own judgement call about which revision.
- **No musl-static build or Docker target**, so there is still no shippable `vc_verifier-zknative` image. That is the larger remaining piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm287nVbhUoBhvVqSMbNCb