### PR TITLE
ci: run the tests under pkg/ in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ BUILD_CONFIGS           := \
 # Phony Targets Declaration
 # ==============================================================================
 
-.PHONY: help pki pki-clean test test-env test-js \
+.PHONY: help pki pki-clean test test-env test-js test-pkg \
 	build build-% \
 	docker-build docker-build-% docker-push docker-push-% docker-push-issuer-hsm docker-tag docker-tag-% docker-pull docker-archive \
 	start stop restart clean_docker_images \

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ pki-clean: ## Clean PKI material
 # Testing Targets
 # ==============================================================================
 
-test: $(addprefix test-,$(SERVICES)) test-js ## Run all service tests
+test: $(addprefix test-,$(SERVICES)) test-pkg test-js ## Run all service tests
 
 # Generate test-SERVICE targets dynamically
 define TEST_TEMPLATE
@@ -204,6 +204,10 @@ $(foreach service,$(SERVICES),$(eval $(call TEST_TEMPLATE,$(service))))
 test-env: ## Set up test environment
 	$(info Setting up test environment)
 	sudo apt-get update && sudo apt-get install -y softhsm2 opensc nodejs npm
+
+test-pkg: ## Test the shared packages under pkg/
+	$(info Testing pkg)
+	go test ./pkg/...
 
 test-js: ## Run JS unit tests for staticembed helpers
 	$(info Running JS unit tests)

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ test-env: ## Set up test environment
 
 test-pkg: ## Test the shared packages under pkg/
 	$(info Testing pkg)
-	go test ./pkg/...
+	go test -v ./pkg/...
 
 test-js: ## Run JS unit tests for staticembed helpers
 	$(info Running JS unit tests)

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ pki-clean: ## Clean PKI material
 # Testing Targets
 # ==============================================================================
 
-test: $(addprefix test-,$(SERVICES)) test-pkg test-js ## Run all service tests
+test: $(addprefix test-,$(SERVICES)) test-pkg test-js ## Run all Go tests (services and pkg/) plus the JS unit tests
 
 # Generate test-SERVICE targets dynamically
 define TEST_TEMPLATE

--- a/pkg/model/generic_test.go
+++ b/pkg/model/generic_test.go
@@ -94,8 +94,13 @@ func TestIdentity_GetOver14(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "person 13 years 364 days old",
-			birthDate: now.AddDate(-14, 0, 1).Format("2006-01-02"),
+			// Two days short, not one. GetOver14 reads its own clock, so a
+			// one-day margin still flips if the test captures now just
+			// before midnight UTC and the call lands just after. The exact
+			// boundary is covered deterministically in
+			// TestAgeThresholdDate, which needs no clock at all.
+			name:      "person 13 years 363 days old",
+			birthDate: now.AddDate(-14, 0, 2).Format("2006-01-02"),
 			want:      false,
 			wantErr:   false,
 		},
@@ -216,10 +221,13 @@ func TestIdentity_GetOver14_EdgeCases(t *testing.T) {
 		assert.True(t, got, "Person turning 14 today should be considered over 14")
 	})
 
-	t.Run("birthday tomorrow - still 13", func(t *testing.T) {
-		// Person who turns 14 tomorrow
-		tomorrow := now.AddDate(0, 0, 1)
-		birthDate := tomorrow.AddDate(-14, 0, 0).Format("2006-01-02")
+	t.Run("birthday in two days - still 13", func(t *testing.T) {
+		// Two days out rather than one: GetOver14 reads its own clock, so a
+		// single day's margin can be erased by a midnight-UTC crossing
+		// between capturing now and the call. See TestAgeThresholdDate for
+		// the exact boundary, tested without a clock.
+		soon := now.AddDate(0, 0, 2)
+		birthDate := soon.AddDate(-14, 0, 0).Format("2006-01-02")
 
 		identity := &Identity{
 			BirthDate: birthDate,
@@ -227,7 +235,7 @@ func TestIdentity_GetOver14_EdgeCases(t *testing.T) {
 
 		got, err := identity.GetOver14()
 		require.NoError(t, err)
-		assert.False(t, got, "Person turning 14 tomorrow should not be considered over 14 yet")
+		assert.False(t, got, "Person turning 14 in two days should not be considered over 14 yet")
 	})
 
 	t.Run("birthday yesterday - just turned 14", func(t *testing.T) {
@@ -355,4 +363,64 @@ func TestIdentity_Marshal_EmptyFields(t *testing.T) {
 
 	// Optional fields should not be present or be empty
 	// (depending on omitempty tag behavior)
+}
+
+// TestAgeThresholdDate covers the exact age boundary without a clock.
+//
+// The GetOverNN tests cannot: they build a fixture from one reading of the
+// clock while the helper compares against another, so anything within a day
+// of the threshold can flip when the two readings straddle midnight UTC.
+// ageThresholdDate is pure, so the boundary is pinned exactly here and the
+// clock-dependent tests stay well clear of it.
+func TestAgeThresholdDate(t *testing.T) {
+	date := func(y int, m time.Month, d int) time.Time {
+		return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+	}
+
+	tests := []struct {
+		name  string
+		birth time.Time
+		years int
+		want  time.Time
+	}{
+		{
+			name:  "ordinary date",
+			birth: date(2012, time.June, 15),
+			years: 14,
+			want:  date(2026, time.June, 15),
+		},
+		{
+			name:  "day before a birthday is not yet the threshold",
+			birth: date(2012, time.June, 16),
+			years: 14,
+			want:  date(2026, time.June, 16),
+		},
+		{
+			// Feb 29 into a non-leap year: EU convention puts the threshold
+			// on Feb 28 rather than letting AddDate normalise to Mar 1,
+			// which would delay it by a day.
+			name:  "leap-day birth, non-leap target year",
+			birth: date(2012, time.February, 29),
+			years: 14,
+			want:  date(2026, time.February, 28),
+		},
+		{
+			name:  "leap-day birth, leap target year",
+			birth: date(2012, time.February, 29),
+			years: 16,
+			want:  date(2028, time.February, 29),
+		},
+		{
+			name:  "Feb 28 is unaffected",
+			birth: date(2012, time.February, 28),
+			years: 14,
+			want:  date(2026, time.February, 28),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ageThresholdDate(tt.birth, tt.years))
+		})
+	}
 }

--- a/pkg/model/generic_test.go
+++ b/pkg/model/generic_test.go
@@ -390,7 +390,9 @@ func TestAgeThresholdDate(t *testing.T) {
 			want:  date(2026, time.June, 15),
 		},
 		{
-			name:  "day before a birthday is not yet the threshold",
+			// The threshold tracks the birth date exactly, so a birth one
+			// day later yields a threshold one day later.
+			name:  "one day later birth, one day later threshold",
 			birth: date(2012, time.June, 16),
 			years: 14,
 			want:  date(2026, time.June, 16),

--- a/pkg/model/generic_test.go
+++ b/pkg/model/generic_test.go
@@ -68,8 +68,12 @@ func TestDecodeCredentialOffer(t *testing.T) {
 }
 
 func TestIdentity_GetOver14(t *testing.T) {
-	currentYear := time.Now().UTC().Year()
-	currentDate := time.Now().UTC()
+	// One reading, used everywhere below. Sampling the clock per row would
+	// reintroduce the flakiness this test was just fixed for, one boundary
+	// further out: a table built across midnight UTC mixes two dates.
+	now := time.Now().UTC()
+	currentYear := now.Year()
+	currentDate := now
 
 	tests := []struct {
 		name      string
@@ -79,19 +83,19 @@ func TestIdentity_GetOver14(t *testing.T) {
 	}{
 		{
 			name:      "person exactly 14 years old today",
-			birthDate: time.Now().UTC().AddDate(-14, 0, 0).Format("2006-01-02"),
+			birthDate: now.AddDate(-14, 0, 0).Format("2006-01-02"),
 			want:      true,
 			wantErr:   false,
 		},
 		{
 			name:      "person 14 years and 1 day old",
-			birthDate: time.Now().UTC().AddDate(-14, 0, -1).Format("2006-01-02"),
+			birthDate: now.AddDate(-14, 0, -1).Format("2006-01-02"),
 			want:      true,
 			wantErr:   false,
 		},
 		{
 			name:      "person 13 years 364 days old",
-			birthDate: time.Now().UTC().AddDate(-14, 0, 1).Format("2006-01-02"),
+			birthDate: now.AddDate(-14, 0, 1).Format("2006-01-02"),
 			want:      false,
 			wantErr:   false,
 		},
@@ -195,9 +199,12 @@ func TestIdentity_GetOver14(t *testing.T) {
 }
 
 func TestIdentity_GetOver14_EdgeCases(t *testing.T) {
+	// Single clock reading, shared by every subtest - see TestIdentity_GetOver14.
+	now := time.Now().UTC()
+
 	t.Run("birthday today - exactly 14 years", func(t *testing.T) {
 		// Person who turns 14 today
-		today := time.Now().UTC()
+		today := now
 		birthDate := today.AddDate(-14, 0, 0).Format("2006-01-02")
 
 		identity := &Identity{
@@ -211,7 +218,7 @@ func TestIdentity_GetOver14_EdgeCases(t *testing.T) {
 
 	t.Run("birthday tomorrow - still 13", func(t *testing.T) {
 		// Person who turns 14 tomorrow
-		tomorrow := time.Now().UTC().AddDate(0, 0, 1)
+		tomorrow := now.AddDate(0, 0, 1)
 		birthDate := tomorrow.AddDate(-14, 0, 0).Format("2006-01-02")
 
 		identity := &Identity{
@@ -225,7 +232,7 @@ func TestIdentity_GetOver14_EdgeCases(t *testing.T) {
 
 	t.Run("birthday yesterday - just turned 14", func(t *testing.T) {
 		// Person who turned 14 yesterday
-		yesterday := time.Now().UTC().AddDate(0, 0, -1)
+		yesterday := now.AddDate(0, 0, -1)
 		birthDate := yesterday.AddDate(-14, 0, 0).Format("2006-01-02")
 
 		identity := &Identity{
@@ -239,10 +246,13 @@ func TestIdentity_GetOver14_EdgeCases(t *testing.T) {
 }
 
 func TestIdentity_GetOver14_LeapYear(t *testing.T) {
+	// Single clock reading, shared by every subtest - see TestIdentity_GetOver14.
+	now := time.Now().UTC()
+
 	t.Run("born on leap day - 15 years ago", func(t *testing.T) {
 		// Testing over-14 age verification with a person born 15 years ago
 		// Using 15 years ensures the person is definitively over the 14-year threshold
-		currentYear := time.Now().UTC().Year()
+		currentYear := now.Year()
 
 		// Find the most recent leap year that was at least 15 years ago
 		leapYear := currentYear - 15

--- a/pkg/model/generic_test.go
+++ b/pkg/model/generic_test.go
@@ -68,8 +68,8 @@ func TestDecodeCredentialOffer(t *testing.T) {
 }
 
 func TestIdentity_GetOver14(t *testing.T) {
-	currentYear := time.Now().Year()
-	currentDate := time.Now()
+	currentYear := time.Now().UTC().Year()
+	currentDate := time.Now().UTC()
 
 	tests := []struct {
 		name      string
@@ -79,19 +79,19 @@ func TestIdentity_GetOver14(t *testing.T) {
 	}{
 		{
 			name:      "person exactly 14 years old today",
-			birthDate: time.Now().AddDate(-14, 0, 0).Format("2006-01-02"),
+			birthDate: time.Now().UTC().AddDate(-14, 0, 0).Format("2006-01-02"),
 			want:      true,
 			wantErr:   false,
 		},
 		{
 			name:      "person 14 years and 1 day old",
-			birthDate: time.Now().AddDate(-14, 0, -1).Format("2006-01-02"),
+			birthDate: time.Now().UTC().AddDate(-14, 0, -1).Format("2006-01-02"),
 			want:      true,
 			wantErr:   false,
 		},
 		{
 			name:      "person 13 years 364 days old",
-			birthDate: time.Now().AddDate(-14, 0, 1).Format("2006-01-02"),
+			birthDate: time.Now().UTC().AddDate(-14, 0, 1).Format("2006-01-02"),
 			want:      false,
 			wantErr:   false,
 		},
@@ -197,7 +197,7 @@ func TestIdentity_GetOver14(t *testing.T) {
 func TestIdentity_GetOver14_EdgeCases(t *testing.T) {
 	t.Run("birthday today - exactly 14 years", func(t *testing.T) {
 		// Person who turns 14 today
-		today := time.Now()
+		today := time.Now().UTC()
 		birthDate := today.AddDate(-14, 0, 0).Format("2006-01-02")
 
 		identity := &Identity{
@@ -211,7 +211,7 @@ func TestIdentity_GetOver14_EdgeCases(t *testing.T) {
 
 	t.Run("birthday tomorrow - still 13", func(t *testing.T) {
 		// Person who turns 14 tomorrow
-		tomorrow := time.Now().AddDate(0, 0, 1)
+		tomorrow := time.Now().UTC().AddDate(0, 0, 1)
 		birthDate := tomorrow.AddDate(-14, 0, 0).Format("2006-01-02")
 
 		identity := &Identity{
@@ -225,7 +225,7 @@ func TestIdentity_GetOver14_EdgeCases(t *testing.T) {
 
 	t.Run("birthday yesterday - just turned 14", func(t *testing.T) {
 		// Person who turned 14 yesterday
-		yesterday := time.Now().AddDate(0, 0, -1)
+		yesterday := time.Now().UTC().AddDate(0, 0, -1)
 		birthDate := yesterday.AddDate(-14, 0, 0).Format("2006-01-02")
 
 		identity := &Identity{
@@ -242,7 +242,7 @@ func TestIdentity_GetOver14_LeapYear(t *testing.T) {
 	t.Run("born on leap day - 15 years ago", func(t *testing.T) {
 		// Testing over-14 age verification with a person born 15 years ago
 		// Using 15 years ensures the person is definitively over the 14-year threshold
-		currentYear := time.Now().Year()
+		currentYear := time.Now().UTC().Year()
 
 		// Find the most recent leap year that was at least 15 years ago
 		leapYear := currentYear - 15


### PR DESCRIPTION
**223 test files under `pkg/` have never run in CI.**

## How

`make test` expands to `test-{verifier,registry,apigw,issuer}`, and each of those is:

```make
go test -v ./cmd/$(1)/... ./internal/$(1)/...
```

`./pkg/...` appears nowhere in it. `test.yaml` runs only `make test` and `make test-zknative` — and the latter is scoped to `./pkg/mdoc/...` behind a build tag.

**They pass.** This is not a backlog of failures being uncovered; it is that nothing was enforcing they keep passing, which makes them documentation rather than tests.

Among them: the WRPAC certificate-profile checks, registration-certificate parsing, and the ARF RPRC_16 binding — places where a silent regression is not obvious from outside.

## Cost

The whole tree runs in **26 seconds**. Docker-backed testcontainer tests already gate themselves on `testsupport.IsDockerAvailable()`, so they behave the same way the existing `internal/*/cache` ones do.

`test-pkg` is a separate target rather than folded into `TEST_TEMPLATE`, so `pkg/` is compiled and run once instead of four times.

## One test had to be fixed first

`TestIdentity_GetOver14` and `TestIdentity_GetOver14_EdgeCases` built their fixture dates from `time.Now()` in **local** time, while `GetOverNN` compares against `time.Now().UTC()`:

```go
birthDate: time.Now().AddDate(-14, 0, 0).Format("2006-01-02")   // local
// GetOver14: threshold at 00:00 UTC on that date, vs time.Now().UTC()
```

Whenever the local civil date runs ahead of UTC — in CEST, between midnight and 02:00 — the fixture says "born exactly 14 years ago today" while UTC is still on yesterday, so the helper correctly reports not-yet-14 and the test fails. I hit this at 01:48 CEST; it would have passed in CI's UTC regardless, which is part of why it went unnoticed.

Pinned both sides to UTC. **Verified in the failing window**: the tree is green here at 23:55 UTC / 01:55 CEST, which is exactly when it used to break.

## Scope note

This is a **test fix only** — `GetOverNN`'s semantics are untouched.

There is a real question underneath: `GetOverNN` evaluates against UTC, so someone in Sweden whose birthday is today is reported as not-yet-14 until 02:00 local. Whether an age gate should use UTC or civil local time is a policy decision rather than a defect, and it should not be settled quietly inside a CI change. Flagging it here rather than acting on it.

## Verification

- `make test-pkg` green.
- `make -n test` confirms `go test ./pkg/...` is now in the graph exactly once.
- Touches only `Makefile` and `pkg/model/generic_test.go` — no overlap with #614, #617 or #618.