### PR TITLE
Add native Vega ZK/PPID mdoc verification support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,31 +72,38 @@ jobs:
       # `make zk-native-lib`, which is a release-mode Rust build — cache it
       # on the resolved crate revision so only the first run after a bump
       # pays for it.
-      - name: Resolve the zk-cred-longfellow revision
+      - name: Resolve the native ZK crate revisions
         id: crate
         run: |
           set -euo pipefail
-          repo=https://github.com/sirosfoundation/zk-cred-longfellow.git
-          ref="${ZK_CRED_LONGFELLOW_REF:-main}"
-          if printf '%s' "$ref" | grep -Eiq '^[0-9a-f]{40}$'; then
-            # The Makefile accepts a raw commit SHA (and pinning the ref to
-            # one is the intended direction), but `git ls-remote` does not
-            # resolve a SHA - it would return nothing. Use it as-is.
-            sha="$ref"
-          else
-            refs=$(git ls-remote "$repo" "$ref")
-            # An annotated tag resolves to two lines; the peeled "^{}" entry
-            # is the commit `git checkout FETCH_HEAD` actually lands on.
-            sha=$(printf '%s\n' "$refs" | awk '$2 ~ /\^\{\}$/ { print $1; exit }')
-            [ -n "$sha" ] || sha=$(printf '%s\n' "$refs" | awk 'NR==1 { print $1 }')
-          fi
-          # Also guarantees a single-line value, so GITHUB_OUTPUT cannot be
-          # corrupted by an unexpected ls-remote result.
-          if ! printf '%s' "$sha" | grep -Eiq '^[0-9a-f]{40}$'; then
-            echo "::error::could not resolve zk-cred-longfellow ref '$ref'"
-            exit 1
-          fi
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          # Both crates are fetched and built from source by their Makefile
+          # targets, and both are cached on the resolved revision, so both
+          # need resolving the same way. One step rather than two so the
+          # ls-remote handling below exists once.
+          resolve() {
+            local name="$1" repo="$2" ref="$3" sha refs
+            if printf '%s' "$ref" | grep -Eiq '^[0-9a-f]{40}$'; then
+              # The Makefile accepts a raw commit SHA (and pinning the ref to
+              # one is the intended direction), but `git ls-remote` does not
+              # resolve a SHA - it would return nothing. Use it as-is.
+              sha="$ref"
+            else
+              refs=$(git ls-remote "$repo" "$ref")
+              # An annotated tag resolves to two lines; the peeled "^{}" entry
+              # is the commit `git checkout FETCH_HEAD` actually lands on.
+              sha=$(printf '%s\n' "$refs" | awk '$2 ~ /\^\{\}$/ { print $1; exit }')
+              [ -n "$sha" ] || sha=$(printf '%s\n' "$refs" | awk 'NR==1 { print $1 }')
+            fi
+            # Also guarantees a single-line value, so GITHUB_OUTPUT cannot be
+            # corrupted by an unexpected ls-remote result.
+            if ! printf '%s' "$sha" | grep -Eiq '^[0-9a-f]{40}$'; then
+              echo "::error::could not resolve $name ref '$ref'"
+              exit 1
+            fi
+            echo "$sha"
+          }
+          echo "sha=$(resolve zk-cred-longfellow https://github.com/sirosfoundation/zk-cred-longfellow.git "${ZK_CRED_LONGFELLOW_REF:-main}")" >> "$GITHUB_OUTPUT"
+          echo "vega_sha=$(resolve zk-cred-vega https://github.com/sirosfoundation/zk-cred-vega.git "${ZK_CRED_VEGA_REF:-main}")" >> "$GITHUB_OUTPUT"
 
       - name: Cache the built C ABI library
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -106,8 +113,21 @@ jobs:
             third_party/.zk-cred-longfellow-src/target
           key: zk-cred-longfellow-${{ runner.os }}-${{ steps.crate.outputs.sha }}
 
-      - name: Build the native library
-        run: make zk-native-lib
+      - name: Cache the built Vega C ABI library
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            third_party/zk-cred-vega
+            third_party/.zk-cred-vega-src/target
+          key: zk-cred-vega-${{ runner.os }}-${{ steps.crate.outputs.vega_sha }}
+
+      - name: Build the native libraries
+        # Both, not just Longfellow: pkg/mdoc/zknative_vega includes
+        # zk_cred_vega_go.h, so the zknative tag does not compile at all
+        # without the Vega library staged as well.
+        run: |
+          make zk-native-lib
+          make zk-native-lib-vega
 
       - name: Run the zknative-tagged tests
         run: make test-zknative
@@ -117,6 +137,12 @@ jobs:
       # never reach.
       - name: Build the verifier with the tag
         run: make build-verifier-zknative
+
+      # The Vega path runs in a separate process, so the verifier binary
+      # above links none of it - this is the only step that compiles and
+      # links the worker.
+      - name: Build the Vega verify worker
+        run: make build-zkvegaverifyworker
 
   # Same reasoning as the zknative job: pkg/bbs's cgo path is behind a build
   # tag, so without a job that sets it neither the cgo code nor its tests is

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,13 @@ bin/
 # zk-cred-longfellow checkout + staged Go C-ABI library/header, populated by
 # `make zk-native-lib`. Never committed - fetched/built on demand.
 /third_party/
+
+# zk-cred-vega's verifier-key test fixture (~105MB decompressed) - unlike
+# pkg/mdoc/testdata/zk_native's small Longfellow fixtures, this one is too
+# large to commit. Regenerate via `cargo test --release
+# go_ffi::tests::dump_golden_fixture_for_go_smoke_test -- --ignored` in a
+# zk-cred-vega checkout (see pkg/mdoc/zknative_vega/verifier_test.go).
+/pkg/mdoc/zknative_vega/testdata/
 pki/*
 !pki/create_pki.sh
 redis-data/

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,12 @@ ZK_CRED_VEGA_REF  ?= main
 ZK_CRED_VEGA_CHECKOUT := third_party/.zk-cred-vega-src
 ZK_CRED_VEGA_STAGE    := third_party/zk-cred-vega
 
+# Both libraries, always. The verifier binary links Longfellow, and it execs
+# zkvegaverifyworker, which links Vega and inherits this from it - so a path
+# carrying only one of them fails at load time for whichever half is missing,
+# and the Vega half fails in the subprocess where it is least obvious.
+ZKNATIVE_LD_PATH := $(CURDIR)/$(ZK_CRED_LONGFELLOW_STAGE)/lib:$(CURDIR)/$(ZK_CRED_VEGA_STAGE)/lib
+
 # bbsnative: blind BBS issuance (pkg/bbs), via cgo against zk-cred-bbs's
 # Go C-ABI build. Same opt-in shape and same reason as zknative above.
 # Unlike Longfellow, this one is needed on the ISSUER side: an issuer
@@ -346,7 +352,7 @@ zk-native-lib: ## Fetch/build zk-cred-longfellow's Go C-ABI library for native Z
 	cp "$(ZK_CRED_LONGFELLOW_CHECKOUT)/target/go-cabi/zk_cred_longfellow_go.h" "$(ZK_CRED_LONGFELLOW_STAGE)/include/"
 	cp "$(ZK_CRED_LONGFELLOW_CHECKOUT)/target/go-cabi"/libzk_cred_longfellow.* "$(ZK_CRED_LONGFELLOW_STAGE)/lib/"
 	@echo "Staged zk-cred-longfellow's Go C-ABI lib + header in $(ZK_CRED_LONGFELLOW_STAGE)"
-	@echo "Build/test with: CGO_ENABLED=1 LD_LIBRARY_PATH=\$$(pwd)/$(ZK_CRED_LONGFELLOW_STAGE)/lib go {build,test} -tags $(ZKNATIVE_TAG) ./..."
+	@echo "Build/test with: CGO_ENABLED=1 LD_LIBRARY_PATH=$(ZKNATIVE_LD_PATH) go {build,test} -tags $(ZKNATIVE_TAG) ./..."
 
 bbs-native-lib-staged: ## Fail with a useful message if zk-cred-bbs is not staged
 	@# Both halves, not just the archive: cgo needs the header to compile at
@@ -405,7 +411,7 @@ zk-native-lib-vega: ## Fetch/build zk-cred-vega's Go C-ABI library for native Ve
 
 test-zknative: ## Run pkg/mdoc's zknative-tagged tests (requires: make zk-native-lib zk-native-lib-vega)
 	$(info Testing with zknative build tag - requires 'make zk-native-lib zk-native-lib-vega' first)
-	CGO_ENABLED=1 LD_LIBRARY_PATH=$(CURDIR)/$(ZK_CRED_LONGFELLOW_STAGE)/lib:$(CURDIR)/$(ZK_CRED_VEGA_STAGE)/lib \
+	CGO_ENABLED=1 LD_LIBRARY_PATH=$(ZKNATIVE_LD_PATH) \
 		go test -tags $(ZKNATIVE_TAG) -v ./pkg/mdoc/...
 
 # DIDComm v2.1 Test targets
@@ -639,7 +645,7 @@ build-verifier-zknative: ## Build verifier with native ZK/PPID proof verificatio
 		CGO_LDFLAGS="-L$(CURDIR)/$(ZK_CRED_LONGFELLOW_STAGE)/lib -lzk_cred_longfellow" \
 		go build -tags $(ZKNATIVE_TAG) $(BUILD_FLAGS) -o ./bin/$(NAME)_verifier-zknative \
 		$(LDFLAGS_DYNAMIC) ./cmd/verifier/
-	@echo "Run with: LD_LIBRARY_PATH=$(CURDIR)/$(ZK_CRED_LONGFELLOW_STAGE)/lib ./bin/$(NAME)_verifier-zknative"
+	@echo "Run with: LD_LIBRARY_PATH=$(ZKNATIVE_LD_PATH) ./bin/$(NAME)_verifier-zknative"
 
 build-zkvegaverifyworker: ## Build the isolated Vega ZK-verify subprocess worker (requires: make zk-native-lib-vega)
 	$(info Building zkvegaverifyworker - requires 'make zk-native-lib-vega' first)
@@ -648,7 +654,7 @@ build-zkvegaverifyworker: ## Build the isolated Vega ZK-verify subprocess worker
 		CGO_LDFLAGS="-L$(CURDIR)/$(ZK_CRED_VEGA_STAGE)/lib -lzk_cred_vega" \
 		go build -tags $(ZKNATIVE_TAG) $(BUILD_FLAGS) -o ./bin/zkvegaverifyworker \
 		$(LDFLAGS_DYNAMIC) ./cmd/zkvegaverifyworker/
-	@echo "Run the verifier with: PATH=$(CURDIR)/bin:\$$PATH LD_LIBRARY_PATH=$(CURDIR)/$(ZK_CRED_VEGA_STAGE)/lib ./bin/$(NAME)_verifier-zknative"
+	@echo "Run the verifier with: PATH=$(CURDIR)/bin:\$$PATH LD_LIBRARY_PATH=$(ZKNATIVE_LD_PATH) ./bin/$(NAME)_verifier-zknative"
 	@echo "(zkvegaverifyworker resolves via PATH by default - see ZkVerifierConfig.VegaWorkerPath to override)"
 
 # ==============================================================================

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,21 @@ ZK_CRED_LONGFELLOW_REF  ?= main
 ZK_CRED_LONGFELLOW_CHECKOUT := third_party/.zk-cred-longfellow-src
 ZK_CRED_LONGFELLOW_STAGE    := third_party/zk-cred-longfellow
 
+# Vega (zk-cred-vega): a second native ZK system, alongside Longfellow -
+# see pkg/mdoc/zknative_vega's own package doc and
+# docs/ZK_PPID_VERIFICATION_PLAN.md. Reuses ZKNATIVE_TAG (CGO_ENABLED=1 +
+# native libs staged, not "Longfellow specifically") - both crates' shared
+# libraries coexist under third_party/ in separate subdirs. Unlike
+# Longfellow, the cgo call itself is NEVER linked into the main verifier
+# binary - only into the standalone cmd/zkvegaverifyworker (see that
+# command's own doc for the subprocess-isolation rationale), so
+# build-verifier-zknative below needs no Vega-specific flags at all; only
+# test-zknative and build-zkvegaverifyworker do.
+ZK_CRED_VEGA_REPO ?= https://github.com/sirosfoundation/zk-cred-vega.git
+ZK_CRED_VEGA_REF  ?= main
+ZK_CRED_VEGA_CHECKOUT := third_party/.zk-cred-vega-src
+ZK_CRED_VEGA_STAGE    := third_party/zk-cred-vega
+
 # bbsnative: blind BBS issuance (pkg/bbs), via cgo against zk-cred-bbs's
 # Go C-ABI build. Same opt-in shape and same reason as zknative above.
 # Unlike Longfellow, this one is needed on the ISSUER side: an issuer
@@ -157,8 +172,10 @@ help: ## Show this help message
 	$(info   make zk-native-lib            - Fetch/build zk-cred-longfellow's Go C-ABI lib for native ZK/PPID verification)
 	$(info   make bbs-native-lib           - Fetch/build zk-cred-bbs's Go C-ABI lib for blind BBS issuance)
 	$(info   make test-bbsnative           - Run pkg/bbs's bbsnative-tagged tests (requires bbs-native-lib))
+	$(info   make zk-native-lib-vega       - Fetch/build zk-cred-vega's Go C-ABI lib for native Vega ZK verification)
 	$(info   make build-verifier-zknative  - Build verifier with native ZK/PPID proof verification (requires zk-native-lib))
-	$(info   make test-zknative            - Run pkg/mdoc's zknative-tagged tests (requires zk-native-lib))
+	$(info   make build-zkvegaverifyworker - Build the isolated Vega ZK-verify subprocess worker (requires zk-native-lib-vega))
+	$(info   make test-zknative            - Run pkg/mdoc's zknative-tagged tests (requires zk-native-lib zk-native-lib-vega))
 	$(info )
 	$(info OpenID Conformance Suite:)
 	$(info   make oidc-conformance-setup      - Start conformance suite)
@@ -365,9 +382,30 @@ test-bbsnative: ## Run pkg/bbs's bbsnative-tagged tests (requires: make bbs-nati
 	CGO_ENABLED=1 LD_LIBRARY_PATH=$(CURDIR)/$(ZK_CRED_BBS_STAGE)/lib \
 		go test -tags $(BBSNATIVE_TAG) -v ./pkg/bbs/...
 
-test-zknative: ## Run pkg/mdoc's zknative-tagged tests (requires: make zk-native-lib)
-	$(info Testing with zknative build tag - requires 'make zk-native-lib' first)
-	CGO_ENABLED=1 LD_LIBRARY_PATH=$(CURDIR)/$(ZK_CRED_LONGFELLOW_STAGE)/lib \
+# Same shape as zk-native-lib above, for zk-cred-vega instead - see that
+# target's own doc comment for the fetch/build/stage mechanics (identical
+# here, just a different crate/stage directory). Only needed for `make
+# test-zknative` and `make build-zkvegaverifyworker`; NOT for
+# build-verifier-zknative (see this file's Vega variable block above for
+# why).
+zk-native-lib-vega: ## Fetch/build zk-cred-vega's Go C-ABI library for native Vega ZK verification
+	$(info Fetching/building zk-cred-vega's go-cabi target from $(ZK_CRED_VEGA_REPO)@$(ZK_CRED_VEGA_REF))
+	@if [ ! -d "$(ZK_CRED_VEGA_CHECKOUT)/.git" ]; then \
+		mkdir -p "$(ZK_CRED_VEGA_CHECKOUT)" && \
+		git -C "$(ZK_CRED_VEGA_CHECKOUT)" init -q && \
+		git -C "$(ZK_CRED_VEGA_CHECKOUT)" remote add origin "$(ZK_CRED_VEGA_REPO)"; \
+	fi
+	git -C "$(ZK_CRED_VEGA_CHECKOUT)" fetch --depth 1 origin "$(ZK_CRED_VEGA_REF)"
+	git -C "$(ZK_CRED_VEGA_CHECKOUT)" checkout FETCH_HEAD
+	$(MAKE) -C "$(ZK_CRED_VEGA_CHECKOUT)" go-cabi
+	@mkdir -p "$(ZK_CRED_VEGA_STAGE)/include" "$(ZK_CRED_VEGA_STAGE)/lib"
+	cp "$(ZK_CRED_VEGA_CHECKOUT)/target/go-cabi/zk_cred_vega_go.h" "$(ZK_CRED_VEGA_STAGE)/include/"
+	cp "$(ZK_CRED_VEGA_CHECKOUT)/target/go-cabi"/libzk_cred_vega.* "$(ZK_CRED_VEGA_STAGE)/lib/"
+	@echo "Staged zk-cred-vega's Go C-ABI lib + header in $(ZK_CRED_VEGA_STAGE)"
+
+test-zknative: ## Run pkg/mdoc's zknative-tagged tests (requires: make zk-native-lib zk-native-lib-vega)
+	$(info Testing with zknative build tag - requires 'make zk-native-lib zk-native-lib-vega' first)
+	CGO_ENABLED=1 LD_LIBRARY_PATH=$(CURDIR)/$(ZK_CRED_LONGFELLOW_STAGE)/lib:$(CURDIR)/$(ZK_CRED_VEGA_STAGE)/lib \
 		go test -tags $(ZKNATIVE_TAG) -v ./pkg/mdoc/...
 
 # DIDComm v2.1 Test targets
@@ -602,6 +640,16 @@ build-verifier-zknative: ## Build verifier with native ZK/PPID proof verificatio
 		go build -tags $(ZKNATIVE_TAG) $(BUILD_FLAGS) -o ./bin/$(NAME)_verifier-zknative \
 		$(LDFLAGS_DYNAMIC) ./cmd/verifier/
 	@echo "Run with: LD_LIBRARY_PATH=$(CURDIR)/$(ZK_CRED_LONGFELLOW_STAGE)/lib ./bin/$(NAME)_verifier-zknative"
+
+build-zkvegaverifyworker: ## Build the isolated Vega ZK-verify subprocess worker (requires: make zk-native-lib-vega)
+	$(info Building zkvegaverifyworker - requires 'make zk-native-lib-vega' first)
+	$(CGO_ENABLED_DYNAMIC) GOOS=$(BUILD_OS) GOARCH=$(BUILD_ARCH) \
+		CGO_CFLAGS="-I$(CURDIR)/$(ZK_CRED_VEGA_STAGE)/include" \
+		CGO_LDFLAGS="-L$(CURDIR)/$(ZK_CRED_VEGA_STAGE)/lib -lzk_cred_vega" \
+		go build -tags $(ZKNATIVE_TAG) $(BUILD_FLAGS) -o ./bin/zkvegaverifyworker \
+		$(LDFLAGS_DYNAMIC) ./cmd/zkvegaverifyworker/
+	@echo "Run the verifier with: PATH=$(CURDIR)/bin:\$$PATH LD_LIBRARY_PATH=$(CURDIR)/$(ZK_CRED_VEGA_STAGE)/lib ./bin/$(NAME)_verifier-zknative"
+	@echo "(zkvegaverifyworker resolves via PATH by default - see ZkVerifierConfig.VegaWorkerPath to override)"
 
 # ==============================================================================
 # Docker Build Targets

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Optional features are enabled via Go build tags. The following tags are availabl
 | `saml,oidcrp` | All optional apigw features    | apigw               | static      | `make build-apigw-all`        |
 | `pkcs11`      | PKCS#11 HSM signing            | issuer              | **dynamic** | `make build-issuer-hsm`       |
 | `vc20`        | W3C Verifiable Credentials 2.0 | vc20-test-server    | static      | `make build-vc20-test-server` |
-| `zknative`    | Native ZK/PPID proof verification (mso_mdoc_zk) | verifier | **dynamic** | `make build-verifier-zknative` |
+| `zknative`    | Native ZK/PPID proof verification (mso_mdoc_zk) - Longfellow + Vega | verifier | **dynamic** | `make build-verifier-zknative` (+ `make build-zkvegaverifyworker` for Vega) |
 
 > **Note:** The `pkcs11` and `zknative` tags require CGO (`CGO_ENABLED=1`) and produce dynamically linked binaries. See "Native ZK/PPID proof verification" below for `zknative` setup.
 
@@ -260,46 +260,77 @@ Set the image version with `VERSION=x.x.x` (default: `latest`).
 
 ### Native ZK/PPID proof verification
 
-vc-verifier can verify "mso_mdoc_zk" presentations (zero-knowledge
-Longfellow proof-of-possession, with an optional pairwise pseudonym over an
-mdoc credential) natively, via a cgo binding to
-[zk-cred-longfellow](https://github.com/sirosfoundation/zk-cred-longfellow)'s
-plain C-ABI Go verifier build. This is **opt-in** (the `zknative` build
-tag) - the default `make build-verifier`/Docker build stays
-`CGO_ENABLED=0` and fully static, exactly like the `pkcs11` tag above, and
-for the same reason: cgo requires a C compiler/linker and a locally built
-shared library that a static build has no use for.
+vc-verifier can verify "mso_mdoc_zk" presentations natively for **two**
+independent ZK systems, both **opt-in** via the `zknative` build tag (the
+default `make build-verifier`/Docker build stays `CGO_ENABLED=0` and
+fully static, exactly like the `pkcs11` tag above):
+
+- **Longfellow** - zero-knowledge proof-of-possession with an optional
+  pairwise pseudonym, via a cgo binding to
+  [zk-cred-longfellow](https://github.com/sirosfoundation/zk-cred-longfellow)'s
+  plain C-ABI Go verifier build, linked directly into the main verifier
+  process (`pkg/mdoc/zknative`).
+- **Vega** - a second, general-purpose ZK circuit backend
+  ([zk-cred-vega](https://github.com/sirosfoundation/zk-cred-vega)),
+  currently only publishing an mdoc circuit but designed for a wider
+  range of provable statements over time. Unlike Longfellow, Vega's cgo
+  binding (`pkg/mdoc/zknative_vega`) is **never linked into the main
+  verifier process** - it's linked only into a small standalone
+  `cmd/zkvegaverifyworker` subprocess binary, which the verifier execs
+  per-call over stdin/stdout. This isolates the actual cgo call touching
+  attacker-controlled proof bytes: a memory-safety fault in the native
+  library takes down one worker process, not the verifier serving other
+  in-flight requests. See `pkg/mdoc/zkvegaworker`'s package doc for the
+  wire protocol and `docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md` for a real
+  wire-format addition Vega's verification needed (flagged there, not yet
+  raised with multipaz upstream).
 
 Setup:
 
 ```sh
-# 1. Clone + build zk-cred-longfellow's `go-cabi` target, staging the
-#    resulting shared library + header under third_party/zk-cred-longfellow/
-#    (gitignored - never committed). Override ZK_CRED_LONGFELLOW_REPO/_REF
-#    to build a fork or pin a specific tag, branch, OR commit SHA - the
-#    target fetches whichever ref is given directly (`git fetch --depth 1
-#    origin $(REF)`), which works for all three ref types.
-make zk-native-lib
+# 1. Clone + build both crates' `go-cabi` targets, staging the resulting
+#    shared libraries + headers under third_party/ (gitignored - never
+#    committed). Override ZK_CRED_LONGFELLOW_REPO/_REF or
+#    ZK_CRED_VEGA_REPO/_REF to build a fork or pin a specific tag, branch,
+#    OR commit SHA - each target fetches whichever ref is given directly
+#    (`git fetch --depth 1 origin $(REF)`), which works for all three ref
+#    types.
+make zk-native-lib        # Longfellow
+make zk-native-lib-vega   # Vega
 
-# 2. Build the verifier with native ZK/PPID verification.
+# 2. Build the verifier (links Longfellow only - see above for why Vega
+#    doesn't need to be here) and, separately, the Vega worker subprocess.
 make build-verifier-zknative
+make build-zkvegaverifyworker
 
-# 3. Run it (needs the shared library on the loader path).
-LD_LIBRARY_PATH=$(pwd)/third_party/zk-cred-longfellow/lib ./bin/vc_verifier-zknative
+# 3. Run the verifier - it needs Longfellow's shared library on the
+#    loader path, and zkvegaverifyworker's binary somewhere on PATH (or
+#    point ZkVerifierConfig.VegaWorkerPath at it directly).
+LD_LIBRARY_PATH=$(pwd)/third_party/zk-cred-longfellow/lib \
+  PATH=$(pwd)/bin:$PATH \
+  ./bin/vc_verifier-zknative
 
-# ...or run pkg/mdoc's zknative-tagged tests directly:
+# ...or run pkg/mdoc's zknative-tagged tests directly (covers both
+# systems - the Vega package's own cgo tests need its library staged
+# too, via LD_LIBRARY_PATH, even though the verifier binary itself
+# doesn't link it):
 make test-zknative
 ```
 
 Configuration: the circuit catalog service vc-verifier fetches circuits
 from is configurable via `verifier.zk_circuits.sources` in YAML config
 (defaults to the live `https://zk-circuits.fly.dev` service if unset) -
-see `docs/CONFIGURATION.md`'s `zk_circuits` section.
+see `docs/CONFIGURATION.md`'s `zk_circuits` section. This applies to both
+systems; Vega additionally resolves a verifier-key catalog entry from the
+wallet-declared prover-key entry via the manifest (see
+`getOrLoadVegaVerifierKey`'s doc comment in `pkg/mdoc/zk_native_cgo_vega.go`).
 
-See `docs/ZK_PPID_VERIFICATION_PLAN.md` for the full design writeup: what
-this verifies, the confirmed `verifier_context`/pseudonym-derivation wire
-formula, and exactly what's still out of scope (the W3C Digital
-Credentials API and older OpenID4VP session-transcript variants).
+See `docs/ZK_PPID_VERIFICATION_PLAN.md` for the full Longfellow design
+writeup: what this verifies, the confirmed
+`verifier_context`/pseudonym-derivation wire formula, and exactly what's
+still out of scope (the W3C Digital Credentials API and older OpenID4VP
+session-transcript variants - both apply to Vega too, which has no
+pseudonym concept of its own yet either).
 
 ## Start, Stop & Restart
 
@@ -320,7 +351,7 @@ Credentials API and older OpenID4VP session-transcript variants).
 | `make test-oidcrp`   | Test with `oidcrp` build tag                                  |
 | `make test-vc20`     | Test with `vc20` build tag                                    |
 | `make test-pkcs11`   | Test with `pkcs11` build tag (requires `make test-env`)       |
-| `make test-zknative` | Test with `zknative` build tag (requires `make zk-native-lib`) |
+| `make test-zknative` | Test with `zknative` build tag (requires `make zk-native-lib zk-native-lib-vega`) |
 | `make test-all-tags` | Test with all build tags                                      |
 | `make test-env`      | Install test dependencies (softhsm2, opensc)                  |
 

--- a/README.md
+++ b/README.md
@@ -303,17 +303,18 @@ make zk-native-lib-vega   # Vega
 make build-verifier-zknative
 make build-zkvegaverifyworker
 
-# 3. Run the verifier - it needs Longfellow's shared library on the
-#    loader path, and zkvegaverifyworker's binary somewhere on PATH (or
-#    point ZkVerifierConfig.VegaWorkerPath at it directly).
-LD_LIBRARY_PATH=$(pwd)/third_party/zk-cred-longfellow/lib \
+# 3. Run the verifier. Both shared libraries need to be on the loader
+#    path - the verifier binary links Longfellow, and it execs
+#    zkvegaverifyworker, which links Vega and inherits this environment.
+#    The worker's binary also needs to be on PATH (or point
+#    ZkVerifierConfig.VegaWorkerPath at it directly).
+LD_LIBRARY_PATH=$(pwd)/third_party/zk-cred-longfellow/lib:$(pwd)/third_party/zk-cred-vega/lib \
   PATH=$(pwd)/bin:$PATH \
   ./bin/vc_verifier-zknative
 
 # ...or run pkg/mdoc's zknative-tagged tests directly (covers both
-# systems - the Vega package's own cgo tests need its library staged
-# too, via LD_LIBRARY_PATH, even though the verifier binary itself
-# doesn't link it):
+# systems; make test-zknative sets the loader path for both libraries
+# itself):
 make test-zknative
 ```
 

--- a/cmd/zkvegaverifyworker/main.go
+++ b/cmd/zkvegaverifyworker/main.go
@@ -64,7 +64,7 @@ func verify(req zkvegaworker.Request) (*zkvegaworker.VerifyResult, error) {
 	}
 	defer vk.Close()
 
-	result, err := vk.Verify(req.ProofBytes)
+	result, err := vk.Verify(req.ProofBytes, req.DisclosedBytes)
 	if err != nil {
 		return nil, fmt.Errorf("verifying proof: %w", err)
 	}

--- a/cmd/zkvegaverifyworker/main.go
+++ b/cmd/zkvegaverifyworker/main.go
@@ -1,0 +1,115 @@
+//go:build zknative
+
+// Command zkvegaverifyworker is a small, standalone subprocess that links
+// pkg/mdoc/zknative_vega (zk-cred-vega's cgo Go C-ABI binding) so the main
+// vc-verifier process never has to. See pkg/mdoc/zkvegaworker's package
+// doc for the full rationale (an isolated-subprocess mitigation for the
+// cgo marshaling shim processing attacker-controlled proof bytes) and wire
+// protocol.
+//
+// Reads exactly one zkvegaworker.Request as JSON from stdin, verifies it,
+// writes exactly one zkvegaworker.Response as JSON to stdout, and exits:
+// 0 on a successful verify (Response.Result set), 1 on any failure
+// (Response.Error set - malformed request, bad verifier key, or a
+// rejected/tampered proof are all reported the same way over stdout; only
+// the exit code distinguishes "something went wrong" for a caller that
+// doesn't parse stdout).
+//
+// Built only with the "zknative" tag (same convention as
+// pkg/mdoc/zknative_vega itself) - see the Makefile's
+// `build-zkvegaverifyworker` target.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/SUNET/vc/pkg/mdoc/zknative_vega"
+	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
+)
+
+func main() {
+	os.Exit(run())
+}
+
+// run does the real work and returns a process exit code, rather than
+// calling os.Exit directly at every failure point - keeps every deferred
+// Close() actually running (os.Exit skips deferred calls) and keeps this
+// testable as an ordinary function.
+func run() int {
+	reqBytes, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fail(fmt.Errorf("reading request from stdin: %w", err))
+	}
+
+	var req zkvegaworker.Request
+	if err := json.Unmarshal(reqBytes, &req); err != nil {
+		return fail(fmt.Errorf("parsing request JSON: %w", err))
+	}
+
+	result, err := verify(req)
+	if err != nil {
+		return fail(err)
+	}
+
+	return succeed(result)
+}
+
+func verify(req zkvegaworker.Request) (*zkvegaworker.VerifyResult, error) {
+	vk, err := zknative_vega.NewVerifierKey(req.VerifierKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("loading verifier key: %w", err)
+	}
+	defer vk.Close()
+
+	result, err := vk.Verify(req.ProofBytes)
+	if err != nil {
+		return nil, fmt.Errorf("verifying proof: %w", err)
+	}
+
+	claims := make([]zkvegaworker.DisclosedClaim, len(result.Claims))
+	for i, c := range result.Claims {
+		claims[i] = zkvegaworker.DisclosedClaim{
+			Disclosed: c.Disclosed,
+			Digest:    c.Digest[:],
+			RealLen:   c.RealLen,
+			Plaintext: c.Plaintext,
+			DigestID:  c.DigestID,
+		}
+	}
+
+	return &zkvegaworker.VerifyResult{
+		Qx:           result.Qx[:],
+		Qy:           result.Qy[:],
+		Claims:       claims,
+		DeviceX:      result.DeviceX[:],
+		DeviceY:      result.DeviceY[:],
+		SignedTs:     result.SignedTs[:],
+		ValidFromTs:  result.ValidFromTs[:],
+		ValidUntilTs: result.ValidUntilTs[:],
+	}, nil
+}
+
+func succeed(result *zkvegaworker.VerifyResult) int {
+	resp := zkvegaworker.Response{Result: result}
+	if err := writeResponse(resp); err != nil {
+		fmt.Fprintln(os.Stderr, "zkvegaverifyworker: failed to write response:", err)
+		return 1
+	}
+	return 0
+}
+
+func fail(err error) int {
+	resp := zkvegaworker.Response{Error: err.Error()}
+	if writeErr := writeResponse(resp); writeErr != nil {
+		fmt.Fprintln(os.Stderr, "zkvegaverifyworker: failed to write error response:", writeErr)
+	}
+	return 1
+}
+
+func writeResponse(resp zkvegaworker.Response) error {
+	enc := json.NewEncoder(os.Stdout)
+	return enc.Encode(resp)
+}

--- a/dockerfiles/verifier-zknative
+++ b/dockerfiles/verifier-zknative
@@ -1,0 +1,103 @@
+# Dockerfile for the "zknative" native ZK/PPID verifier build (Longfellow +
+# Vega) - see README.md's "Native ZK/PPID proof verification" section and
+# docs/ZK_PPID_VERIFICATION_PLAN.md.
+#
+# Deliberately NOT based on dockerfiles/worker: that Dockerfile always
+# passes `--extldflags '-static'`, which is fine for the pkcs11 build
+# (dlopen's an HSM driver at runtime, unrelated to link-time linking) but
+# incompatible with this build - zk-cred-longfellow's cgo binding links
+# directly against libzk_cred_longfellow.so at link time, which a fully
+# static executable cannot do. This mirrors the Makefile's own
+# build-verifier-zknative target, which already uses LDFLAGS_DYNAMIC
+# (`-w -s`, no `-static`) instead of the default LDFLAGS for exactly this
+# reason.
+#
+# EARLY-TESTING SHORTCUT (see this repo's own Phase 5 notes): this
+# Dockerfile expects the native libraries to already be staged under
+# third_party/{zk-cred-longfellow,zk-cred-vega}/{include,lib} in the BUILD
+# CONTEXT (i.e. `make zk-native-lib zk-native-lib-vega` already run on the
+# host before `docker build`), rather than building them fresh from source
+# inside this Dockerfile. A production version of this Dockerfile should
+# add a builder stage that runs those make targets itself (needs a Rust
+# toolchain) for full reproducibility; that's explicitly deferred here to
+# keep this one-off test deployment simple.
+#
+# The runtime stage uses a glibc base (debian:bookworm-slim), NOT Alpine
+# (musl libc) like dockerfiles/worker - the native .so files here are
+# built against glibc, and Alpine's musl libc cannot load them.
+
+ARG GOBUILD_IMAGE=golang:1.26.6
+FROM ${GOBUILD_IMAGE} AS gobuild
+WORKDIR /go/src/app
+COPY Makefile .
+RUN make install-tools
+RUN make clean-apt-cache
+
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM gobuild AS builder
+
+ARG BUILDTAG
+
+ENV GOTOOLCHAIN=local
+ENV GOFLAGS=-mod=vendor
+ENV GOPROXY=off
+ENV GONOSUMDB=*
+ENV GONOSUMCHECK=*
+
+COPY . .
+
+RUN make swagger-verifier swagger-fmt
+RUN make proto-verifier
+
+ARG TARGETARCH=amd64
+ENV CGO_ENABLED=1
+ENV CGO_CFLAGS="-I/go/src/app/third_party/zk-cred-longfellow/include -I/go/src/app/third_party/zk-cred-vega/include"
+ENV CGO_LDFLAGS="-L/go/src/app/third_party/zk-cred-longfellow/lib -L/go/src/app/third_party/zk-cred-vega/lib -lzk_cred_longfellow -lzk_cred_vega"
+
+# The verifier binary itself only ever links Longfellow's cgo binding -
+# see nativeVerifyZkProofVega's own doc comment for why Vega's is confined
+# to the separate zkvegaverifyworker binary below instead. Harmless that
+# CGO_LDFLAGS above names both libraries for this build: an unused
+# -l flag is not an error, and keeping one shared CGO_CFLAGS/LDFLAGS
+# environment for both `go build` invocations in this Dockerfile is
+# simpler than threading two different sets through.
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    go build -v -tags zknative -o bin/vc_verifier -ldflags \
+    "-X vc/pkg/model.BuildVariableGitCommit=$(git rev-list -1 HEAD) \
+    -X vc/pkg/model.BuildVariableGitBranch=$(git rev-parse --abbrev-ref HEAD) \
+    -X vc/pkg/model.BuildVariableTimestamp=$(date +'%F:T%TZ') \
+    -X vc/pkg/model.BuildVariableGoVersion=$(go version|awk '{print $3}') \
+    -X vc/pkg/model.BuildVariableGoArch=$(go version|awk '{print $4}') \
+    -X vc/pkg/model.BuildVersion=$(echo $BUILDTAG) \
+    -w -s" ./cmd/verifier
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    go build -v -tags zknative -o bin/zkvegaverifyworker -ldflags "-w -s" ./cmd/zkvegaverifyworker
+
+# Deploy — glibc base required for the native .so files (see top-of-file note).
+FROM debian:bookworm-slim
+
+WORKDIR /
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r vcservice && useradd -r -g vcservice vcservice
+
+COPY --from=builder /go/src/app/bin/vc_verifier /vc_service
+COPY --from=builder /go/src/app/bin/zkvegaverifyworker /usr/local/bin/zkvegaverifyworker
+COPY --from=builder /go/src/app/docs /docs
+COPY --from=builder /go/src/app/standards /standards
+COPY --from=builder /go/src/app/third_party/zk-cred-longfellow/lib/libzk_cred_longfellow.so /usr/lib/libzk_cred_longfellow.so
+COPY --from=builder /go/src/app/third_party/zk-cred-vega/lib/libzk_cred_vega.so /usr/lib/libzk_cred_vega.so
+RUN ldconfig
+
+EXPOSE 8080
+
+USER vcservice
+
+HEALTHCHECK --interval=20s --timeout=10s CMD curl -k --connect-timeout 5 https://localhost:8080/health | grep -q STATUS_OK
+
+CMD [ "./vc_service" ]

--- a/dockerfiles/verifier-zknative
+++ b/dockerfiles/verifier-zknative
@@ -51,18 +51,24 @@ RUN make proto-verifier
 
 ARG TARGETARCH=amd64
 ENV CGO_ENABLED=1
-ENV CGO_CFLAGS="-I/go/src/app/third_party/zk-cred-longfellow/include -I/go/src/app/third_party/zk-cred-vega/include"
-ENV CGO_LDFLAGS="-L/go/src/app/third_party/zk-cred-longfellow/lib -L/go/src/app/third_party/zk-cred-vega/lib -lzk_cred_longfellow -lzk_cred_vega"
-
-# The verifier binary itself only ever links Longfellow's cgo binding -
-# see nativeVerifyZkProofVega's own doc comment for why Vega's is confined
-# to the separate zkvegaverifyworker binary below instead. Harmless that
-# CGO_LDFLAGS above names both libraries for this build: an unused
-# -l flag is not an error, and keeping one shared CGO_CFLAGS/LDFLAGS
-# environment for both `go build` invocations in this Dockerfile is
-# simpler than threading two different sets through.
+# Each binary is built against only the library it actually uses, rather
+# than one shared environment naming both.
+#
+# The verifier links Longfellow's cgo binding only - Vega's is confined to
+# the zkvegaverifyworker binary below, which is the whole point: a
+# memory-safety fault in the Vega library takes down one short-lived
+# subprocess instead of the process serving other requests (see
+# nativeVerifyZkProofVega's own doc comment). The Go side already
+# guarantees this - `go list -tags zknative -deps ./pkg/mdoc` names
+# pkg/mdoc/zknative and not zknative_vega - but passing -lzk_cred_vega to
+# the verifier's link step left that guarantee resting on the linker
+# dropping an unreferenced -l via --as-needed. Without it the verifier
+# would carry a DT_NEEDED on libzk_cred_vega.so and map it into its own
+# address space, which is exactly what the subprocess exists to avoid.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
+    CGO_CFLAGS="-I/go/src/app/third_party/zk-cred-longfellow/include" \
+    CGO_LDFLAGS="-L/go/src/app/third_party/zk-cred-longfellow/lib -lzk_cred_longfellow" \
     go build -v -tags zknative -o bin/vc_verifier -ldflags \
     "-X vc/pkg/model.BuildVariableGitCommit=$(git rev-list -1 HEAD) \
     -X vc/pkg/model.BuildVariableGitBranch=$(git rev-parse --abbrev-ref HEAD) \
@@ -74,6 +80,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
+    CGO_CFLAGS="-I/go/src/app/third_party/zk-cred-vega/include" \
+    CGO_LDFLAGS="-L/go/src/app/third_party/zk-cred-vega/lib -lzk_cred_vega" \
     go build -v -tags zknative -o bin/zkvegaverifyworker -ldflags "-w -s" ./cmd/zkvegaverifyworker
 
 # Deploy — glibc base required for the native .so files (see top-of-file note).

--- a/dockerfiles/verifier-zknative
+++ b/dockerfiles/verifier-zknative
@@ -49,7 +49,6 @@ COPY . .
 RUN make swagger-verifier swagger-fmt
 RUN make proto-verifier
 
-ARG TARGETARCH=amd64
 ENV CGO_ENABLED=1
 # Each binary is built against only the library it actually uses, rather
 # than one shared environment naming both.

--- a/dockerfiles/verifier-zknative
+++ b/dockerfiles/verifier-zknative
@@ -26,7 +26,7 @@
 # (musl libc) like dockerfiles/worker - the native .so files here are
 # built against glibc, and Alpine's musl libc cannot load them.
 
-ARG GOBUILD_IMAGE=golang:1.26.6
+ARG GOBUILD_IMAGE=golang:1.27.0
 FROM ${GOBUILD_IMAGE} AS gobuild
 WORKDIR /go/src/app
 COPY Makefile .

--- a/dockerfiles/verifier-zknative
+++ b/dockerfiles/verifier-zknative
@@ -72,7 +72,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -v -tags zknative -o bin/vc_verifier -ldflags \
     "-X vc/pkg/model.BuildVariableGitCommit=$(git rev-list -1 HEAD) \
     -X vc/pkg/model.BuildVariableGitBranch=$(git rev-parse --abbrev-ref HEAD) \
-    -X vc/pkg/model.BuildVariableTimestamp=$(date +'%F:T%TZ') \
+    -X vc/pkg/model.BuildVariableTimestamp=$(date -u +'%FT%TZ') \
     -X vc/pkg/model.BuildVariableGoVersion=$(go version|awk '{print $3}') \
     -X vc/pkg/model.BuildVariableGoArch=$(go version|awk '{print $4}') \
     -X vc/pkg/model.BuildVersion=$(echo $BUILDTAG) \

--- a/dockerfiles/verifier-zknative
+++ b/dockerfiles/verifier-zknative
@@ -69,12 +69,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_CFLAGS="-I/go/src/app/third_party/zk-cred-longfellow/include" \
     CGO_LDFLAGS="-L/go/src/app/third_party/zk-cred-longfellow/lib -lzk_cred_longfellow" \
     go build -v -tags zknative -o bin/vc_verifier -ldflags \
-    "-X vc/pkg/model.BuildVariableGitCommit=$(git rev-list -1 HEAD) \
-    -X vc/pkg/model.BuildVariableGitBranch=$(git rev-parse --abbrev-ref HEAD) \
-    -X vc/pkg/model.BuildVariableTimestamp=$(date -u +'%FT%TZ') \
-    -X vc/pkg/model.BuildVariableGoVersion=$(go version|awk '{print $3}') \
-    -X vc/pkg/model.BuildVariableGoArch=$(go version|awk '{print $4}') \
-    -X vc/pkg/model.BuildVersion=$(echo $BUILDTAG) \
+    "-X github.com/SUNET/vc/pkg/status.BuildVariableGitCommit=$(git rev-list -1 HEAD) \
+    -X github.com/SUNET/vc/pkg/status.BuildVariableGitBranch=$(git rev-parse --abbrev-ref HEAD) \
+    -X github.com/SUNET/vc/pkg/status.BuildVariableTimestamp=$(date -u +'%FT%TZ') \
+    -X github.com/SUNET/vc/pkg/status.BuildVariableGoVersion=$(go version|awk '{print $3}') \
+    -X github.com/SUNET/vc/pkg/status.BuildVariableGoArch=$(go version|awk '{print $4}') \
+    -X github.com/SUNET/vc/pkg/status.BuildVersion=$(echo $BUILDTAG) \
     -w -s" ./cmd/verifier
 
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/dockerfiles/worker
+++ b/dockerfiles/worker
@@ -52,7 +52,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH} go build -v ${GO_BUILD_TAGS:+-tags "$GO_BUILD_TAGS"} -o bin/vc_$SERVICE_NAME -ldflags \
     "-X github.com/SUNET/vc/pkg/status.BuildVariableGitCommit=$(git rev-list -1 HEAD) \
     -X github.com/SUNET/vc/pkg/status.BuildVariableGitBranch=$(git rev-parse --abbrev-ref HEAD) \
-    -X github.com/SUNET/vc/pkg/status.BuildVariableTimestamp=$(date +'%F:T%TZ') \
+    -X github.com/SUNET/vc/pkg/status.BuildVariableTimestamp=$(date -u +'%FT%TZ') \
     -X github.com/SUNET/vc/pkg/status.BuildVariableGoVersion=$(go version|awk '{print $3}') \
     -X github.com/SUNET/vc/pkg/status.BuildVariableGoArch=$(go version|awk '{print $4}') \
     -X github.com/SUNET/vc/pkg/status.BuildVersion=$(echo $BUILDTAG) \

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1230,11 +1230,13 @@ as the human-readable label.
 
 > **Path:** `.verifier.presets.<preset label>.credentials.<key>`
 
-| Field            | Type    | Description                                                     | Example | Default | Required |
-| ---------------- | ------- | --------------------------------------------------------------- | ------- | ------- | -------- |
-| `claims`         | `array` | Specific claims to request. If empty, all VCTM claims are used. | -       | -       | No       |
-| `exclude_claims` | `array` | Claims to exclude from the DCQL query.                          | -       | -       | No       |
-| `validations`    | `array` | Optional rules applied server-side after claims extraction      | -       | -       | No       |
+| Field            | Type     | Description                                                                                                                                                                                                                                                                    | Example | Default | Required |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------- | -------- |
+| `claims`         | `array`  | Specific claims to request. If empty, all VCTM claims are used.                                                                                                                                                                                                                | -       | -       | No       |
+| `exclude_claims` | `array`  | Claims to exclude from the DCQL query.                                                                                                                                                                                                                                         | -       | -       | No       |
+| `validations`    | `array`  | Optional rules applied server-side after claims extraction                                                                                                                                                                                                                     | -       | -       | No       |
+| `format`         | `string` | Format overrides the scope's own credential_metadata format (e.g. requesting "mso_mdoc_zk" - a zero-knowledge proof - over a scope whose credential_metadata format is the plain "mso_mdoc" it's actually issued as). Empty means use the scope's own format unchanged.        | -       | -       | No       |
+| `zk_system_type` | `array`  | ZKSystemType overrides meta.zk_system_type - required whenever Format is set to "mso_mdoc_zk" (openid4vp.FormatMsoMdocZk), since a ZK-mdoc DCQL query has no other way to say which proof system/circuit a verifier accepts. See openid4vp.ZKSystemTypeSpec's own doc comment. | -       | -       | No       |
 
 ### `claims` entry
 
@@ -1253,6 +1255,29 @@ as the human-readable label.
 | `rule`  | `string`   | Validation rule to apply, e.g., "age_over".     | `"age_over"`    | -       | Yes      |
 | `path`  | `[]string` | Claim path to validate, e.g., ["birthdate"].    | `["birthdate"]` | -       | Yes      |
 | `value` | `object`   | Threshold or expected value for the validation. | `18`            | -       | Yes      |
+
+### `zk_system_type` entry
+
+> **Path:** `.verifier.presets.<preset label>.<scope>.zk_system_type[]`
+
+array — a verifier's declaration of one ZK proof system + circuit variant
+it is willing to accept, mirroring multipaz's `ZkSystemSpec` wire shape
+(`{"id": ..., "system": ..., ...params}`, e.g.
+`{"id": "longfellow-libzk-v1_8_1_4259_2945", "system": "longfellow-libzk-v1",
+"num_attributes": 1, "circuit_hash": "...", "block_enc_hash": ...,
+"block_enc_sig": ...}`).
+
+Params is a flat string->string bag (all non-id/system JSON members of the
+wire object). Numeric wire values (e.g. num_attributes, block_enc_hash)
+are carried through as their JSON text representation - callers that need
+a specific field as an int/int64 should parse it themselves. This mirrors
+the DCQL CredentialQuery model overall: format-specific "meta" properties
+are intentionally loosely typed at this layer.
+
+| Field    | Type     | Description                                                                                                                                                                                                                                                                                                                                                           | Example | Default | Required |
+| -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------- | -------- |
+| `id`     | `string` | ID identifies this specific system+circuit combination (e.g. "longfellow-libzk-v1_8_1_4259_2945"). A presented ZK document's own `zkSystemId` (pkg/mdoc.ZkDocumentDataMdoc.ZkSystemID) is expected to equal one of a request's ZKSystemType[].ID entries - this is how a verifier confirms the wallet actually used a circuit it offered, rather than some other one. | -       | -       | Yes      |
+| `system` | `string` | ZK proof system identifier (e.g. "longfellow-libzk-v1"). Params other than "id"/"system" are format-specific (circuit_hash, num_attributes, block_enc_hash, block_enc_sig for Longfellow).                                                                                                                                                                            | -       | -       | Yes      |
 
 ### `combined_presentation`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -371,15 +371,15 @@ an authorization-code redirect flow so admins log in via the OIDC provider.
 
 Supports both file-based and HSM-based keys with explicit control.
 
-| Field              | Type     | Description                                                                                                               | Example           | Default | Required                          |
-| ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------- | --------------------------------- |
-| `private_key_path` | `string` | File-based configuration                                                                                                  | -                 | -       | Yes (if pkcs11 not set)           |
-| `chain_path`       | `string` | Path to certificate chain (optional)                                                                                      | -                 | -       | No                                |
-| `pkcs11`           | `object` | HSM-based configuration                                                                                                   | -                 | -       | Yes (if private_key_path not set) |
-| `source`           | `object` | Source selection (determines which config to use) If empty, tries in order: File (if FilePath set), then HSM (if HSM set) | -                 | -       | No                                |
-| `enable_file`      | `bool`   | File-based key loading (default: true if FilePath set)                                                                    | -                 | -       | No                                |
-| `enable_hsm`       | `bool`   | HSM-based key loading (default: true if HSM set)                                                                          | -                 | -       | No                                |
-| `priority`         | `array`  | Fallback order when both are enabled If nil, uses Source field or auto-detects based on what's configured                 | `["hsm", "file"]` | -       | No                                |
+| Field              | Type     | Description                                                                                                                                                             | Example           | Default | Required                          |
+| ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------- | --------------------------------- |
+| `private_key_path` | `string` | File-based configuration                                                                                                                                                | -                 | -       | Yes (if pkcs11 not set)           |
+| `chain_path`       | `string` | Path to certificate chain (optional). Should contain the signing certificate followed by intermediates, and the root certificate if it is not in the system trust store | -                 | -       | No                                |
+| `pkcs11`           | `object` | HSM-based configuration                                                                                                                                                 | -                 | -       | Yes (if private_key_path not set) |
+| `source`           | `object` | Source selection (determines which config to use) If empty, tries in order: File (if FilePath set), then HSM (if HSM set)                                               | -                 | -       | No                                |
+| `enable_file`      | `bool`   | File-based key loading (default: true if FilePath set)                                                                                                                  | -                 | -       | No                                |
+| `enable_hsm`       | `bool`   | HSM-based key loading (default: true if HSM set)                                                                                                                        | -                 | -       | No                                |
+| `priority`         | `array`  | Fallback order when both are enabled If nil, uses Source field or auto-detects based on what's configured                                                               | `["hsm", "file"]` | -       | No                                |
 
 ### `pkcs11`
 
@@ -1258,7 +1258,7 @@ as the human-readable label.
 
 ### `zk_system_type` entry
 
-> **Path:** `.verifier.presets.<preset label>.<scope>.zk_system_type[]`
+> **Path:** `.verifier.presets.<preset label>.credentials.<key>.zk_system_type[]`
 
 array — a verifier's declaration of one ZK proof system + circuit variant
 it is willing to accept, mirroring multipaz's `ZkSystemSpec` wire shape

--- a/docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md
+++ b/docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md
@@ -75,6 +75,82 @@ proof's disclosed plaintext against. That's what this field is for.
   (including the third-party multipaz-based one this org has
   interop-tested against, `siros-multipaz-verifier.fly.dev`) reads it.
 
+## r12 addendum: `issuerSignedItemBytes` and `claimSlotDigestIds`
+
+**Status: implemented in siros-sdk-kotlin (wallet, producer); vc's own
+consumer side is the change this addendum documents.**
+
+The original `digestId` field above assumed the proof itself would keep
+reporting each disclosed slot's plaintext, so the verifier only ever
+needed to match an ALREADY-RETURNED slot to a wire-declared claim
+*after* a successful `verify()` call - `digestId` was purely a post-hoc
+join key.
+
+`zk-cred-vega`'s r12 circuit revision (shrunk blinding nonce, disclosed
+bytes moved out of proof public IO - see that repo's own release notes)
+changes this: `zk_cred_vega::verify()` no longer returns a disclosed
+claim's plaintext at all. Instead, the **caller** must supply, as an
+input to `verify()`, the real bytes for every disclosed slot (empty for
+undisclosed ones) - the function re-derives each slot's blinded digest
+from those bytes and rejects the whole proof (a hard error, not a
+per-slot soft-fail) if any slot's supplied bytes don't match what the
+proof committed to. `digestId` alone is no longer enough: the verifier
+needs it BEFORE calling `verify()`, not after, and it needs to know
+ALL `MAX_CLAIMS_V1` slots' identities, not just the disclosed ones, to
+build a correctly-shaped and correctly-ordered input.
+
+Two more fields cover this:
+
+```
+{ "elementIdentifier": tstr, "elementValue": any, "digestId": uint / omitted,
+  "issuerSignedItemBytes": bstr / omitted }
+```
+
+- `issuerSignedItemBytes` (per disclosed item, Vega-only): that element's
+  exact original `IssuerSignedItem` bytes
+  (`NamespaceItem.original.EncodeToBytes()` in siros-sdk-kotlin - the same
+  bytes `VegaProofSystem.buildWitness` feeds into `FfiClaim
+  .issuerSignedItemBytes` at proving time). This is what the verifier now
+  passes as `verify()`'s per-slot disclosed-bytes input for this claim's
+  slot - not a re-derivation from `elementValue`, since the circuit's
+  digest is over the FULL original item bytes (digestID + random salt +
+  elementIdentifier + elementValue, CBOR-encoded), and `random` never
+  otherwise crosses the wire.
+
+And, at the `documentData` level rather than per-item:
+
+```
+{ ..., "claimSlotDigestIds": [uint, uint, uint, uint] / omitted }
+```
+
+- `claimSlotDigestIds` (Vega-only): the credential's FULL, fixed-shape
+  claim-slot list - `VegaProofSystem.MAX_CLAIMS_V1` entries, in the
+  credential's own document order (the same order `buildWitness` assigns
+  to `FfiClaim` slots) - each entry being that slot's `digestID`
+  regardless of whether THIS presentation discloses it. Populated from
+  the wallet's own stored credential (`storedItems.map { it.item.digestId
+  }}` in siros-sdk-kotlin, already in document order - see
+  `SirosWallet.buildZkPresentationToken`), since a presentation on its own
+  only ever carries the DISCLOSED subset and undisclosed slots have no
+  serialized representation to derive an order from. Without this, a
+  verifier has no way to place a wire-disclosed item at the correct proof
+  slot index at all: `digestId` alone identifies WHICH claim was disclosed,
+  never WHERE (slot 0-3) it lives in the fixed-shape circuit.
+
+Verifier-side reconstruction (`vc`'s `pkg/mdoc/zk_verifier.go`): for each
+index `i` in `claimSlotDigestIds`, look up that digestID in the
+presentation's wire-disclosed items; if found, `disclosedBytes[i]` is that
+item's `issuerSignedItemBytes`; if not found (the slot wasn't disclosed),
+`disclosedBytes[i]` is empty. This ordered array is exactly what
+`zk_cred_vega`'s `verify()` (Go C-ABI: `CDisclosedInput[MAX_CLAIMS_V1]`)
+requires.
+
+Same additive/optional shape as the original `digestId` field - both are
+`omitempty`/absent for Longfellow presentations and for any pre-r12 Vega
+artifact, and a verifier that doesn't understand them simply never sees
+the keys. Same siros-sdk-swift parity gap as `digestId` above (Vega isn't
+implemented in the Swift SDK at all yet, so this is moot until it is).
+
 ## What needs to happen before wider interop
 
 This is exactly the kind of change that's easy to get away with unilaterally

--- a/docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md
+++ b/docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md
@@ -1,0 +1,99 @@
+# Wire-format extension: `digestId` on `zkDocuments` issuer-/device-signed items
+
+**Status: implemented in siros-sdk-kotlin (wallet, producer) and this repo
+(verifier, consumer). NOT yet proposed upstream to multipaz. Flagging this
+document explicitly so it gets raised in the appropriate cross-org
+collaboration before/alongside any interop testing against a
+non-SIROS-Foundation `zkDocuments` implementation.**
+
+## What changed
+
+`multipaz`'s `zkDocuments` extension to the ISO 18013-5 `DeviceResponse`
+(itself pre-standardization - see `ZK_PPID_VERIFICATION_PLAN.md`'s
+"Background" section, and the `balfanz/multipaz` `ppid` branch this org has
+previously interop-tested against and sent fixes to) represents each
+disclosed issuer-signed/device-signed element as:
+
+```
+{ "elementIdentifier": tstr, "elementValue": any }
+```
+
+This org's implementation (siros-sdk-kotlin's `MdocDeviceResponseBuilder
+.buildZkDeviceResponse`, `vc`'s `pkg/mdoc.ZkSignedItemMdoc`) now ADDS an
+**optional** third field:
+
+```
+{ "elementIdentifier": tstr, "elementValue": any, "digestId": uint / omitted }
+```
+
+`digestId` is the credential's own real ISO 18013-5 `IssuerSignedItem
+.digestID` for that element (an existing per-item field on the *original*,
+un-ZK-wrapped mdoc structure - not something invented for this). It is
+`omitempty` on both the CBOR wire and the Go struct field - a verifier that
+doesn't know about it (including multipaz's own reference verifier, and
+any other unmodified consumer of the pre-existing format) simply never
+sees the key, exactly as if this change didn't exist. A plain "mso_mdoc"
+`DeviceResponse` and every existing Longfellow-based `zkDocuments`
+presentation are both unaffected.
+
+## Why
+
+The existing `zkDocuments` format (and this org's own Longfellow
+integration) never needed a claim's `digestID` on the wire: Longfellow's
+verifier matches disclosed attributes to circuit slots **by position**,
+and the position is derived from the verifier's own request order (see
+`vc`'s `ZkPresentationContext.RequestedClaimIDs` doc comment) - a value
+both sides already agree on independently, so nothing extra needs to cross
+the wire.
+
+Vega (`zk-cred-vega`, a second, general-purpose ZK circuit backend this
+org is integrating alongside Longfellow - see
+`~/.claude/plans/dreamy-frolicking-chipmunk.md`) does not share that
+property. Its circuit has a fixed number of claim slots, but slot
+assignment is the **credential's own document order** (stable per
+credential, independent of which claims a given presentation discloses -
+see `VegaProofSystem.buildWitness`'s doc comment in siros-sdk-kotlin), not
+the verifier's request order. A verifier has no independent way to know
+which of the circuit's fixed slots corresponds to which requested claim
+identifier - the proof itself reports each slot's `digestID` back
+(`zk-cred-vega`'s own `DisclosedClaim.digest_id`), and the verifier needs
+*something* on the wire, tagged with that same `digestID`, to check the
+proof's disclosed plaintext against. That's what this field is for.
+
+## Compatibility / rollout
+
+- **Additive and optional** - no version bump, no breaking change to the
+  existing format for any consumer that ignores unknown map keys (CBOR's
+  normal decode behavior, and Go's own `cbor:",omitempty"` tag here).
+- Currently produced only by siros-sdk-kotlin. **siros-sdk-swift does not
+  yet emit `digestId`** - a real parity gap for Vega presentations from an
+  iOS wallet (Longfellow presentations are unaffected either way, since
+  they never consult this field). Track this alongside the rest of the
+  siros-sdk-swift Vega work.
+- Consumed only by this repo (`vc`)'s Vega verification path
+  (`pkg/mdoc/zk_verifier.go`'s Vega dispatch branch). No other verifier
+  (including the third-party multipaz-based one this org has
+  interop-tested against, `siros-multipaz-verifier.fly.dev`) reads it.
+
+## What needs to happen before wider interop
+
+This is exactly the kind of change that's easy to get away with unilaterally
+inside one org's own wallet+verifier pair, and easy to silently diverge on
+if a second implementer (multipaz itself, or any other `zkDocuments`
+consumer) later adds its own answer to the same "how does a
+non-positionally-matched ZK system's verifier know which slot is which"
+question, incompatibly. Before this is relied on for any interop testing
+against a party outside this org:
+
+1. Raise it with whoever this org coordinates with on the `balfanz/multipaz`
+   `ppid` branch (the existing channel used for prior ZK/PPID fixes sent
+   upstream - see `ZK_PPID_VERIFICATION_PLAN.md` and this org's prior PRs
+   there) - as a proposed addition to the shared wire format, not a
+   unilateral extension.
+2. Confirm whether multipaz's own format already has (or is planning) an
+   equivalent field under a different name, to avoid two incompatible
+   answers to the same problem.
+3. Once/if agreed upstream, drop the "not yet proposed upstream" caveat at
+   the top of this document and fold the confirmed shape into
+   `ZK_PPID_VERIFICATION_PLAN.md` proper instead of keeping it as a
+   separate flagged document.

--- a/docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md
+++ b/docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md
@@ -47,8 +47,7 @@ both sides already agree on independently, so nothing extra needs to cross
 the wire.
 
 Vega (`zk-cred-vega`, a second, general-purpose ZK circuit backend this
-org is integrating alongside Longfellow - see
-`~/.claude/plans/dreamy-frolicking-chipmunk.md`) does not share that
+org is integrating alongside Longfellow) does not share that
 property. Its circuit has a fixed number of claim slots, but slot
 assignment is the **credential's own document order** (stable per
 credential, independent of which claims a given presentation discloses -

--- a/docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md
+++ b/docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md
@@ -144,6 +144,23 @@ item's `issuerSignedItemBytes`; if not found (the slot wasn't disclosed),
 `zk_cred_vega`'s `verify()` (Go C-ABI: `CDisclosedInput[MAX_CLAIMS_V1]`)
 requires.
 
+### Known limitation: one namespace per presentation
+
+`digestId` is namespace-scoped in ISO 18013-5, and `claimSlotDigestIds` is
+a flat list of digestIDs with no namespace beside them. A credential whose
+disclosed claims span two namespaces can therefore collide - two
+namespaces counting from zero both have digestID 0, which is perfectly
+well-formed mdoc - and nothing in this extension can say which slot each
+belongs to.
+
+A verifier rejects that case rather than guessing (see
+`IssuerSignedItemsByDigestID`), so it fails safely and says why. But it is
+a real constraint, not a defensive check: **a Vega presentation must
+disclose from a single namespace.** Lifting it means carrying the
+namespace alongside each entry - a wire change, and one to make together
+with whatever answer the question below settles on rather than
+unilaterally.
+
 Same additive/optional shape as the original `digestId` field - both are
 `omitempty`/absent for Longfellow presentations and for any pre-r12 Vega
 artifact, and a verifier that doesn't understand them simply never sees

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -85,8 +85,13 @@ type UIPresetCredential struct {
 // They are mutually exclusive, hence omitempty on both - sending an empty
 // vct_values alongside a doctype, or vice versa, is a malformed query.
 type UIPresetMeta struct {
-	VCTValues    []string `json:"vct_values,omitempty"`
-	DoctypeValue string   `json:"doctype_value,omitempty"`
+	VCTValues []string `json:"vct_values,omitempty"`
+	// DoctypeValue is set for mdoc/ZK-mdoc scopes (openid4vp.MetaQuery's
+	// mdoc-format field) - mirrors UICredentialInfo.VCT's mdoc branch.
+	DoctypeValue string `json:"doctype_value,omitempty"`
+	// ZKSystemType is set when the preset's VerificationPresetScope
+	// overrides it - see that type's own doc comment.
+	ZKSystemType []openid4vp.ZKSystemTypeSpec `json:"zk_system_type,omitempty"`
 }
 
 // UIPresetClaim is a claim path within a preset credential.
@@ -273,6 +278,18 @@ func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
 						// doctype_value above and has no vct to offer.
 						uiCred.Meta.VCTValues = vs
 					}
+					if mddl := meta.GetMDDL(); mddl != nil {
+						uiCred.Meta.DoctypeValue = mddl.DocType
+					}
+				}
+
+				// A preset's Format/ZKSystemType override lets an otherwise
+				// plain-format scope (e.g. mso_mdoc) be requested as a ZK
+				// proof (mso_mdoc_zk) instead - see
+				// model.VerificationPresetScope's own doc comment.
+				if scopeCfg != nil && scopeCfg.Format != "" {
+					uiCred.Format = scopeCfg.Format
+					uiCred.Meta.ZKSystemType = scopeCfg.ZKSystemType
 				}
 
 				// scopeCfg may be nil (scope with no overrides)

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -278,9 +278,6 @@ func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
 						// doctype_value above and has no vct to offer.
 						uiCred.Meta.VCTValues = vs
 					}
-					if mddl := meta.GetMDDL(); mddl != nil {
-						uiCred.Meta.DoctypeValue = mddl.DocType
-					}
 				}
 
 				// A preset's Format/ZKSystemType override lets an otherwise

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -450,8 +450,21 @@ func (c *Client) UIInteraction(ctx context.Context, req *UIInteractionRequest) (
 	// encryption and produce a payload this page can't submit at all, so
 	// it's ignored here to keep request/response shapes consistent
 	// end-to-end for this specific flow.
+	// Also gated on AutoAttempt (default true): when it's false,
+	// _tryNativeDCAPI() never runs client-side at all (no manual retry
+	// button exists either - see presentation-definition.js's
+	// dcApiAutoAttempt check) and every request goes out through
+	// _setupFallbackFlow()'s QR/same-device-link path instead, which
+	// submits via /verification/direct_post through the ordinary
+	// WS-engine relay - NOT the DC API response channel. Serving
+	// "dc_api.jwt" there anyway produced a real, confirmed-live bug:
+	// go-wallet-backend's oid4vp.go correctly refuses to submit a
+	// dc_api.jwt-mode VP ("unsupported response_mode: dc_api.jwt"), since
+	// that response mode is JWE-encrypted specifically for
+	// navigator.credentials.get()'s own response construction, not a
+	// redirect/relay POST body.
 	responseMode := "direct_post.jwt"
-	if c.cfg.Verifier.DigitalCredentials.Enable {
+	if c.cfg.Verifier.DigitalCredentials.Enable && model.BoolVal(c.cfg.Verifier.DigitalCredentials.AutoAttempt, true) {
 		responseMode = "dc_api.jwt"
 	}
 

--- a/internal/verifier/apiv1/handlers_verification.go
+++ b/internal/verifier/apiv1/handlers_verification.go
@@ -2,6 +2,7 @@ package apiv1
 
 import (
 	"context"
+	"crypto"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -352,7 +353,34 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 				c.log.Error(err, "failed to construct response URI for ZK session transcript", "scope", scope)
 				return nil, fmt.Errorf("failed to construct response URI for scope %s: %w", scope, err)
 			}
-			sessionTranscript, err := mdoc.BuildOID4VPSessionTranscript(authCtx.ClientID, authCtx.Nonce, responseURI, nil)
+			// BuildOID4VPSessionTranscript's own doc comment: the JWK
+			// thumbprint is nil "unless the request advertised an
+			// encryption key for the response" - this request always does
+			// (CreateRequestObject sets ClientMetadata.JWKS to the same
+			// ephemeral key cached under EphemeralEncryptionKeyID, and
+			// response_mode is "direct_post.jwt"/"dc_api.jwt" whenever
+			// AutoAttempt is off, per UIInteraction's own responseMode
+			// comment), so passing nil unconditionally contradicted the
+			// documented condition and silently left the ZK proof's
+			// Fiat-Shamir transcript unbound from the actual encryption
+			// key the wallet saw and included in its own transcript.
+			var readerPubKeyThumbprint []byte
+			if authCtx.EphemeralEncryptionKeyID != "" {
+				if privKey, found := c.openid4vp.EphemeralKeyCache.Get(authCtx.EphemeralEncryptionKeyID); found {
+					pubKeyIface, err := privKey.PublicKey()
+					if err != nil {
+						c.log.Error(err, "failed to derive public key for ZK session transcript", "scope", scope)
+						return nil, fmt.Errorf("failed to derive public key for scope %s: %w", scope, err)
+					}
+					tp, err := pubKeyIface.Thumbprint(crypto.SHA256)
+					if err != nil {
+						c.log.Error(err, "failed to compute JWK thumbprint for ZK session transcript", "scope", scope)
+						return nil, fmt.Errorf("failed to compute JWK thumbprint for scope %s: %w", scope, err)
+					}
+					readerPubKeyThumbprint = tp
+				}
+			}
+			sessionTranscript, err := mdoc.BuildOID4VPSessionTranscript(authCtx.ClientID, authCtx.Nonce, responseURI, readerPubKeyThumbprint)
 			if err != nil {
 				c.log.Error(err, "failed to build ZK session transcript", "scope", scope)
 				return nil, fmt.Errorf("failed to build ZK session transcript for scope %s: %w", scope, err)

--- a/internal/verifier/apiv1/handlers_verification.go
+++ b/internal/verifier/apiv1/handlers_verification.go
@@ -385,7 +385,6 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 				c.log.Error(err, "failed to build ZK session transcript", "scope", scope)
 				return nil, fmt.Errorf("failed to build ZK session transcript for scope %s: %w", scope, err)
 			}
-
 			zkResult, err := zkHandler.VerifyAndExtract(ctx, vpToken, mdoc.ZkPresentationContext{
 				SessionID:          authCtx.SessionID,
 				ClientID:           authCtx.ClientID,

--- a/internal/verifier/apiv1/handlers_verification.go
+++ b/internal/verifier/apiv1/handlers_verification.go
@@ -331,18 +331,23 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 				}
 			}
 
-			// SessionTranscript for the OpenID4VP redirect flow. Its wire
-			// format is cross-checked against an independent CBOR library
-			// (see pkg/mdoc.TestBuildOID4VPSessionTranscript_MatchesIndependentKotlinCBORLibraryCrossCheck),
-			// but is STILL NOT confirmed against a real wallet's own
-			// transcript bytes from a live session - no such fixture could
-			// be found (checked siros-sdk-kotlin, siros-sdk-swift,
-			// go-wallet-backend, multipaz). TRACKED GAP: if native ZK
-			// verification of a real presentation fails in a way that looks
-			// like a transcript/binding mismatch, treat
-			// BuildOID4VPSessionTranscript's exact byte layout as a prime
-			// suspect and get a real captured transcript to compare against.
-			responseURI, err := url.JoinPath(c.cfg.Verifier.PublicURL, "verification", "oidc-direct_post")
+			// SessionTranscript for the OpenID4VP redirect flow. CONFIRMED
+			// LIVE as the exact cause of a real "InvalidSumcheckProof"
+			// rejection of a genuinely valid proof: this endpoint path MUST
+			// match the responseURI actually sent to the wallet as
+			// requestObject.ResponseURI (see UIInteraction/CreateRequestObject,
+			// which use "direct_post", not "oidc-direct_post" - the latter
+			// belongs to a wholly separate OIDC RP flow with its own
+			// session/state cache namespace, see _submitDCAPIResponse's
+			// identical distinction in presentation-definition.js). Any
+			// difference here changes handoverInfo's encoded bytes, which
+			// changes its SHA-256 digest, which changes the whole
+			// SessionTranscript the ZK proof's Fiat-Shamir transcript was
+			// built against - a wallet-side proof built over the real
+			// "direct_post" responseURI can never verify against a
+			// recomputed transcript using a different one, regardless of
+			// whether the underlying disclosed claims are correct.
+			responseURI, err := url.JoinPath(c.cfg.Verifier.PublicURL, "verification", "direct_post")
 			if err != nil {
 				c.log.Error(err, "failed to construct response URI for ZK session transcript", "scope", scope)
 				return nil, fmt.Errorf("failed to construct response URI for scope %s: %w", scope, err)

--- a/internal/verifier/apiv1/handlers_verification.go
+++ b/internal/verifier/apiv1/handlers_verification.go
@@ -299,8 +299,25 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 			// rather than silently skipping either check.
 			var zkMeta openid4vp.MetaQuery
 			var requestedClaimIDs []string
-			if authCtx.DCQLQuery != nil {
-				for _, cq := range authCtx.DCQLQuery.Credentials {
+			// authCtx.DCQLQuery is the Mongo-persisted copy - confirmed live
+			// (via a temporary debug log, since removed) that it comes back
+			// nil here even for a session whose consent screen the wallet
+			// just correctly rendered from the SAME original DCQL query,
+			// meaning the query itself was never lost, only this particular
+			// round-trip through AuthContext's Mongo store. Fall back to
+			// RequestObjectCache (an in-memory, non-Mongo cache keyed by
+			// RequestObjectID) - it holds the exact RequestObject that was
+			// signed and served to the wallet at /verification/request-object
+			// (see VerificationRequestObject), which necessarily carries the
+			// same DCQLQuery the wallet just demonstrably parsed correctly.
+			dcqlQuery := authCtx.DCQLQuery
+			if dcqlQuery == nil {
+				if requestObject, found := c.openid4vp.RequestObjectCache.Get(authCtx.RequestObjectID); found {
+					dcqlQuery = requestObject.DCQLQuery
+				}
+			}
+			if dcqlQuery != nil {
+				for _, cq := range dcqlQuery.Credentials {
 					if cq.ID == scope && openid4vp.IsMdocZkFormat(cq.Format) {
 						zkMeta = cq.Meta
 						for _, claim := range cq.Claims {

--- a/internal/verifier/apiv1/handlers_verification.go
+++ b/internal/verifier/apiv1/handlers_verification.go
@@ -378,6 +378,15 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 						return nil, fmt.Errorf("failed to compute JWK thumbprint for scope %s: %w", scope, err)
 					}
 					readerPubKeyThumbprint = tp
+				} else {
+					// A miss means the key expired or was evicted between
+					// issuing the request and the wallet answering it. The
+					// wallet built ITS transcript with that key, so carrying
+					// on with a nil thumbprint guarantees a mismatch - and
+					// one that surfaces as an opaque proof failure rather
+					// than as the cache miss it actually is.
+					c.log.Error(nil, "ephemeral encryption key missing from cache for ZK session transcript", "scope", scope, "key_id", authCtx.EphemeralEncryptionKeyID)
+					return nil, fmt.Errorf("ephemeral encryption key %q is no longer cached, cannot rebuild the session transcript the wallet used for scope %s", authCtx.EphemeralEncryptionKeyID, scope)
 				}
 			}
 			sessionTranscript, err := mdoc.BuildOID4VPSessionTranscript(authCtx.ClientID, authCtx.Nonce, responseURI, readerPubKeyThumbprint)

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -152,6 +152,18 @@ const dcqlQueryCredentialSchema = v.object({
         v.object({
             vct_values: v.optional(v.array(v.string())),
             doctype_value: v.optional(v.string()),
+            // zk_system_type (mso_mdoc_zk only) is an array of flat
+            // {id, system, ...params} objects - declared explicitly since
+            // the catch-all record below only accepts string/string[]
+            // values, not array-of-object, and would otherwise reject
+            // (not silently drop) this entire query at the
+            // v.safeParse(dcqlQuerySchema, ...) gate right before it's
+            // sent - "Malformed predefined DCQL query" with no further
+            // detail. See the identical fix on metadataResponseSchema's
+            // preset meta - same root cause, different validation
+            // checkpoint (that one stripped the field silently; this one
+            // rejects the whole query instead).
+            zk_system_type: v.optional(v.array(v.record(v.string(), v.string()))),
         }),
         v.record(v.string(), v.union([v.string(), v.array(v.string())])),
     ]),

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -165,7 +165,19 @@ const dcqlQueryCredentialSchema = v.object({
             // rejects the whole query instead).
             zk_system_type: v.optional(v.array(v.record(v.string(), v.string()))),
         }),
-        v.record(v.string(), v.union([v.string(), v.array(v.string())])),
+        // v.intersect validates the object against EVERY member schema, not
+        // just "whichever keys aren't already declared above" - confirmed
+        // live (both via the deployed error and a local valibot repro):
+        // this catch-all record still runs against the ENTIRE meta object,
+        // zk_system_type included, so its value union has to independently
+        // accept zk_system_type's own array-of-objects shape too, or the
+        // intersection fails even though the object schema above already
+        // declared and accepted the field.
+        v.record(v.string(), v.union([
+            v.string(),
+            v.array(v.string()),
+            v.array(v.record(v.string(), v.string())),
+        ])),
     ]),
     claims: v.optional(v.array(v.object({
         path: v.array(v.nullable(v.string())),

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -116,6 +116,18 @@ const metadataResponseSchema = v.object({
             meta: v.object({
                 vct_values: v.optional(v.array(v.string())),
                 doctype_value: v.optional(v.string()),
+                // zk_system_type entries are a flat {id, system, ...params}
+                // string-keyed object on the wire (ZKSystemTypeSpec's own
+                // MarshalJSON flattens params to the top level, no nested
+                // "params" key) - v.record(string,string), not a fixed
+                // {id, system} shape, so an arbitrary param (e.g.
+                // num_attributes, circuit_hash) isn't silently dropped.
+                // Without this field declared at all, v.object() stripped
+                // it from every parsed preset - the verifier's own
+                // zk_system_type was present on the wire but never reached
+                // the DCQL query the wallet received, which is
+                // indistinguishable from "no ZK system offered" wallet-side.
+                zk_system_type: v.optional(v.array(v.record(v.string(), v.string()))),
             }),
             claims: v.optional(v.array(v.object({
                 path: v.array(v.nullable(v.string())),

--- a/pkg/helpers/validate.go
+++ b/pkg/helpers/validate.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/openid4vp"
 	"github.com/SUNET/vc/pkg/sqlstore"
 	"github.com/SUNET/vc/pkg/trace"
 
@@ -356,6 +357,26 @@ func NewValidator() (*validator.Validate, error) {
 			sl.ReportError(cfg.JWKSURL, "JWKSURL", "JWKSURL", "jwks_source_required", "")
 		}
 	}, model.APIAuthJWKS{})
+
+	// Register struct-level validation for VerificationPresetScope: a
+	// "mso_mdoc_zk" format override has no meaning without a zk_system_type.
+	//
+	// The field's own doc comment already said it was required in that case;
+	// nothing enforced it, so the failure surfaced later as a DCQL query the
+	// wallet reads as "no ZK system offered" - which is indistinguishable
+	// from a wallet that cannot do ZK at all.
+	validate.RegisterStructValidation(func(sl validator.StructLevel) {
+		scope := sl.Current().Interface().(model.VerificationPresetScope)
+		if scope.Format == openid4vp.FormatMsoMdocZk && len(scope.ZKSystemType) == 0 {
+			sl.ReportError(scope.ZKSystemType, "ZKSystemType", "ZKSystemType", "zk_system_type_required_for_mso_mdoc_zk", "")
+		}
+		// The converse is a configuration that says nothing coherent: a
+		// zk_system_type only reaches the query through the ZK format, so on
+		// any other format it is silently inert rather than wrong-but-applied.
+		if len(scope.ZKSystemType) > 0 && scope.Format != openid4vp.FormatMsoMdocZk {
+			sl.ReportError(scope.Format, "Format", "Format", "zk_system_type_requires_mso_mdoc_zk_format", scope.Format)
+		}
+	}, model.VerificationPresetScope{})
 
 	// Register struct-level validation for DataSources: openid4vp auth_scopes must not self-reference
 	validate.RegisterStructValidation(func(sl validator.StructLevel) {

--- a/pkg/helpers/validate_preset_zk_test.go
+++ b/pkg/helpers/validate_preset_zk_test.go
@@ -1,0 +1,80 @@
+package helpers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/openid4vp"
+	"github.com/go-playground/validator/v10"
+)
+
+// TestVerificationPresetScopeZKSystemType pins the "mso_mdoc_zk needs a
+// zk_system_type" rule that VerificationPresetScope.ZKSystemType's doc
+// comment has always claimed.
+//
+// Without it the failure surfaced much later, as a DCQL query carrying a ZK
+// format and no system type - which a wallet reads as "no ZK system offered",
+// indistinguishable from a wallet that cannot do ZK at all.
+func TestVerificationPresetScopeZKSystemType(t *testing.T) {
+	v, err := NewValidator()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec := []openid4vp.ZKSystemTypeSpec{{ID: "vega-mc-p256-v1-r12", System: "vega-mc-p256-v1"}}
+
+	for _, tc := range []struct {
+		name    string
+		scope   model.VerificationPresetScope
+		wantTag string
+	}{
+		{
+			name:    "zk format without a system type is rejected",
+			scope:   model.VerificationPresetScope{Format: openid4vp.FormatMsoMdocZk},
+			wantTag: "zk_system_type_required_for_mso_mdoc_zk",
+		},
+		{
+			// Inert rather than wrong-but-applied: a zk_system_type only
+			// reaches the query through the ZK format.
+			name:    "system type without the zk format is rejected",
+			scope:   model.VerificationPresetScope{ZKSystemType: spec},
+			wantTag: "zk_system_type_requires_mso_mdoc_zk_format",
+		},
+		{
+			name:  "zk format with a system type is accepted",
+			scope: model.VerificationPresetScope{Format: openid4vp.FormatMsoMdocZk, ZKSystemType: spec},
+		},
+		{
+			name:  "neither is accepted - the override is optional",
+			scope: model.VerificationPresetScope{},
+		},
+		{
+			name:  "a non-ZK format override needs no system type",
+			scope: model.VerificationPresetScope{Format: "mso_mdoc"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := v.Struct(tc.scope)
+			if tc.wantTag == "" {
+				if err != nil {
+					t.Fatalf("expected acceptance, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected rejection")
+			}
+			var verrs validator.ValidationErrors
+			if !errors.As(err, &verrs) {
+				t.Fatalf("expected validation errors, got %T: %v", err, err)
+			}
+			for _, ve := range verrs {
+				if ve.Tag() == tc.wantTag {
+					return
+				}
+			}
+			t.Fatalf("expected a %q failure, got: %v", tc.wantTag, err)
+		})
+	}
+}

--- a/pkg/mdoc/vega_key_cache.go
+++ b/pkg/mdoc/vega_key_cache.go
@@ -6,8 +6,12 @@ package mdoc
 // zkSystemID, so an unbounded one grows the verifier's RSS permanently by
 // that much for every distinct circuit revision it is ever asked to verify
 // against, and never gives any of it back. 256MiB leaves room for two
-// revisions in flight - what a circuit rollover needs - while keeping the
-// ceiling a number someone can reason about when sizing the process.
+// revisions in flight - what a circuit rollover needs.
+//
+// The ceiling is PER PROCESS, not per deployment. Under Common.HA.Enable
+// there are several verifier instances, each with its own copy of this
+// cache, so the footprint to size for is 256MiB times the instance count -
+// and a rollover can have every instance holding two keys at once.
 const maxVegaVerifierKeyCacheBytes = 256 << 20
 
 // vegaKeyCache is a byte-bounded LRU of decompressed verifier-key blobs.
@@ -19,6 +23,26 @@ const maxVegaVerifierKeyCacheBytes = 256 << 20
 // caller, which is behind the zknative build tag - the eviction rule has no
 // cgo in it, and a rule that cannot be exercised without the crate staged is
 // a rule nobody checks.
+//
+// Deliberately outside pkg/cache and Common.HA, which is the convention for
+// everything else the verifier caches (see internal/verifier/cache: HA backs
+// those with MongoDB so instances share them). Two reasons, and the first is
+// decisive:
+//
+//   - a value here cannot go in that backend. The Mongo store persists each
+//     entry as a BSON document, and MongoDB caps those at 16MiB; a ~100MB
+//     key exceeds it by an order of magnitude, and pkg/cache has no size
+//     guard that would catch the attempt before it failed at runtime.
+//   - sharing would not help even if it fit. These are immutable public
+//     artifacts fetched from the circuit catalog, identical on every
+//     instance, so a per-instance copy is not divergent state - it is the
+//     same bytes, and pulling 100MB out of Mongo on a miss is strictly worse
+//     than fetching from the catalog the miss would have gone to anyway.
+//
+// What HA does change is the footprint (see maxVegaVerifierKeyCacheBytes)
+// and that the in-flight dedup beside this is per process too: on a cold
+// start or a circuit rollover, every instance fetches the artifact once,
+// independently, rather than one fetching it for all of them.
 type vegaKeyCache struct {
 	byID  map[string][]byte
 	lru   []string // oldest first

--- a/pkg/mdoc/vega_key_cache.go
+++ b/pkg/mdoc/vega_key_cache.go
@@ -5,14 +5,24 @@ package mdoc
 // A decompressed Vega verifier key is ~100MB, and the cache is keyed by
 // zkSystemID, so an unbounded one grows the verifier's RSS permanently by
 // that much for every distinct circuit revision it is ever asked to verify
-// against, and never gives any of it back. 256MiB leaves room for two
-// revisions in flight - what a circuit rollover needs.
+// against, and never gives any of it back.
+//
+// 512MiB, which is room for about five keys. Two would cover a clean
+// rollover, and the extra headroom is deliberately cheap: this is a cap, not
+// a reservation, so RSS only reaches it if that many distinct revisions are
+// genuinely in use. The scenario it buys off is the one that fails quietly -
+// a working set one key larger than the cap makes every request evict the
+// key the next one needs, so the cache degrades to a full fetch per
+// verification with no error and nothing in the logs but latency. Paying
+// memory only in the case where the alternative is refetching 100MB per
+// request is the right side of that trade.
 //
 // The ceiling is PER PROCESS, not per deployment. Under Common.HA.Enable
 // there are several verifier instances, each with its own copy of this
-// cache, so the footprint to size for is 256MiB times the instance count -
-// and a rollover can have every instance holding two keys at once.
-const maxVegaVerifierKeyCacheBytes = 256 << 20
+// cache, so the footprint to size for is this times the instance count -
+// and each instance only reaches it if it has actually served that many
+// revisions.
+const maxVegaVerifierKeyCacheBytes = 512 << 20
 
 // vegaKeyCache is a byte-bounded LRU of decompressed verifier-key blobs.
 //

--- a/pkg/mdoc/vega_key_cache.go
+++ b/pkg/mdoc/vega_key_cache.go
@@ -1,0 +1,73 @@
+package mdoc
+
+// maxVegaVerifierKeyCacheBytes bounds what vegaKeyCache may hold.
+//
+// A decompressed Vega verifier key is ~100MB, and the cache is keyed by
+// zkSystemID, so an unbounded one grows the verifier's RSS permanently by
+// that much for every distinct circuit revision it is ever asked to verify
+// against, and never gives any of it back. 256MiB leaves room for two
+// revisions in flight - what a circuit rollover needs - while keeping the
+// ceiling a number someone can reason about when sizing the process.
+const maxVegaVerifierKeyCacheBytes = 256 << 20
+
+// vegaKeyCache is a byte-bounded LRU of decompressed verifier-key blobs.
+//
+// Deliberately not locked: it lives inside a struct that already holds a
+// mutex covering both this and the in-flight-load bookkeeping beside it, and
+// a second lock here would only invite the two to disagree. Callers hold
+// that one. It is also in its own untagged file rather than beside its only
+// caller, which is behind the zknative build tag - the eviction rule has no
+// cgo in it, and a rule that cannot be exercised without the crate staged is
+// a rule nobody checks.
+type vegaKeyCache struct {
+	byID  map[string][]byte
+	lru   []string // oldest first
+	bytes int
+	max   int
+}
+
+func newVegaKeyCache(max int) *vegaKeyCache {
+	return &vegaKeyCache{byID: make(map[string][]byte), max: max}
+}
+
+// get returns the cached bytes for id, marking it most recently used.
+func (c *vegaKeyCache) get(id string) ([]byte, bool) {
+	b, ok := c.byID[id]
+	if ok {
+		c.touch(id)
+	}
+	return b, ok
+}
+
+// put caches b under id and evicts oldest-first until the total fits.
+//
+// The entry just stored is never evicted, even when it alone exceeds the
+// bound: the caller is about to use it, and handing back bytes that were
+// dropped on the way out would be a strange way to enforce a ceiling. A
+// single key larger than max therefore exceeds it, by design, for as long as
+// it is the only one held.
+func (c *vegaKeyCache) put(id string, b []byte) {
+	if previous, ok := c.byID[id]; ok {
+		c.bytes -= len(previous)
+	}
+	c.byID[id] = b
+	c.bytes += len(b)
+	c.touch(id)
+
+	for c.bytes > c.max && len(c.lru) > 1 {
+		oldest := c.lru[0]
+		c.lru = c.lru[1:]
+		c.bytes -= len(c.byID[oldest])
+		delete(c.byID, oldest)
+	}
+}
+
+func (c *vegaKeyCache) touch(id string) {
+	for i, existing := range c.lru {
+		if existing == id {
+			c.lru = append(append(c.lru[:i:i], c.lru[i+1:]...), id)
+			return
+		}
+	}
+	c.lru = append(c.lru, id)
+}

--- a/pkg/mdoc/vega_key_cache_test.go
+++ b/pkg/mdoc/vega_key_cache_test.go
@@ -1,0 +1,88 @@
+package mdoc
+
+import "testing"
+
+func blob(n int) []byte { return make([]byte, n) }
+
+func TestVegaKeyCacheEviction(t *testing.T) {
+	t.Run("evicts oldest first once the bound is passed", func(t *testing.T) {
+		c := newVegaKeyCache(300)
+		c.put("a", blob(100))
+		c.put("b", blob(100))
+		c.put("c", blob(100))
+		if c.bytes != 300 {
+			t.Fatalf("expected 300 bytes held, got %d", c.bytes)
+		}
+
+		c.put("d", blob(100)) // 400 > 300, so "a" goes
+		if _, ok := c.byID["a"]; ok {
+			t.Fatal("the oldest entry should have been evicted")
+		}
+		if c.bytes != 300 {
+			t.Fatalf("expected the bound to be restored, got %d bytes", c.bytes)
+		}
+	})
+
+	t.Run("a read makes an entry the newest", func(t *testing.T) {
+		c := newVegaKeyCache(300)
+		c.put("a", blob(100))
+		c.put("b", blob(100))
+		c.put("c", blob(100))
+
+		if _, ok := c.get("a"); !ok {
+			t.Fatal("a should still be cached")
+		}
+		c.put("d", blob(100)) // "b" is now the oldest, not "a"
+
+		if _, ok := c.byID["a"]; !ok {
+			t.Fatal("a was just read and must survive")
+		}
+		if _, ok := c.byID["b"]; ok {
+			t.Fatal("b was the least recently used and should have gone")
+		}
+	})
+
+	t.Run("re-putting the same id does not double-count", func(t *testing.T) {
+		c := newVegaKeyCache(1000)
+		c.put("a", blob(100))
+		c.put("a", blob(250))
+		if c.bytes != 250 {
+			t.Fatalf("expected the replacement to be counted once, got %d", c.bytes)
+		}
+		if len(c.lru) != 1 {
+			t.Fatalf("expected one entry in the lru, got %d", len(c.lru))
+		}
+	})
+
+	t.Run("a single oversized entry is kept", func(t *testing.T) {
+		// The caller is about to use it - handing back bytes evicted on the
+		// way out would be a strange way to enforce a ceiling.
+		c := newVegaKeyCache(100)
+		c.put("huge", blob(500))
+		if _, ok := c.get("huge"); !ok {
+			t.Fatal("the only entry must be kept even when it exceeds the bound")
+		}
+	})
+
+	t.Run("an oversized entry still evicts what came before it", func(t *testing.T) {
+		c := newVegaKeyCache(100)
+		c.put("small", blob(50))
+		c.put("huge", blob(500))
+		if _, ok := c.byID["small"]; ok {
+			t.Fatal("the older entry should have been evicted to make room")
+		}
+		if c.bytes != 500 {
+			t.Fatalf("expected only the new entry counted, got %d", c.bytes)
+		}
+	})
+
+	t.Run("the real bound leaves room for two keys", func(t *testing.T) {
+		// ~100MB each; a circuit rollover needs two in flight.
+		c := newVegaKeyCache(maxVegaVerifierKeyCacheBytes)
+		c.put("r11", blob(100<<20))
+		c.put("r12", blob(100<<20))
+		if _, ok := c.byID["r11"]; !ok {
+			t.Fatal("two ~100MB keys must fit inside the bound")
+		}
+	})
+}

--- a/pkg/mdoc/vega_key_cache_test.go
+++ b/pkg/mdoc/vega_key_cache_test.go
@@ -76,13 +76,23 @@ func TestVegaKeyCacheEviction(t *testing.T) {
 		}
 	})
 
-	t.Run("the real bound leaves room for two keys", func(t *testing.T) {
-		// ~100MB each; a circuit rollover needs two in flight.
+	t.Run("the real bound holds a plausible working set", func(t *testing.T) {
+		// ~100MB each. Two cover a clean rollover; the headroom is for a
+		// wallet population straddling more than two revisions, which is
+		// where a tight bound would thrash instead of cache.
 		c := newVegaKeyCache(maxVegaVerifierKeyCacheBytes)
-		c.put("r11", blob(100<<20))
-		c.put("r12", blob(100<<20))
-		if _, ok := c.byID["r11"]; !ok {
-			t.Fatal("two ~100MB keys must fit inside the bound")
+		for _, id := range []string{"r10", "r11", "r12", "r13", "r14"} {
+			c.put(id, blob(100<<20))
+		}
+		for _, id := range []string{"r10", "r11", "r12", "r13", "r14"} {
+			if _, ok := c.byID[id]; !ok {
+				t.Fatalf("%s should still be cached inside the bound", id)
+			}
+		}
+		// Still bounded, though: a sixth evicts the oldest.
+		c.put("r15", blob(100<<20))
+		if _, ok := c.byID["r10"]; ok {
+			t.Fatal("the bound must still evict - this is a cap, not unbounded growth")
 		}
 	})
 }

--- a/pkg/mdoc/zk.go
+++ b/pkg/mdoc/zk.go
@@ -109,6 +109,16 @@ type ZkDocumentDataMdoc struct {
 	// convention as a COSE x5chain header (see cose.go). May be absent.
 	// Use X5ChainCertificates to get parsed *x509.Certificate values.
 	MsoX5Chain any `cbor:"msoX5chain,omitempty"`
+
+	// ClaimSlotDigestIds is Vega-only (r12 circuit revision addendum to
+	// docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md): the credential's FULL,
+	// fixed-shape claim-slot list, in the credential's own document order
+	// (VegaProofSystem.MAX_CLAIMS_V1 entries in siros-sdk-kotlin), each
+	// entry being that slot's digestID regardless of whether this
+	// presentation discloses it. nil for a Longfellow presentation or a
+	// pre-r12 Vega artifact. See BuildVegaDisclosedBytes's doc comment for
+	// why the verifier needs this to call zk_cred_vega's r12 verify().
+	ClaimSlotDigestIds []uint32 `cbor:"claimSlotDigestIds,omitempty"`
 }
 
 // ZkSignedItemMdoc is one disclosed element inside a ZkDocumentDataMdoc's
@@ -128,6 +138,14 @@ type ZkSignedItemMdoc struct {
 	// Vega-producing wallets (siros-sdk-kotlin as of this field's
 	// addition - siros-sdk-swift does not yet emit it) populate it.
 	DigestID *uint32 `cbor:"digestId,omitempty"`
+
+	// IssuerSignedItemBytes is Vega-only (r12 circuit revision addendum to
+	// docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md): this element's exact
+	// original IssuerSignedItem bytes. nil for a Longfellow presentation
+	// or a pre-r12 Vega artifact - see BuildVegaDisclosedBytes's doc
+	// comment for why r12 needs it (verify() takes disclosed bytes as an
+	// input rather than returning them from the proof).
+	IssuerSignedItemBytes []byte `cbor:"issuerSignedItemBytes,omitempty"`
 }
 
 // FlattenIssuerSigned converts IssuerSigned into the same

--- a/pkg/mdoc/zk.go
+++ b/pkg/mdoc/zk.go
@@ -116,6 +116,18 @@ type ZkDocumentDataMdoc struct {
 type ZkSignedItemMdoc struct {
 	ElementIdentifier string `cbor:"elementIdentifier"`
 	ElementValue      any    `cbor:"elementValue"`
+
+	// DigestID is the credential's own real ISO 18013-5 IssuerSignedItem
+	// digestID for this element - an ADDITIVE, optional extension to
+	// multipaz's own zkDocuments wire shape (see
+	// docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md for the full rationale and
+	// its "not yet proposed upstream" status). nil when absent - a
+	// Longfellow presentation never needs this (attributes are matched by
+	// request-order position, not digestID - see
+	// ZkPresentationContext.RequestedClaimIDs's doc comment), so only
+	// Vega-producing wallets (siros-sdk-kotlin as of this field's
+	// addition - siros-sdk-swift does not yet emit it) populate it.
+	DigestID *uint32 `cbor:"digestId,omitempty"`
 }
 
 // FlattenIssuerSigned converts IssuerSigned into the same
@@ -128,6 +140,38 @@ func (dd *ZkDocumentDataMdoc) FlattenIssuerSigned() map[string]map[string]any {
 // FlattenDeviceSigned is the DeviceSigned equivalent of FlattenIssuerSigned.
 func (dd *ZkDocumentDataMdoc) FlattenDeviceSigned() map[string]map[string]any {
 	return flattenZkSignedItems(dd.DeviceSigned)
+}
+
+// IssuerSignedItemsByDigestID indexes IssuerSigned by DigestID, across all
+// namespaces - the lookup a Vega presentation's verify path needs (see
+// docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md): the returned proof's disclosed
+// claims are matched to a requested identifier via digestID, not position,
+// so the verifier needs the wire-declared elementValue for that same
+// digestID to compare against.
+//
+// Returns an error if any disclosed item has no DigestID at all (expected
+// only from a pre-digestId-extension wallet, or a non-Vega presentation
+// mistakenly routed through this path), or if the same DigestID appears
+// more than once (ambiguous - refuses to guess which one was intended,
+// mirroring findClaimInNamespaces' identical stance on a duplicate
+// elementIdentifier).
+func (dd *ZkDocumentDataMdoc) IssuerSignedItemsByDigestID() (map[uint32]ZkSignedItemMdoc, error) {
+	out := make(map[uint32]ZkSignedItemMdoc)
+	for ns, items := range dd.IssuerSigned {
+		for _, item := range items {
+			if item.DigestID == nil {
+				return nil, fmt.Errorf("issuerSigned item %q (namespace %q) has no digestId - required for Vega claim matching", item.ElementIdentifier, ns)
+			}
+			if existing, ok := out[*item.DigestID]; ok {
+				return nil, fmt.Errorf(
+					"digestId %d is disclosed more than once (%q and %q) - ambiguous, refusing to guess which one was intended",
+					*item.DigestID, existing.ElementIdentifier, item.ElementIdentifier,
+				)
+			}
+			out[*item.DigestID] = item
+		}
+	}
+	return out, nil
 }
 
 func flattenZkSignedItems(m map[string][]ZkSignedItemMdoc) map[string]map[string]any {

--- a/pkg/mdoc/zk.go
+++ b/pkg/mdoc/zk.go
@@ -170,23 +170,44 @@ func (dd *ZkDocumentDataMdoc) FlattenDeviceSigned() map[string]map[string]any {
 // Returns an error if any disclosed item has no DigestID at all (expected
 // only from a pre-digestId-extension wallet, or a non-Vega presentation
 // mistakenly routed through this path), or if the same DigestID appears
-// more than once (ambiguous - refuses to guess which one was intended,
-// mirroring findClaimInNamespaces' identical stance on a duplicate
-// elementIdentifier).
+// more than once.
+//
+// That second case includes a collision BETWEEN namespaces, which is not a
+// malformed credential: ISO 18013-5 scopes digestID to its namespace, and
+// this package's own MSOBuilder counts from zero per namespace, so two
+// namespaces sharing digestID 0 is entirely well-formed. The limitation is
+// the wire extension's, not the mdoc's - claimSlotDigestIds is a flat list
+// of digestIDs with no namespace beside them, so nothing downstream could
+// place a colliding pair in the right slots even if this map allowed them
+// through. Rejecting is therefore the honest outcome rather than a
+// conservative one, but the error says which namespaces collided so it
+// does not read as a wallet bug. Disclosing across namespaces in one Vega
+// presentation needs a wire change; see that document.
 func (dd *ZkDocumentDataMdoc) IssuerSignedItemsByDigestID() (map[uint32]ZkSignedItemMdoc, error) {
 	out := make(map[uint32]ZkSignedItemMdoc)
+	// Which namespace each digestID came from, so a cross-namespace
+	// collision can be reported as the wire-format constraint it is rather
+	// than as a duplicate the wallet got wrong.
+	seenNS := make(map[uint32]string)
 	for ns, items := range dd.IssuerSigned {
 		for _, item := range items {
 			if item.DigestID == nil {
 				return nil, fmt.Errorf("issuerSigned item %q (namespace %q) has no digestId - required for Vega claim matching", item.ElementIdentifier, ns)
 			}
 			if existing, ok := out[*item.DigestID]; ok {
+				if existingNS, sameNS := seenNS[*item.DigestID]; sameNS && existingNS != ns {
+					return nil, fmt.Errorf(
+						"digestId %d appears in both namespace %q (%q) and namespace %q (%q): digestIDs are namespace-scoped in ISO 18013-5, but claimSlotDigestIds carries no namespace, so a Vega presentation cannot disclose colliding digestIDs from two namespaces",
+						*item.DigestID, existingNS, existing.ElementIdentifier, ns, item.ElementIdentifier,
+					)
+				}
 				return nil, fmt.Errorf(
 					"digestId %d is disclosed more than once (%q and %q) - ambiguous, refusing to guess which one was intended",
 					*item.DigestID, existing.ElementIdentifier, item.ElementIdentifier,
 				)
 			}
 			out[*item.DigestID] = item
+			seenNS[*item.DigestID] = ns
 		}
 	}
 	return out, nil

--- a/pkg/mdoc/zk_native_cgo_vega.go
+++ b/pkg/mdoc/zk_native_cgo_vega.go
@@ -1,0 +1,253 @@
+//go:build zknative
+
+package mdoc
+
+// This file provides the real implementation of nativeVerifyZkProofVega -
+// the Vega counterpart of zk_native_cgo.go's nativeVerifyZkProofWithPPID.
+//
+// Unlike the Longfellow path, this does NOT link zk-cred-vega's cgo
+// binding directly into this process. Per the agreed cgo-risk mitigation
+// (see ~/.claude/plans/dreamy-frolicking-chipmunk.md's "cgo risk decision"
+// and pkg/mdoc/zknative_vega's own package doc), the actual cgo call
+// touching attacker-controlled proof bytes runs in the isolated
+// cmd/zkvegaverifyworker subprocess instead: this file only resolves the
+// wallet-declared zkSystemId to a verifier-key artifact (caching the raw
+// bytes, same shape as getOrLoadVerifier below) and execs the worker once
+// per verify call, so a memory-safety fault in the native library only
+// takes down one worker process, not this one.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/SUNET/vc/pkg/mdoc/zkcircuit"
+	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
+)
+
+// DefaultZkVegaWorkerPath is used when ZkVerifierConfig.VegaWorkerPath is
+// empty - resolved via the OS's normal PATH lookup at exec time (see
+// exec.Command's own doc on bare-name resolution), so a deployment only
+// needs cmd/zkvegaverifyworker's build output somewhere on PATH rather
+// than wiring an absolute path through config.
+const DefaultZkVegaWorkerPath = "zkvegaverifyworker"
+
+// nativeVerifyZkProofVega resolves zkSystemID (the wallet-declared
+// PROVER-key catalog id, e.g. "vega-mc-p256-v1-prover-key-r7" - see
+// getOrLoadVegaVerifierKey's doc comment for why the corresponding
+// VERIFIER-key entry has to be separately resolved) to a verifier-key
+// artifact, then execs the isolated worker subprocess to verify proof
+// against it.
+//
+// This does NOT perform the caller's own comparison checks (issuer pubkey
+// vs. trust-evaluated cert, disclosed plaintext vs. wire-declared
+// elementValue, validity window vs. now) - see zk_verifier.go's Vega
+// dispatch branch for those; this function only reports what the proof
+// itself proved.
+func nativeVerifyZkProofVega(
+	ctx context.Context,
+	zkSystemID string,
+	proof []byte,
+	zkCircuitSources []string,
+	workerPath string,
+) (zkvegaworker.VerifyResult, error) {
+	verifierKeyBytes, err := getOrLoadVegaVerifierKey(ctx, zkSystemID, zkCircuitSources)
+	if err != nil {
+		return zkvegaworker.VerifyResult{}, fmt.Errorf("failed to resolve/load Vega verifier key for %q: %w", zkSystemID, err)
+	}
+
+	if workerPath == "" {
+		workerPath = DefaultZkVegaWorkerPath
+	}
+	result, err := runZkVegaVerifyWorker(ctx, workerPath, verifierKeyBytes, proof)
+	if err != nil {
+		return zkvegaworker.VerifyResult{}, fmt.Errorf("Vega ZK proof verification failed: %w", err)
+	}
+	return result, nil
+}
+
+// runZkVegaVerifyWorker execs workerPath, writes a zkvegaworker.Request as
+// JSON to its stdin, and reads a zkvegaworker.Response as JSON from its
+// stdout - see pkg/mdoc/zkvegaworker's package doc for the full protocol
+// and subprocess-isolation rationale. One process per call (see that
+// package's doc on why this isn't pooled yet).
+func runZkVegaVerifyWorker(ctx context.Context, workerPath string, verifierKeyBytes, proof []byte) (zkvegaworker.VerifyResult, error) {
+	reqBytes, err := json.Marshal(zkvegaworker.Request{
+		VerifierKeyBytes: verifierKeyBytes,
+		ProofBytes:       proof,
+	})
+	if err != nil {
+		return zkvegaworker.VerifyResult{}, fmt.Errorf("encoding worker request: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, workerPath)
+	cmd.Stdin = bytes.NewReader(reqBytes)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	var resp zkvegaworker.Response
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &resp); decodeErr != nil {
+		// The worker may have crashed (e.g. a memory-safety fault in the
+		// native library) before writing any valid JSON at all - report
+		// the raw exit error/stderr rather than a confusing JSON decode
+		// error, since that's the actually useful signal here.
+		if runErr != nil {
+			return zkvegaworker.VerifyResult{}, fmt.Errorf("worker exited without a valid response (%w); stderr: %s", runErr, strings.TrimSpace(stderr.String()))
+		}
+		return zkvegaworker.VerifyResult{}, fmt.Errorf("failed to decode worker response: %w; stderr: %s", decodeErr, strings.TrimSpace(stderr.String()))
+	}
+	if resp.Error != "" {
+		return zkvegaworker.VerifyResult{}, fmt.Errorf("%s", resp.Error)
+	}
+	if resp.Result == nil {
+		return zkvegaworker.VerifyResult{}, fmt.Errorf("worker reported neither a result nor an error")
+	}
+	return *resp.Result, nil
+}
+
+// vegaVerifierKeyCacheState caches raw (decompressed) verifier-key
+// artifact bytes, keyed by the wallet-declared PROVER-key zkSystemID -
+// mirrors verifierCacheState's shape/in-flight-dedup pattern below, but
+// caches bytes rather than a loaded native handle: deserialization into a
+// native handle happens once PER WORKER INVOCATION (see
+// zknative_vega.NewVerifierKey), not once per process, since the handle
+// only ever exists inside a short-lived worker subprocess.
+var vegaVerifierKeyCacheState = struct {
+	mu    sync.Mutex
+	byID  map[string][]byte
+	inFly map[string]*inFlightLoad
+}{
+	byID:  make(map[string][]byte),
+	inFly: make(map[string]*inFlightLoad),
+}
+
+// getOrLoadVegaVerifierKey returns cached, raw (decompressed) verifier-key
+// bytes for the wallet-declared zkSystemID, loading them on a cache miss.
+//
+// zkSystemID (from ZkDocumentDataMdoc.ZkSystemID, i.e. ZkSystemSpec.id on
+// the wallet side - see SirosWallet.buildZkPresentationToken) is the
+// PROVER-key catalog entry id the wallet actually used to build the proof
+// (e.g. "vega-mc-p256-v1-prover-key-r7") - unlike Longfellow, where one
+// circuit artifact serves both roles, zk-cred-vega publishes SEPARATE
+// prover-key/verifier-key catalog entries (see go-zk-circuits' vega-mc
+// catalog: params.role "prover" vs "verifier", same system+systemVersion).
+// A verifier never needs the prover key at all, so this resolves the
+// CORRESPONDING verifier-key entry instead: fetch the prover descriptor
+// first (to read its System/SystemVersion), then search the full manifest
+// for the sibling entry with the same System+SystemVersion and
+// params.role == "verifier" - robust against the exact id-suffix
+// convention (e.g. "-prover-key-r7" -> "-verifier-key-r7") ever changing,
+// unlike a plain string substitution would be.
+func getOrLoadVegaVerifierKey(ctx context.Context, zkSystemID string, zkCircuitSources []string) (verifierKeyBytes []byte, err error) {
+	vegaVerifierKeyCacheState.mu.Lock()
+	if cached, ok := vegaVerifierKeyCacheState.byID[zkSystemID]; ok {
+		vegaVerifierKeyCacheState.mu.Unlock()
+		return cached, nil
+	}
+	if load, loading := vegaVerifierKeyCacheState.inFly[zkSystemID]; loading {
+		vegaVerifierKeyCacheState.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("waiting for Vega verifier key %q to finish loading on another goroutine: %w", zkSystemID, ctx.Err())
+		case <-load.done:
+		}
+		if load.err != nil {
+			return nil, fmt.Errorf("Vega verifier key %q failed to load on another goroutine: %w", zkSystemID, load.err)
+		}
+		vegaVerifierKeyCacheState.mu.Lock()
+		cached, ok := vegaVerifierKeyCacheState.byID[zkSystemID]
+		vegaVerifierKeyCacheState.mu.Unlock()
+		if !ok {
+			return nil, fmt.Errorf("Vega verifier key %q finished loading on another goroutine but is unexpectedly missing from the cache", zkSystemID)
+		}
+		return cached, nil
+	}
+
+	load := &inFlightLoad{done: make(chan struct{})}
+	vegaVerifierKeyCacheState.inFly[zkSystemID] = load
+	vegaVerifierKeyCacheState.mu.Unlock()
+
+	defer func() {
+		if r := recover(); r != nil {
+			vegaVerifierKeyCacheState.mu.Lock()
+			load.err = fmt.Errorf("panic while loading Vega verifier key %q: %v", zkSystemID, r)
+			delete(vegaVerifierKeyCacheState.inFly, zkSystemID)
+			close(load.done)
+			vegaVerifierKeyCacheState.mu.Unlock()
+			panic(r)
+		}
+
+		vegaVerifierKeyCacheState.mu.Lock()
+		if err == nil && len(verifierKeyBytes) > 0 {
+			vegaVerifierKeyCacheState.byID[zkSystemID] = verifierKeyBytes
+		}
+		load.err = err
+		delete(vegaVerifierKeyCacheState.inFly, zkSystemID)
+		close(load.done)
+		vegaVerifierKeyCacheState.mu.Unlock()
+	}()
+
+	client := zkcircuit.NewClient(zkCircuitSources...)
+	proverDescriptor, fetchErr := client.FetchCircuit(ctx, zkSystemID)
+	if fetchErr != nil {
+		err = fmt.Errorf("fetching prover-key circuit descriptor: %w", fetchErr)
+		return nil, err
+	}
+
+	manifest, manifestErr := client.FetchManifest(ctx)
+	if manifestErr != nil {
+		err = fmt.Errorf("fetching circuit manifest to resolve verifier-key sibling: %w", manifestErr)
+		return nil, err
+	}
+
+	verifierDescriptor, findErr := findVegaVerifierKeyEntry(manifest, proverDescriptor)
+	if findErr != nil {
+		err = findErr
+		return nil, err
+	}
+
+	circuitBytes, dlErr := client.DownloadAndDecompress(ctx, verifierDescriptor)
+	if dlErr != nil {
+		err = fmt.Errorf("downloading verifier-key artifact %q: %w", verifierDescriptor.ID, dlErr)
+		return nil, err
+	}
+
+	verifierKeyBytes = circuitBytes
+	return verifierKeyBytes, nil
+}
+
+// findVegaVerifierKeyEntry searches manifest for the single entry sharing
+// proverDescriptor's System/SystemVersion with params.role == "verifier" -
+// see getOrLoadVegaVerifierKey's doc comment for why this lookup (rather
+// than a naming-convention string substitution) is used.
+func findVegaVerifierKeyEntry(manifest *zkcircuit.Manifest, proverDescriptor *zkcircuit.CircuitDescriptor) (*zkcircuit.CircuitDescriptor, error) {
+	var match *zkcircuit.CircuitDescriptor
+	for i := range manifest.Circuits {
+		c := &manifest.Circuits[i]
+		if c.System != proverDescriptor.System || c.SystemVersion != proverDescriptor.SystemVersion {
+			continue
+		}
+		role, _ := c.ParamString("role")
+		if role != "verifier" {
+			continue
+		}
+		if match != nil {
+			return nil, fmt.Errorf(
+				"more than one verifier-key entry found for system %q version %q (%q and %q) - ambiguous, refusing to guess which one was intended",
+				proverDescriptor.System, proverDescriptor.SystemVersion, match.ID, c.ID,
+			)
+		}
+		match = c
+	}
+	if match == nil {
+		return nil, fmt.Errorf("no verifier-key entry found for system %q version %q (prover-key id %q)", proverDescriptor.System, proverDescriptor.SystemVersion, proverDescriptor.ID)
+	}
+	return match, nil
+}

--- a/pkg/mdoc/zk_native_cgo_vega.go
+++ b/pkg/mdoc/zk_native_cgo_vega.go
@@ -52,6 +52,7 @@ func nativeVerifyZkProofVega(
 	ctx context.Context,
 	zkSystemID string,
 	proof []byte,
+	disclosedBytes [][]byte,
 	zkCircuitSources []string,
 	workerPath string,
 ) (zkvegaworker.VerifyResult, error) {
@@ -63,7 +64,7 @@ func nativeVerifyZkProofVega(
 	if workerPath == "" {
 		workerPath = DefaultZkVegaWorkerPath
 	}
-	result, err := runZkVegaVerifyWorker(ctx, workerPath, verifierKeyBytes, proof)
+	result, err := runZkVegaVerifyWorker(ctx, workerPath, verifierKeyBytes, proof, disclosedBytes)
 	if err != nil {
 		return zkvegaworker.VerifyResult{}, fmt.Errorf("Vega ZK proof verification failed: %w", err)
 	}
@@ -75,10 +76,11 @@ func nativeVerifyZkProofVega(
 // stdout - see pkg/mdoc/zkvegaworker's package doc for the full protocol
 // and subprocess-isolation rationale. One process per call (see that
 // package's doc on why this isn't pooled yet).
-func runZkVegaVerifyWorker(ctx context.Context, workerPath string, verifierKeyBytes, proof []byte) (zkvegaworker.VerifyResult, error) {
+func runZkVegaVerifyWorker(ctx context.Context, workerPath string, verifierKeyBytes, proof []byte, disclosedBytes [][]byte) (zkvegaworker.VerifyResult, error) {
 	reqBytes, err := json.Marshal(zkvegaworker.Request{
 		VerifierKeyBytes: verifierKeyBytes,
 		ProofBytes:       proof,
+		DisclosedBytes:   disclosedBytes,
 	})
 	if err != nil {
 		return zkvegaworker.VerifyResult{}, fmt.Errorf("encoding worker request: %w", err)

--- a/pkg/mdoc/zk_native_cgo_vega.go
+++ b/pkg/mdoc/zk_native_cgo_vega.go
@@ -6,9 +6,9 @@ package mdoc
 // the Vega counterpart of zk_native_cgo.go's nativeVerifyZkProofWithPPID.
 //
 // Unlike the Longfellow path, this does NOT link zk-cred-vega's cgo
-// binding directly into this process. Per the agreed cgo-risk mitigation
-// (see ~/.claude/plans/dreamy-frolicking-chipmunk.md's "cgo risk decision"
-// and pkg/mdoc/zknative_vega's own package doc), the actual cgo call
+// binding directly into this process. The reason is the cgo risk this
+// package cannot mitigate any other way (see pkg/mdoc/zknative_vega's own
+// package doc, and docs/ZK_PPID_VERIFICATION_PLAN.md): the actual cgo call
 // touching attacker-controlled proof bytes runs in the isolated
 // cmd/zkvegaverifyworker subprocess instead: this file only resolves the
 // wallet-declared zkSystemId to a verifier-key artifact (caching the raw
@@ -110,6 +110,15 @@ func runZkVegaVerifyWorker(ctx context.Context, workerPath string, verifierKeyBy
 	}
 	if resp.Result == nil {
 		return zkvegaworker.VerifyResult{}, fmt.Errorf("worker reported neither a result nor an error")
+	}
+	// A parseable success response is not on its own proof the worker
+	// finished cleanly: it could have written a result and then died (a
+	// fault in the native library after the answer was serialized, or a
+	// context kill). The protocol says a successful worker exits zero, so a
+	// non-zero exit here contradicts the response and the response is not
+	// trustworthy.
+	if runErr != nil {
+		return zkvegaworker.VerifyResult{}, fmt.Errorf("worker returned a result but exited non-zero (%w); stderr: %s", runErr, strings.TrimSpace(stderr.String()))
 	}
 	return *resp.Result, nil
 }

--- a/pkg/mdoc/zk_native_cgo_vega.go
+++ b/pkg/mdoc/zk_native_cgo_vega.go
@@ -106,6 +106,12 @@ func runZkVegaVerifyWorker(ctx context.Context, workerPath string, verifierKeyBy
 		return zkvegaworker.VerifyResult{}, fmt.Errorf("failed to decode worker response: %w; stderr: %s", decodeErr, strings.TrimSpace(stderr.String()))
 	}
 	if resp.Error != "" {
+		// stderr comes along: a native fault can print a diagnostic there and
+		// still let the worker serialize an error, and dropping it leaves the
+		// most useful half of the failure on the floor.
+		if diag := strings.TrimSpace(stderr.String()); diag != "" {
+			return zkvegaworker.VerifyResult{}, fmt.Errorf("%s; stderr: %s", resp.Error, diag)
+		}
 		return zkvegaworker.VerifyResult{}, fmt.Errorf("%s", resp.Error)
 	}
 	if resp.Result == nil {
@@ -130,12 +136,16 @@ func runZkVegaVerifyWorker(ctx context.Context, workerPath string, verifierKeyBy
 // native handle happens once PER WORKER INVOCATION (see
 // zknative_vega.NewVerifierKey), not once per process, since the handle
 // only ever exists inside a short-lived worker subprocess.
+//
+// The blobs themselves live in a byte-bounded LRU - see vegaKeyCache, which
+// is in its own untagged file so its eviction rule can be tested without the
+// crate staged. The mutex here covers both that and the in-flight map.
 var vegaVerifierKeyCacheState = struct {
 	mu    sync.Mutex
-	byID  map[string][]byte
+	keys  *vegaKeyCache
 	inFly map[string]*inFlightLoad
 }{
-	byID:  make(map[string][]byte),
+	keys:  newVegaKeyCache(maxVegaVerifierKeyCacheBytes),
 	inFly: make(map[string]*inFlightLoad),
 }
 
@@ -158,7 +168,7 @@ var vegaVerifierKeyCacheState = struct {
 // unlike a plain string substitution would be.
 func getOrLoadVegaVerifierKey(ctx context.Context, zkSystemID string, zkCircuitSources []string) (verifierKeyBytes []byte, err error) {
 	vegaVerifierKeyCacheState.mu.Lock()
-	if cached, ok := vegaVerifierKeyCacheState.byID[zkSystemID]; ok {
+	if cached, ok := vegaVerifierKeyCacheState.keys.get(zkSystemID); ok {
 		vegaVerifierKeyCacheState.mu.Unlock()
 		return cached, nil
 	}
@@ -173,7 +183,7 @@ func getOrLoadVegaVerifierKey(ctx context.Context, zkSystemID string, zkCircuitS
 			return nil, fmt.Errorf("Vega verifier key %q failed to load on another goroutine: %w", zkSystemID, load.err)
 		}
 		vegaVerifierKeyCacheState.mu.Lock()
-		cached, ok := vegaVerifierKeyCacheState.byID[zkSystemID]
+		cached, ok := vegaVerifierKeyCacheState.keys.get(zkSystemID)
 		vegaVerifierKeyCacheState.mu.Unlock()
 		if !ok {
 			return nil, fmt.Errorf("Vega verifier key %q finished loading on another goroutine but is unexpectedly missing from the cache", zkSystemID)
@@ -197,7 +207,7 @@ func getOrLoadVegaVerifierKey(ctx context.Context, zkSystemID string, zkCircuitS
 
 		vegaVerifierKeyCacheState.mu.Lock()
 		if err == nil && len(verifierKeyBytes) > 0 {
-			vegaVerifierKeyCacheState.byID[zkSystemID] = verifierKeyBytes
+			vegaVerifierKeyCacheState.keys.put(zkSystemID, verifierKeyBytes)
 		}
 		load.err = err
 		delete(vegaVerifierKeyCacheState.inFly, zkSystemID)

--- a/pkg/mdoc/zk_native_cgo_vega.go
+++ b/pkg/mdoc/zk_native_cgo_vega.go
@@ -139,7 +139,16 @@ func runZkVegaVerifyWorker(ctx context.Context, workerPath string, verifierKeyBy
 //
 // The blobs themselves live in a byte-bounded LRU - see vegaKeyCache, which
 // is in its own untagged file so its eviction rule can be tested without the
-// crate staged. The mutex here covers both that and the in-flight map.
+// crate staged, and whose doc comment explains why this cache sits outside
+// pkg/cache and Common.HA. The mutex here covers both that and the in-flight
+// map.
+//
+// inFly dedups concurrent loads within one process only. Under HA that means
+// each instance fetches a given artifact once rather than one fetching it for
+// the whole deployment - N cold-start fetches from the circuit catalog, not
+// one. Acceptable (they are cache misses on immutable public artifacts, and
+// the catalog is a CDN-shaped mirror list), but worth knowing before reading
+// a burst of identical fetches as a bug.
 var vegaVerifierKeyCacheState = struct {
 	mu    sync.Mutex
 	keys  *vegaKeyCache

--- a/pkg/mdoc/zk_native_stub.go
+++ b/pkg/mdoc/zk_native_stub.go
@@ -14,7 +14,11 @@ package mdoc
 // argument assembly, verifier_context derivation - see zk_verifier.go) is
 // real and already runs before either of these functions is reached.
 
-import "context"
+import (
+	"context"
+
+	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
+)
 
 // nativeVerifyZkProof is the (stubbed) call site for a non-PPID native ZK
 // verify. See docs/ZK_PPID_VERIFICATION_PLAN.md for what a real binding
@@ -55,4 +59,16 @@ func nativeVerifyZkProofWithPPID(
 	zkCircuitSources []string,
 ) error {
 	return ErrNativeZkVerifyNotImplemented
+}
+
+// nativeVerifyZkProofVega is the (stubbed) call site for Vega verification.
+// Real with the "zknative" build tag - see zk_native_cgo_vega.go.
+func nativeVerifyZkProofVega(
+	ctx context.Context,
+	zkSystemID string,
+	proof []byte,
+	zkCircuitSources []string,
+	workerPath string,
+) (zkvegaworker.VerifyResult, error) {
+	return zkvegaworker.VerifyResult{}, ErrNativeZkVerifyNotImplemented
 }

--- a/pkg/mdoc/zk_native_stub.go
+++ b/pkg/mdoc/zk_native_stub.go
@@ -67,6 +67,7 @@ func nativeVerifyZkProofVega(
 	ctx context.Context,
 	zkSystemID string,
 	proof []byte,
+	disclosedBytes [][]byte,
 	zkCircuitSources []string,
 	workerPath string,
 ) (zkvegaworker.VerifyResult, error) {

--- a/pkg/mdoc/zk_native_stub.go
+++ b/pkg/mdoc/zk_native_stub.go
@@ -71,5 +71,5 @@ func nativeVerifyZkProofVega(
 	zkCircuitSources []string,
 	workerPath string,
 ) (zkvegaworker.VerifyResult, error) {
-	return zkvegaworker.VerifyResult{}, ErrNativeZkVerifyNotImplemented
+	return zkvegaworker.VerifyResult{}, ErrNativeVegaVerifyNotImplemented
 }

--- a/pkg/mdoc/zk_verifier.go
+++ b/pkg/mdoc/zk_verifier.go
@@ -503,6 +503,14 @@ func checkVegaIssuerKeyMatches(issuerPubKeySEC1, qx, qy []byte) error {
 // entry.original.EncodeToBytes()`), not just the bare elementValue -
 // checkVegaDisclosedClaimsMatchWire decodes this to extract ElementValue
 // for comparison against the wire-declared value.
+//
+// The returned plaintext is the item's real wire bytes verbatim - a
+// #6.24(bstr <map>)-wrapped CBOR item, not a bare map (confirmed against a
+// real device presentation's captured claim bytes: `d818 58XX a4...`) -
+// so it must be unwrapped via EncodedCBORBytes before unmarshaling into
+// this struct; unmarshaling the tagged bytes directly fails with "cannot
+// unmarshal byte string into" this type, since the top-level CBOR item is
+// a tagged byte string, not a map.
 type vegaIssuerSignedItemPlaintext struct {
 	DigestID          uint32 `cbor:"digestID"`
 	Random            []byte `cbor:"random"`
@@ -552,8 +560,12 @@ func checkVegaDisclosedClaimsMatchWire(dd *ZkDocumentDataMdoc, claims []zkvegawo
 			return fmt.Errorf("claim %q (digestId %d) is declared on the wire but the ZK proof never disclosed that digestId", wireItem.ElementIdentifier, digestID)
 		}
 
+		var wrapped EncodedCBORBytes
+		if err := cborEncoder.Unmarshal(proofClaim.Plaintext, &wrapped); err != nil {
+			return fmt.Errorf("failed to unwrap tag(24) from proof-disclosed plaintext for digestId %d: %w", digestID, err)
+		}
 		var plaintext vegaIssuerSignedItemPlaintext
-		if err := cborEncoder.Unmarshal(proofClaim.Plaintext, &plaintext); err != nil {
+		if err := cborEncoder.Unmarshal(wrapped, &plaintext); err != nil {
 			return fmt.Errorf("failed to decode proof-disclosed plaintext for digestId %d: %w", digestID, err)
 		}
 

--- a/pkg/mdoc/zk_verifier.go
+++ b/pkg/mdoc/zk_verifier.go
@@ -36,8 +36,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
 	"github.com/SUNET/vc/pkg/openid4vp"
 	"github.com/SUNET/vc/pkg/trust"
 
@@ -447,7 +445,12 @@ func (h *ZkHandler) verifyOneDocument(ctx context.Context, zkDoc *ZkDocumentMdoc
 // for the real research task pseudonym support needs before that
 // changes).
 func (h *ZkHandler) verifyVegaDocument(ctx context.Context, zkDoc *ZkDocumentMdoc, dd *ZkDocumentDataMdoc, dsCert *x509.Certificate) (*ZkDocumentResult, error) {
-	result, err := nativeVerifyZkProofVega(ctx, dd.ZkSystemID, zkDoc.Proof, h.zkCircuitSources, h.vegaWorkerPath)
+	disclosedBytes, err := BuildVegaDisclosedBytes(dd)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := nativeVerifyZkProofVega(ctx, dd.ZkSystemID, zkDoc.Proof, disclosedBytes, h.zkCircuitSources, h.vegaWorkerPath)
 	if err != nil {
 		return nil, err
 	}
@@ -460,9 +463,11 @@ func (h *ZkHandler) verifyVegaDocument(ctx context.Context, zkDoc *ZkDocumentMdo
 		return nil, err
 	}
 
-	if err := checkVegaDisclosedClaimsMatchWire(dd, result.Claims); err != nil {
-		return nil, err
-	}
+	// checkVegaDisclosedClaimsMatchWire's job (pre-r12) is now done more
+	// strongly, and earlier, by BuildVegaDisclosedBytes + verify() itself:
+	// disclosedBytes above IS the wire's own issuerSignedItemBytes, so a
+	// successful verify() already proves the proof's binding matches the
+	// EXACT wire bytes, not just their decoded elementValue.
 
 	if err := checkVegaValidityWindow(result.ValidFromTs, result.ValidUntilTs, h.clock()); err != nil {
 		return nil, err
@@ -474,6 +479,58 @@ func (h *ZkHandler) verifyVegaDocument(ctx context.Context, zkDoc *ZkDocumentMdo
 		Claims:     dd.FlattenIssuerSigned(),
 		Pseudonym:  nil,
 	}, nil
+}
+
+// vegaMaxClaims mirrors zk-cred-vega's MAX_CLAIMS_V1 (also
+// VegaProofSystem.MAX_CLAIMS_V1 in siros-sdk-kotlin, ZK_CRED_VEGA_MAX_CLAIMS
+// in zk_cred_vega_go.h) - duplicated here (not imported from the
+// "zknative"-tagged zknative_vega package) since this file has no zknative
+// build tag and must compile in both configurations.
+const vegaMaxClaims = 4
+
+// BuildVegaDisclosedBytes builds zk_cred_vega's r12 verify() input: exactly
+// vegaMaxClaims entries, in claim-slot order, each either a disclosed
+// slot's real IssuerSignedItemBytes or an empty slice for an undisclosed
+// one - see docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md's r12 addendum for the
+// full rationale.
+//
+// Returns an error if dd.ClaimSlotDigestIds is absent or the wrong length
+// (a pre-r12 Vega artifact, or a non-Vega presentation mistakenly routed
+// here), if a disclosed wire item has no issuerSignedItemBytes, or if a
+// disclosed wire item's digestId doesn't appear in ClaimSlotDigestIds at
+// all (a claim the wallet declared disclosed with no proof slot binding
+// for it - reject rather than silently drop it).
+func BuildVegaDisclosedBytes(dd *ZkDocumentDataMdoc) ([][]byte, error) {
+	if len(dd.ClaimSlotDigestIds) != vegaMaxClaims {
+		return nil, fmt.Errorf("expected exactly %d claimSlotDigestIds (one per Vega circuit slot), got %d", vegaMaxClaims, len(dd.ClaimSlotDigestIds))
+	}
+
+	byDigestID, err := dd.IssuerSignedItemsByDigestID()
+	if err != nil {
+		return nil, err
+	}
+
+	used := make(map[uint32]bool, len(byDigestID))
+	disclosedBytes := make([][]byte, vegaMaxClaims)
+	for i, digestID := range dd.ClaimSlotDigestIds {
+		item, ok := byDigestID[digestID]
+		if !ok {
+			continue // undisclosed slot - leave disclosedBytes[i] nil (empty).
+		}
+		if len(item.IssuerSignedItemBytes) == 0 {
+			return nil, fmt.Errorf("claim %q (digestId %d) is disclosed but has no issuerSignedItemBytes on the wire", item.ElementIdentifier, digestID)
+		}
+		disclosedBytes[i] = item.IssuerSignedItemBytes
+		used[digestID] = true
+	}
+
+	for digestID, item := range byDigestID {
+		if !used[digestID] {
+			return nil, fmt.Errorf("claim %q (digestId %d) is disclosed on the wire but does not appear in claimSlotDigestIds - no proof slot binds it", item.ElementIdentifier, digestID)
+		}
+	}
+
+	return disclosedBytes, nil
 }
 
 // checkVegaIssuerKeyMatches rejects a proof whose recomputed issuer public
@@ -492,94 +549,6 @@ func checkVegaIssuerKeyMatches(issuerPubKeySEC1, qx, qy []byte) error {
 	}
 	if !bytes.Equal(issuerPubKeySEC1[1:33], qx) || !bytes.Equal(issuerPubKeySEC1[33:65], qy) {
 		return fmt.Errorf("Vega proof's recomputed issuer public key does not match the trust-evaluated certificate's public key")
-	}
-	return nil
-}
-
-// vegaIssuerSignedItemPlaintext is the CBOR shape of the plaintext bytes
-// zk-cred-vega's verify returns for a disclosed claim: the FULL, original
-// IssuerSignedItem structure (see VegaProofSystem.buildWitness's doc
-// comment in siros-sdk-kotlin: `issuerSignedItemBytes =
-// entry.original.EncodeToBytes()`), not just the bare elementValue -
-// checkVegaDisclosedClaimsMatchWire decodes this to extract ElementValue
-// for comparison against the wire-declared value.
-//
-// The returned plaintext is the item's real wire bytes verbatim - a
-// #6.24(bstr <map>)-wrapped CBOR item, not a bare map (confirmed against a
-// real device presentation's captured claim bytes: `d818 58XX a4...`) -
-// so it must be unwrapped via EncodedCBORBytes before unmarshaling into
-// this struct; unmarshaling the tagged bytes directly fails with "cannot
-// unmarshal byte string into" this type, since the top-level CBOR item is
-// a tagged byte string, not a map.
-type vegaIssuerSignedItemPlaintext struct {
-	DigestID          uint32 `cbor:"digestID"`
-	Random            []byte `cbor:"random"`
-	ElementIdentifier string `cbor:"elementIdentifier"`
-	ElementValue      any    `cbor:"elementValue"`
-}
-
-// checkVegaDisclosedClaimsMatchWire is the check that prevents a wallet
-// from proving one claim value while declaring a different one on the
-// wire: for every claim declared in dd.IssuerSigned (indexed by digestId -
-// see ZkDocumentDataMdoc.IssuerSignedItemsByDigestID and
-// docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md), the proof must have actually
-// disclosed that same digestId, and the plaintext it proved must
-// canonical-CBOR-match the wire-declared elementValue.
-//
-// Deliberately does NOT require the reverse (every proof-disclosed slot
-// also appearing on the wire) - a wallet choosing not to reveal something
-// the proof could have revealed is harmless.
-func checkVegaDisclosedClaimsMatchWire(dd *ZkDocumentDataMdoc, claims []zkvegaworker.DisclosedClaim) error {
-	wireByDigestID, err := dd.IssuerSignedItemsByDigestID()
-	if err != nil {
-		return fmt.Errorf("indexing wire-declared claims by digestId: %w", err)
-	}
-
-	proofByDigestID := make(map[uint32]zkvegaworker.DisclosedClaim, len(claims))
-	for _, c := range claims {
-		if !c.Disclosed {
-			continue
-		}
-		if _, dup := proofByDigestID[c.DigestID]; dup {
-			return fmt.Errorf("proof discloses digestId %d more than once - ambiguous, refusing to guess which slot was intended", c.DigestID)
-		}
-		proofByDigestID[c.DigestID] = c
-	}
-
-	// Canonical (sorted-map-key) CBOR encoding for comparison-safe values -
-	// see buildZkAttributes' own doc comment for why raw Go-value equality
-	// (e.g. reflect.DeepEqual) isn't used here.
-	cborEncoder, err := NewCBOREncoder()
-	if err != nil {
-		return fmt.Errorf("failed to create CBOR encoder: %w", err)
-	}
-
-	for digestID, wireItem := range wireByDigestID {
-		proofClaim, ok := proofByDigestID[digestID]
-		if !ok {
-			return fmt.Errorf("claim %q (digestId %d) is declared on the wire but the ZK proof never disclosed that digestId", wireItem.ElementIdentifier, digestID)
-		}
-
-		var wrapped EncodedCBORBytes
-		if err := cborEncoder.Unmarshal(proofClaim.Plaintext, &wrapped); err != nil {
-			return fmt.Errorf("failed to unwrap tag(24) from proof-disclosed plaintext for digestId %d: %w", digestID, err)
-		}
-		var plaintext vegaIssuerSignedItemPlaintext
-		if err := cborEncoder.Unmarshal(wrapped, &plaintext); err != nil {
-			return fmt.Errorf("failed to decode proof-disclosed plaintext for digestId %d: %w", digestID, err)
-		}
-
-		wireValueCBOR, err := cborEncoder.Marshal(wireItem.ElementValue)
-		if err != nil {
-			return fmt.Errorf("failed to encode wire-declared value for claim %q: %w", wireItem.ElementIdentifier, err)
-		}
-		proofValueCBOR, err := cborEncoder.Marshal(plaintext.ElementValue)
-		if err != nil {
-			return fmt.Errorf("failed to encode proof-disclosed value for digestId %d: %w", digestID, err)
-		}
-		if !bytes.Equal(wireValueCBOR, proofValueCBOR) {
-			return fmt.Errorf("claim %q (digestId %d): wire-declared value does not match the ZK proof's disclosed value", wireItem.ElementIdentifier, digestID)
-		}
 	}
 	return nil
 }

--- a/pkg/mdoc/zk_verifier.go
+++ b/pkg/mdoc/zk_verifier.go
@@ -25,6 +25,7 @@ package mdoc
 // verification is opt-in. See docs/ZK_PPID_VERIFICATION_PLAN.md and
 // README.md's "Native ZK/PPID proof verification" section for setup.
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
@@ -36,6 +37,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
 	"github.com/SUNET/vc/pkg/openid4vp"
 	"github.com/SUNET/vc/pkg/trust"
 
@@ -92,6 +94,16 @@ type ZkVerifierConfig struct {
 	// default stub. If empty, zkcircuit.DefaultZkCircuitURL is used.
 	ZkCircuitSources []string
 
+	// VegaWorkerPath is the path (or bare name, resolved via PATH) to the
+	// cmd/zkvegaverifyworker binary - see nativeVerifyZkProofVega's doc
+	// comment for why Vega verification execs an isolated subprocess
+	// rather than linking zk-cred-vega's cgo binding directly into this
+	// process. Only consulted when built with the "zknative" tag AND a
+	// presented document's zkSystemId identifies a Vega circuit; ignored
+	// otherwise. Defaults to nativeVerifyZkProofVega's own
+	// DefaultZkVegaWorkerPath if empty.
+	VegaWorkerPath string
+
 	// Clock is an optional function that returns the current time. Defaults
 	// to time.Now.
 	Clock func() time.Time
@@ -103,6 +115,7 @@ type ZkHandler struct {
 	trustEvaluator   trust.TrustEvaluator
 	issuerURL        string
 	zkCircuitSources []string
+	vegaWorkerPath   string
 	clock            func() time.Time
 }
 
@@ -119,6 +132,7 @@ func NewZkHandler(cfg ZkVerifierConfig) (*ZkHandler, error) {
 		trustEvaluator:   cfg.TrustEvaluator,
 		issuerURL:        cfg.IssuerURL,
 		zkCircuitSources: cfg.ZkCircuitSources,
+		vegaWorkerPath:   cfg.VegaWorkerPath,
 		clock:            clock,
 	}, nil
 }
@@ -347,7 +361,19 @@ func (h *ZkHandler) verifyOneDocument(ctx context.Context, zkDoc *ZkDocumentMdoc
 		return nil, fmt.Errorf("issuer not trusted: %s", decision.Reason)
 	}
 
-	// 3. Assemble the native call's arguments.
+	// 3. Call into the native ZK verifier - the two system families have
+	// genuinely different verify shapes (see nativeVerifyZkProofVega's doc
+	// comment), so this branches BEFORE any Longfellow-specific argument
+	// assembly below, not just at the final native-call site. Vega
+	// presentations never carry a pseudonym in the first place (no PPID
+	// concept in this v1 circuit - see verifyVegaDocument's own doc
+	// comment), so "which system" and "PPID or not" are kept as two
+	// independent axes rather than folded into one three-way if/else.
+	if strings.HasPrefix(dd.ZkSystemID, "vega-mc") {
+		return h.verifyVegaDocument(ctx, zkDoc, dd, dsCert)
+	}
+
+	// 4. Assemble the native call's arguments (Longfellow only).
 	issuerSigned := dd.FlattenIssuerSigned()
 	attributes, pseudonym, err := buildZkAttributes(issuerSigned, pctx.RequestedClaimIDs)
 	if err != nil {
@@ -380,7 +406,7 @@ func (h *ZkHandler) verifyOneDocument(ctx context.Context, zkDoc *ZkDocumentMdoc
 
 	timeStr := string(dd.Timestamp)
 
-	// 4. Call into the native ZK verifier.
+	// 5. Call into the native ZK verifier (Longfellow).
 	if pseudonym != nil {
 		verifierContext := ComputeZkVerifierContext(pctx.SessionID, pctx.ClientID, pctx.PPIDContext)
 		if err := nativeVerifyZkProofWithPPID(
@@ -405,6 +431,167 @@ func (h *ZkHandler) verifyOneDocument(ctx context.Context, zkDoc *ZkDocumentMdoc
 		Claims:     issuerSigned,
 		Pseudonym:  pseudonym,
 	}, nil
+}
+
+// verifyVegaDocument verifies a Vega ("vega-mc*") presentation -
+// nativeVerifyZkProofVega's own doc comment explains why this is a
+// genuinely different verify shape from the Longfellow path above, not a
+// drop-in call: Vega's verify only returns the RECOMPUTED public values,
+// so every check below - tying the proof to the trust-evaluated issuer,
+// checking disclosed claims against what the wire declares, checking the
+// credential's own validity window - is real, new comparison logic the
+// Longfellow path never needed (it hands its own expected values IN and
+// gets a bare pass/fail back). Vega presentations never carry a
+// pseudonym - this v1 circuit has no PPID concept at all (see
+// [[project_vega_broader_circuit_ambitions]] / the tracked plan's Phase 6
+// for the real research task pseudonym support needs before that
+// changes).
+func (h *ZkHandler) verifyVegaDocument(ctx context.Context, zkDoc *ZkDocumentMdoc, dd *ZkDocumentDataMdoc, dsCert *x509.Certificate) (*ZkDocumentResult, error) {
+	result, err := nativeVerifyZkProofVega(ctx, dd.ZkSystemID, zkDoc.Proof, h.zkCircuitSources, h.vegaWorkerPath)
+	if err != nil {
+		return nil, err
+	}
+
+	issuerPubKeySEC1, err := sec1PublicKeyFromCert(dsCert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract issuer public key: %w", err)
+	}
+	if err := checkVegaIssuerKeyMatches(issuerPubKeySEC1, result.Qx, result.Qy); err != nil {
+		return nil, err
+	}
+
+	if err := checkVegaDisclosedClaimsMatchWire(dd, result.Claims); err != nil {
+		return nil, err
+	}
+
+	if err := checkVegaValidityWindow(result.ValidFromTs, result.ValidUntilTs, h.clock()); err != nil {
+		return nil, err
+	}
+
+	return &ZkDocumentResult{
+		DocType:    dd.DocType,
+		ZkSystemID: dd.ZkSystemID,
+		Claims:     dd.FlattenIssuerSigned(),
+		Pseudonym:  nil,
+	}, nil
+}
+
+// checkVegaIssuerKeyMatches rejects a proof whose recomputed issuer public
+// key (qx/qy) doesn't match the certificate the trust decision was made
+// about - the check that ties the ZK proof to the SAME issuer as the
+// x5chain, not merely to "some trusted issuer".
+//
+// issuerPubKeySEC1 must be a 65-byte uncompressed SEC1 point
+// (0x04 || X(32) || Y(32) - sec1PublicKeyFromCert's own return shape);
+// qx/qy are each exactly 32 bytes (zk-cred-vega's fixed P-256 coordinate
+// width).
+func checkVegaIssuerKeyMatches(issuerPubKeySEC1, qx, qy []byte) error {
+	const sec1UncompressedLen = 1 + 32 + 32
+	if len(issuerPubKeySEC1) != sec1UncompressedLen || issuerPubKeySEC1[0] != 0x04 {
+		return fmt.Errorf("issuer certificate public key is not a %d-byte uncompressed SEC1 point (got %d bytes)", sec1UncompressedLen, len(issuerPubKeySEC1))
+	}
+	if !bytes.Equal(issuerPubKeySEC1[1:33], qx) || !bytes.Equal(issuerPubKeySEC1[33:65], qy) {
+		return fmt.Errorf("Vega proof's recomputed issuer public key does not match the trust-evaluated certificate's public key")
+	}
+	return nil
+}
+
+// vegaIssuerSignedItemPlaintext is the CBOR shape of the plaintext bytes
+// zk-cred-vega's verify returns for a disclosed claim: the FULL, original
+// IssuerSignedItem structure (see VegaProofSystem.buildWitness's doc
+// comment in siros-sdk-kotlin: `issuerSignedItemBytes =
+// entry.original.EncodeToBytes()`), not just the bare elementValue -
+// checkVegaDisclosedClaimsMatchWire decodes this to extract ElementValue
+// for comparison against the wire-declared value.
+type vegaIssuerSignedItemPlaintext struct {
+	DigestID          uint32 `cbor:"digestID"`
+	Random            []byte `cbor:"random"`
+	ElementIdentifier string `cbor:"elementIdentifier"`
+	ElementValue      any    `cbor:"elementValue"`
+}
+
+// checkVegaDisclosedClaimsMatchWire is the check that prevents a wallet
+// from proving one claim value while declaring a different one on the
+// wire: for every claim declared in dd.IssuerSigned (indexed by digestId -
+// see ZkDocumentDataMdoc.IssuerSignedItemsByDigestID and
+// docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md), the proof must have actually
+// disclosed that same digestId, and the plaintext it proved must
+// canonical-CBOR-match the wire-declared elementValue.
+//
+// Deliberately does NOT require the reverse (every proof-disclosed slot
+// also appearing on the wire) - a wallet choosing not to reveal something
+// the proof could have revealed is harmless.
+func checkVegaDisclosedClaimsMatchWire(dd *ZkDocumentDataMdoc, claims []zkvegaworker.DisclosedClaim) error {
+	wireByDigestID, err := dd.IssuerSignedItemsByDigestID()
+	if err != nil {
+		return fmt.Errorf("indexing wire-declared claims by digestId: %w", err)
+	}
+
+	proofByDigestID := make(map[uint32]zkvegaworker.DisclosedClaim, len(claims))
+	for _, c := range claims {
+		if !c.Disclosed {
+			continue
+		}
+		if _, dup := proofByDigestID[c.DigestID]; dup {
+			return fmt.Errorf("proof discloses digestId %d more than once - ambiguous, refusing to guess which slot was intended", c.DigestID)
+		}
+		proofByDigestID[c.DigestID] = c
+	}
+
+	// Canonical (sorted-map-key) CBOR encoding for comparison-safe values -
+	// see buildZkAttributes' own doc comment for why raw Go-value equality
+	// (e.g. reflect.DeepEqual) isn't used here.
+	cborEncoder, err := NewCBOREncoder()
+	if err != nil {
+		return fmt.Errorf("failed to create CBOR encoder: %w", err)
+	}
+
+	for digestID, wireItem := range wireByDigestID {
+		proofClaim, ok := proofByDigestID[digestID]
+		if !ok {
+			return fmt.Errorf("claim %q (digestId %d) is declared on the wire but the ZK proof never disclosed that digestId", wireItem.ElementIdentifier, digestID)
+		}
+
+		var plaintext vegaIssuerSignedItemPlaintext
+		if err := cborEncoder.Unmarshal(proofClaim.Plaintext, &plaintext); err != nil {
+			return fmt.Errorf("failed to decode proof-disclosed plaintext for digestId %d: %w", digestID, err)
+		}
+
+		wireValueCBOR, err := cborEncoder.Marshal(wireItem.ElementValue)
+		if err != nil {
+			return fmt.Errorf("failed to encode wire-declared value for claim %q: %w", wireItem.ElementIdentifier, err)
+		}
+		proofValueCBOR, err := cborEncoder.Marshal(plaintext.ElementValue)
+		if err != nil {
+			return fmt.Errorf("failed to encode proof-disclosed value for digestId %d: %w", digestID, err)
+		}
+		if !bytes.Equal(wireValueCBOR, proofValueCBOR) {
+			return fmt.Errorf("claim %q (digestId %d): wire-declared value does not match the ZK proof's disclosed value", wireItem.ElementIdentifier, digestID)
+		}
+	}
+	return nil
+}
+
+// checkVegaValidityWindow checks the credential's own MSO validity window
+// (proven by the circuit, not otherwise carried by a Vega presentation -
+// unlike the Longfellow path, which has no MSO validity concept at all)
+// against now.
+func checkVegaValidityWindow(validFromTs, validUntilTs []byte, now time.Time) error {
+	validFrom, err := time.Parse(time.RFC3339, string(validFromTs))
+	if err != nil {
+		return fmt.Errorf("failed to parse Vega proof's valid_from_ts %q: %w", validFromTs, err)
+	}
+	validUntil, err := time.Parse(time.RFC3339, string(validUntilTs))
+	if err != nil {
+		return fmt.Errorf("failed to parse Vega proof's valid_until_ts %q: %w", validUntilTs, err)
+	}
+	if now.Before(validFrom) {
+		return fmt.Errorf("credential not yet valid: valid from %s", validFrom)
+	}
+	if now.After(validUntil) {
+		return fmt.Errorf("credential expired: valid until %s", validUntil)
+	}
+	return nil
 }
 
 // buildZkAttributes converts a flattened issuerSigned claim map into the

--- a/pkg/mdoc/zk_verifier.go
+++ b/pkg/mdoc/zk_verifier.go
@@ -33,11 +33,11 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/SUNET/vc/pkg/openid4vp"
+	"github.com/SUNET/vc/pkg/trust"
 	"sort"
 	"strings"
 	"time"
-	"github.com/SUNET/vc/pkg/openid4vp"
-	"github.com/SUNET/vc/pkg/trust"
 
 	"github.com/sirosfoundation/go-trust/pkg/trustapi"
 )
@@ -463,11 +463,14 @@ func (h *ZkHandler) verifyVegaDocument(ctx context.Context, zkDoc *ZkDocumentMdo
 		return nil, err
 	}
 
-	// checkVegaDisclosedClaimsMatchWire's job (pre-r12) is now done more
-	// strongly, and earlier, by BuildVegaDisclosedBytes + verify() itself:
-	// disclosedBytes above IS the wire's own issuerSignedItemBytes, so a
-	// successful verify() already proves the proof's binding matches the
-	// EXACT wire bytes, not just their decoded elementValue.
+	// verify() proves the proof commits to the EXACT bytes in
+	// disclosedBytes - but not that the elementIdentifier/elementValue the
+	// wire declares alongside them say the same thing. Those are separate
+	// fields, and the claims handed downstream come from them, so they have
+	// to be checked against the bytes the proof actually bound.
+	if err := checkVegaWireMatchesProofBoundItems(dd); err != nil {
+		return nil, err
+	}
 
 	if err := checkVegaValidityWindow(result.ValidFromTs, result.ValidUntilTs, h.clock()); err != nil {
 		return nil, err
@@ -531,6 +534,125 @@ func BuildVegaDisclosedBytes(dd *ZkDocumentDataMdoc) ([][]byte, error) {
 	}
 
 	return disclosedBytes, nil
+}
+
+// vegaIssuerSignedItem is the CBOR shape inside a disclosed slot's
+// issuerSignedItemBytes - the credential's original ISO 18013-5
+// IssuerSignedItem. random never otherwise crosses the wire, which is why
+// these bytes cannot be reconstructed from the wire-declared fields and
+// have to travel intact (see docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md's r12
+// addendum).
+type vegaIssuerSignedItem struct {
+	DigestID          uint32 `cbor:"digestID"`
+	Random            []byte `cbor:"random"`
+	ElementIdentifier string `cbor:"elementIdentifier"`
+	ElementValue      any    `cbor:"elementValue"`
+}
+
+// checkVegaWireMatchesProofBoundItems is the check that stops a wallet
+// proving one claim and declaring another.
+//
+// r12's verify() takes each disclosed slot's issuerSignedItemBytes as an
+// input and rejects the proof unless it committed to exactly those bytes.
+// That authenticates the BYTES. It says nothing about
+// ZkSignedItemMdoc.ElementIdentifier and .ElementValue, which are separate
+// wire fields - and those are what FlattenIssuerSigned hands downstream.
+// Without this, a wallet could send the genuine bytes for a claim it holds
+// (so the proof verifies) while declaring any identifier and value it
+// liked, and the verifier would surface the declared ones.
+//
+// Pre-r12 this was checkVegaDisclosedClaimsMatchWire, comparing the wire
+// against the plaintext verify() used to return. r12 stopped returning it,
+// and the check went with it; this is the same guarantee rebuilt against
+// the bytes instead.
+//
+// Must run only AFTER a successful verify(): it parses issuerSignedItemBytes,
+// and verify() having accepted them is what makes them trustworthy input
+// rather than attacker-chosen CBOR.
+func checkVegaWireMatchesProofBoundItems(dd *ZkDocumentDataMdoc) error {
+	enc, err := NewCBOREncoder()
+	if err != nil {
+		return fmt.Errorf("failed to create CBOR encoder: %w", err)
+	}
+
+	for ns, items := range dd.IssuerSigned {
+		for _, item := range items {
+			if len(item.IssuerSignedItemBytes) == 0 {
+				// BuildVegaDisclosedBytes already rejects this; a disclosed
+				// item with no bytes never reaches a successful verify().
+				return fmt.Errorf("claim %q (namespace %q) has no issuerSignedItemBytes to check the wire against", item.ElementIdentifier, ns)
+			}
+
+			bound, err := decodeVegaIssuerSignedItem(enc, item.IssuerSignedItemBytes)
+			if err != nil {
+				return fmt.Errorf("claim %q (namespace %q): %w", item.ElementIdentifier, ns, err)
+			}
+
+			if item.DigestID == nil || *item.DigestID != bound.DigestID {
+				wire := "absent"
+				if item.DigestID != nil {
+					wire = fmt.Sprintf("%d", *item.DigestID)
+				}
+				return fmt.Errorf(
+					"claim %q (namespace %q): wire-declared digestId %s does not match the proof-bound item's digestID %d",
+					item.ElementIdentifier, ns, wire, bound.DigestID,
+				)
+			}
+
+			if item.ElementIdentifier != bound.ElementIdentifier {
+				return fmt.Errorf(
+					"namespace %q, digestId %d: wire declares elementIdentifier %q but the proof-bound item says %q",
+					ns, bound.DigestID, item.ElementIdentifier, bound.ElementIdentifier,
+				)
+			}
+
+			// Canonical CBOR on both sides, so equality does not depend on Go
+			// value identity - see buildZkAttributes' own doc comment.
+			wireValue, err := enc.Marshal(item.ElementValue)
+			if err != nil {
+				return fmt.Errorf("claim %q (namespace %q): failed to encode wire-declared value: %w", item.ElementIdentifier, ns, err)
+			}
+			boundValue, err := enc.Marshal(bound.ElementValue)
+			if err != nil {
+				return fmt.Errorf("claim %q (namespace %q): failed to encode proof-bound value: %w", item.ElementIdentifier, ns, err)
+			}
+			if !bytes.Equal(wireValue, boundValue) {
+				return fmt.Errorf(
+					"claim %q (namespace %q, digestId %d): wire-declared elementValue does not match the value the proof bound",
+					item.ElementIdentifier, ns, bound.DigestID,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// decodeVegaIssuerSignedItem parses one disclosed slot's
+// issuerSignedItemBytes.
+//
+// ISO 18013-5 frames IssuerSignedItemBytes as #6.24(bstr .cbor
+// IssuerSignedItem), and that is what a producer sending "the exact
+// original item bytes" should emit. The bare map is accepted too: no
+// captured wallet artifact is checked in here to pin the framing, and
+// siros-sdk-swift has not implemented Vega at all yet, so refusing one
+// form would be guessing. Being lenient here costs nothing - verify() has
+// already accepted these bytes, so this is parsing authenticated data, and
+// the comparison the caller makes is identical either way.
+func decodeVegaIssuerSignedItem(enc *CBOREncoder, raw []byte) (*vegaIssuerSignedItem, error) {
+	var item vegaIssuerSignedItem
+
+	var inner EncodedCBORBytes
+	if err := enc.Unmarshal(raw, &inner); err == nil {
+		if err := enc.Unmarshal(inner, &item); err != nil {
+			return nil, fmt.Errorf("decoding tag-24-wrapped issuerSignedItemBytes: %w", err)
+		}
+		return &item, nil
+	}
+
+	if err := enc.Unmarshal(raw, &item); err != nil {
+		return nil, fmt.Errorf("issuerSignedItemBytes is neither #6.24(bstr) nor a bare IssuerSignedItem map: %w", err)
+	}
+	return &item, nil
 }
 
 // checkVegaIssuerKeyMatches rejects a proof whose recomputed issuer public

--- a/pkg/mdoc/zk_verifier.go
+++ b/pkg/mdoc/zk_verifier.go
@@ -440,10 +440,8 @@ func (h *ZkHandler) verifyOneDocument(ctx context.Context, zkDoc *ZkDocumentMdoc
 // credential's own validity window - is real, new comparison logic the
 // Longfellow path never needed (it hands its own expected values IN and
 // gets a bare pass/fail back). Vega presentations never carry a
-// pseudonym - this v1 circuit has no PPID concept at all (see
-// [[project_vega_broader_circuit_ambitions]] / the tracked plan's Phase 6
-// for the real research task pseudonym support needs before that
-// changes).
+// pseudonym - this v1 circuit has no PPID concept at all, and adding it
+// is a design task rather than a port of the Longfellow PPID scheme.
 func (h *ZkHandler) verifyVegaDocument(ctx context.Context, zkDoc *ZkDocumentMdoc, dd *ZkDocumentDataMdoc, dsCert *x509.Certificate) (*ZkDocumentResult, error) {
 	disclosedBytes, err := BuildVegaDisclosedBytes(dd)
 	if err != nil {
@@ -506,6 +504,19 @@ const vegaMaxClaims = 4
 func BuildVegaDisclosedBytes(dd *ZkDocumentDataMdoc) ([][]byte, error) {
 	if len(dd.ClaimSlotDigestIds) != vegaMaxClaims {
 		return nil, fmt.Errorf("expected exactly %d claimSlotDigestIds (one per Vega circuit slot), got %d", vegaMaxClaims, len(dd.ClaimSlotDigestIds))
+	}
+
+	// A digestId appearing in two slots would place one wire item's bytes
+	// in both, silently building a differently-shaped input than the
+	// credential the proof was made over - and the "every disclosed item is
+	// bound" check below would still pass, since it only asks whether each
+	// item was used at all.
+	seenSlots := make(map[uint32]int, len(dd.ClaimSlotDigestIds))
+	for i, digestID := range dd.ClaimSlotDigestIds {
+		if first, dup := seenSlots[digestID]; dup {
+			return nil, fmt.Errorf("claimSlotDigestIds lists digestId %d in both slot %d and slot %d - ambiguous, refusing to guess which slot it belongs to", digestID, first, i)
+		}
+		seenSlots[digestID] = i
 	}
 
 	byDigestID, err := dd.IssuerSignedItemsByDigestID()

--- a/pkg/mdoc/zk_verifier.go
+++ b/pkg/mdoc/zk_verifier.go
@@ -33,12 +33,13 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
-	"github.com/SUNET/vc/pkg/openid4vp"
-	"github.com/SUNET/vc/pkg/trust"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
+	"github.com/SUNET/vc/pkg/openid4vp"
+	"github.com/SUNET/vc/pkg/trust"
 
 	"github.com/sirosfoundation/go-trust/pkg/trustapi"
 )

--- a/pkg/mdoc/zk_verifier.go
+++ b/pkg/mdoc/zk_verifier.go
@@ -323,7 +323,7 @@ func (h *ZkHandler) VerifyAndExtract(ctx context.Context, vpToken string, pctx Z
 
 func (h *ZkHandler) verifyOneDocument(ctx context.Context, zkDoc *ZkDocumentMdoc, dd *ZkDocumentDataMdoc, pctx ZkPresentationContext) (*ZkDocumentResult, error) {
 	// 1. Match the declared ZK system against what this verifier requested.
-	_, matched := openid4vp.MatchZKSystemType(pctx.RequestedZkSystems, dd.ZkSystemID)
+	spec, matched := openid4vp.MatchZKSystemType(pctx.RequestedZkSystems, dd.ZkSystemID)
 	if !matched {
 		return nil, fmt.Errorf("zkSystemId %q was not offered in this request's zk_system_type", dd.ZkSystemID)
 	}
@@ -377,7 +377,7 @@ func (h *ZkHandler) verifyOneDocument(ctx context.Context, zkDoc *ZkDocumentMdoc
 	// concept in this v1 circuit - see verifyVegaDocument's own doc
 	// comment), so "which system" and "PPID or not" are kept as two
 	// independent axes rather than folded into one three-way if/else.
-	if strings.HasPrefix(dd.ZkSystemID, "vega-mc") {
+	if isVegaSystem(spec, dd.ZkSystemID) {
 		return h.verifyVegaDocument(ctx, zkDoc, dd, dsCert)
 	}
 
@@ -439,6 +439,31 @@ func (h *ZkHandler) verifyOneDocument(ctx context.Context, zkDoc *ZkDocumentMdoc
 		Claims:     issuerSigned,
 		Pseudonym:  pseudonym,
 	}, nil
+}
+
+// vegaSystemPrefix names the Vega proof-system family, as it appears in a
+// DCQL zk_system_type entry's "system" field (e.g. "vega-mc-p256-v1").
+const vegaSystemPrefix = "vega-mc"
+
+// isVegaSystem decides which verify path a presentation takes.
+//
+// The request's own matched zk_system_type entry is the authority: "system"
+// names the proof system, which is exactly this question, whereas "id"
+// names one circuit build and is free to be spelled however the catalog
+// spells it. Routing on the id's prefix meant a Vega circuit whose id did
+// not happen to start with "vega-mc" went down the Longfellow path and
+// failed there, for reasons that would have looked nothing like a naming
+// problem.
+//
+// The id is still consulted, but only when the matched entry carries no
+// system at all - ZKSystemTypeSpec.System is validate:"required", so that
+// is a request that did not come through validation rather than a shape
+// worth supporting.
+func isVegaSystem(spec *openid4vp.ZKSystemTypeSpec, zkSystemID string) bool {
+	if spec != nil && spec.System != "" {
+		return strings.HasPrefix(spec.System, vegaSystemPrefix)
+	}
+	return strings.HasPrefix(zkSystemID, vegaSystemPrefix)
 }
 
 // verifyVegaDocument verifies a Vega ("vega-mc*") presentation -

--- a/pkg/mdoc/zk_verifier.go
+++ b/pkg/mdoc/zk_verifier.go
@@ -33,6 +33,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
 	"github.com/SUNET/vc/pkg/openid4vp"
 	"github.com/SUNET/vc/pkg/trust"
 	"sort"
@@ -482,12 +483,11 @@ func (h *ZkHandler) verifyVegaDocument(ctx context.Context, zkDoc *ZkDocumentMdo
 	}, nil
 }
 
-// vegaMaxClaims mirrors zk-cred-vega's MAX_CLAIMS_V1 (also
-// VegaProofSystem.MAX_CLAIMS_V1 in siros-sdk-kotlin, ZK_CRED_VEGA_MAX_CLAIMS
-// in zk_cred_vega_go.h) - duplicated here (not imported from the
-// "zknative"-tagged zknative_vega package) since this file has no zknative
-// build tag and must compile in both configurations.
-const vegaMaxClaims = 4
+// vegaMaxClaims is the Vega circuit's fixed claim-slot count, from the
+// shared non-cgo package rather than restated here: zknative_vega holds the
+// authoritative value but only compiles under the zknative tag, and this
+// file has to build in both configurations. See zkvegaworker.MaxClaims.
+const vegaMaxClaims = zkvegaworker.MaxClaims
 
 // BuildVegaDisclosedBytes builds zk_cred_vega's r12 verify() input: exactly
 // vegaMaxClaims entries, in claim-slot order, each either a disclosed

--- a/pkg/mdoc/zk_verifier.go
+++ b/pkg/mdoc/zk_verifier.go
@@ -65,6 +65,14 @@ var ErrNativeZkVerifyNotImplemented = errors.New(
 	"native Longfellow ZK proof verification is not available in this build/direction (see docs/ZK_PPID_VERIFICATION_PLAN.md)",
 )
 
+// ErrNativeVegaVerifyNotImplemented is the Vega counterpart. Separate from
+// the Longfellow error above because the two are built and staged
+// independently: naming the wrong system sends whoever reads the log
+// looking at the wrong library and the wrong build flag.
+var ErrNativeVegaVerifyNotImplemented = errors.New(
+	"native Vega ZK proof verification is not available in this build (rebuild with -tags zknative and zk-cred-vega staged - see docs/ZK_VEGA_DIGESTID_WIRE_EXTENSION.md)",
+)
+
 // ZkAttribute mirrors zk-cred-longfellow's own `Attribute` FFI record
 // (see zk-cred-longfellow/src/mdoc_zk/verifier.rs): an element identifier
 // plus the CBOR encoding of its value - the shape the native

--- a/pkg/mdoc/zk_verifier_vega_test.go
+++ b/pkg/mdoc/zk_verifier_vega_test.go
@@ -1,16 +1,15 @@
 package mdoc
 
 // Unit tests for the Vega comparison logic (checkVegaIssuerKeyMatches /
-// checkVegaDisclosedClaimsMatchWire / checkVegaValidityWindow) - pure Go
-// functions, testable without the "zknative" build tag or any native
-// library, independent of the full cgo/subprocess round trip already
-// verified end-to-end in pkg/mdoc/zknative_vega's own tests.
+// BuildVegaDisclosedBytes / checkVegaValidityWindow) - pure Go functions,
+// testable without the "zknative" build tag or any native library,
+// independent of the full cgo/subprocess round trip already verified
+// end-to-end in pkg/mdoc/zknative_vega's own tests.
 
 import (
+	"bytes"
 	"testing"
 	"time"
-
-	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
 )
 
 func digestIDPtr(v uint32) *uint32 { return &v }
@@ -51,29 +50,43 @@ func TestCheckVegaIssuerKeyMatches(t *testing.T) {
 	})
 }
 
-// buildVegaPlaintext CBOR-encodes a vegaIssuerSignedItemPlaintext - the
-// shape zk-cred-vega's verify returns as a disclosed claim's plaintext
-// bytes (the full original IssuerSignedItem, not just elementValue).
-func buildVegaPlaintext(t *testing.T, digestID uint32, identifier string, value any) []byte {
-	t.Helper()
-	encoder, err := NewCBOREncoder()
-	if err != nil {
-		t.Fatalf("NewCBOREncoder: %v", err)
-	}
-	b, err := encoder.Marshal(vegaIssuerSignedItemPlaintext{
-		DigestID:          digestID,
-		Random:            []byte{0x01, 0x02, 0x03},
-		ElementIdentifier: identifier,
-		ElementValue:      value,
+func TestBuildVegaDisclosedBytes(t *testing.T) {
+	t.Run("disclosed slot gets its wire bytes, undisclosed slots are empty", func(t *testing.T) {
+		givenNameBytes := []byte{0xd8, 0x18, 0x01, 0x02, 0x03}
+		dd := &ZkDocumentDataMdoc{
+			ClaimSlotDigestIds: []uint32{26, 300, 4444, 55555},
+			IssuerSigned: map[string][]ZkSignedItemMdoc{
+				Namespace: {
+					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(300), IssuerSignedItemBytes: givenNameBytes},
+				},
+			},
+		}
+		out, err := BuildVegaDisclosedBytes(dd)
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+		if len(out) != 4 {
+			t.Fatalf("expected 4 slots, got %d", len(out))
+		}
+		if len(out[0]) != 0 || len(out[2]) != 0 || len(out[3]) != 0 {
+			t.Fatalf("expected undisclosed slots empty, got %v", out)
+		}
+		if !bytes.Equal(out[1], givenNameBytes) {
+			t.Fatalf("expected slot 1 (digestId 300) to carry given_name's wire bytes, got %v", out[1])
+		}
 	})
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	return b
-}
 
-func TestCheckVegaDisclosedClaimsMatchWire(t *testing.T) {
-	t.Run("matching disclosed claim succeeds", func(t *testing.T) {
+	t.Run("wrong claimSlotDigestIds length is rejected", func(t *testing.T) {
+		dd := &ZkDocumentDataMdoc{
+			ClaimSlotDigestIds: []uint32{26, 300},
+			IssuerSigned:       map[string][]ZkSignedItemMdoc{},
+		}
+		if _, err := BuildVegaDisclosedBytes(dd); err == nil {
+			t.Fatal("expected wrong-length claimSlotDigestIds to be rejected")
+		}
+	})
+
+	t.Run("missing claimSlotDigestIds (pre-r12 or non-Vega artifact) is rejected", func(t *testing.T) {
 		dd := &ZkDocumentDataMdoc{
 			IssuerSigned: map[string][]ZkSignedItemMdoc{
 				Namespace: {
@@ -81,82 +94,51 @@ func TestCheckVegaDisclosedClaimsMatchWire(t *testing.T) {
 				},
 			},
 		}
-		claims := []zkvegaworker.DisclosedClaim{
-			{Disclosed: true, DigestID: 26, Plaintext: buildVegaPlaintext(t, 26, "given_name", "Jane")},
-		}
-		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err != nil {
-			t.Fatalf("expected match, got error: %v", err)
+		if _, err := BuildVegaDisclosedBytes(dd); err == nil {
+			t.Fatal("expected absent claimSlotDigestIds to be rejected")
 		}
 	})
 
-	t.Run("wire value not matching proof-disclosed value is rejected", func(t *testing.T) {
+	t.Run("disclosed wire item missing issuerSignedItemBytes is rejected", func(t *testing.T) {
 		dd := &ZkDocumentDataMdoc{
+			ClaimSlotDigestIds: []uint32{26, 300, 4444, 55555},
 			IssuerSigned: map[string][]ZkSignedItemMdoc{
 				Namespace: {
-					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(26)},
+					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(300)},
 				},
 			},
 		}
-		claims := []zkvegaworker.DisclosedClaim{
-			// Proof actually attests a DIFFERENT value than what the wire
-			// declares for the same digestId - the exact attack this check
-			// exists to catch.
-			{Disclosed: true, DigestID: 26, Plaintext: buildVegaPlaintext(t, 26, "given_name", "NotJane")},
-		}
-		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err == nil {
-			t.Fatal("expected value mismatch to be rejected")
+		if _, err := BuildVegaDisclosedBytes(dd); err == nil {
+			t.Fatal("expected missing issuerSignedItemBytes to be rejected")
 		}
 	})
 
-	t.Run("wire claim with no matching disclosed proof slot is rejected", func(t *testing.T) {
+	t.Run("wire claim whose digestId is absent from claimSlotDigestIds is rejected", func(t *testing.T) {
 		dd := &ZkDocumentDataMdoc{
+			// 300 (given_name's digestId below) is not one of these four.
+			ClaimSlotDigestIds: []uint32{1, 2, 3, 4},
 			IssuerSigned: map[string][]ZkSignedItemMdoc{
 				Namespace: {
-					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(26)},
+					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(300), IssuerSignedItemBytes: []byte{0x01}},
 				},
 			},
 		}
-		claims := []zkvegaworker.DisclosedClaim{
-			// The proof never disclosed digestId 26 at all.
-			{Disclosed: false, DigestID: 26, Plaintext: nil},
-		}
-		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err == nil {
-			t.Fatal("expected undisclosed-on-proof claim to be rejected")
+		if _, err := BuildVegaDisclosedBytes(dd); err == nil {
+			t.Fatal("expected a wire claim with no matching circuit slot to be rejected")
 		}
 	})
 
 	t.Run("wire item missing digestId is rejected", func(t *testing.T) {
 		dd := &ZkDocumentDataMdoc{
+			ClaimSlotDigestIds: []uint32{26, 300, 4444, 55555},
 			IssuerSigned: map[string][]ZkSignedItemMdoc{
 				Namespace: {
-					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: nil},
+					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: nil, IssuerSignedItemBytes: []byte{0x01}},
 				},
 			},
 		}
-		claims := []zkvegaworker.DisclosedClaim{
-			{Disclosed: true, DigestID: 26, Plaintext: buildVegaPlaintext(t, 26, "given_name", "Jane")},
-		}
-		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err == nil {
+		if _, err := BuildVegaDisclosedBytes(dd); err == nil {
 			t.Fatal("expected missing-digestId wire item to be rejected")
-		}
-	})
-
-	t.Run("undisclosed proof claims not on the wire are ignored", func(t *testing.T) {
-		dd := &ZkDocumentDataMdoc{
-			IssuerSigned: map[string][]ZkSignedItemMdoc{
-				Namespace: {
-					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(26)},
-				},
-			},
-		}
-		claims := []zkvegaworker.DisclosedClaim{
-			{Disclosed: true, DigestID: 26, Plaintext: buildVegaPlaintext(t, 26, "given_name", "Jane")},
-			// A second, undisclosed slot the wallet chose not to reveal -
-			// harmless, must not cause a rejection.
-			{Disclosed: false, DigestID: 300, Plaintext: nil},
-		}
-		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err != nil {
-			t.Fatalf("expected undisclosed unrelated claim to be ignored, got error: %v", err)
 		}
 	})
 }

--- a/pkg/mdoc/zk_verifier_vega_test.go
+++ b/pkg/mdoc/zk_verifier_vega_test.go
@@ -1,0 +1,195 @@
+package mdoc
+
+// Unit tests for the Vega comparison logic (checkVegaIssuerKeyMatches /
+// checkVegaDisclosedClaimsMatchWire / checkVegaValidityWindow) - pure Go
+// functions, testable without the "zknative" build tag or any native
+// library, independent of the full cgo/subprocess round trip already
+// verified end-to-end in pkg/mdoc/zknative_vega's own tests.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
+)
+
+func digestIDPtr(v uint32) *uint32 { return &v }
+
+func TestCheckVegaIssuerKeyMatches(t *testing.T) {
+	qx := make([]byte, 32)
+	qy := make([]byte, 32)
+	qx[31] = 0x01
+	qy[31] = 0x02
+
+	sec1 := append([]byte{0x04}, append(append([]byte{}, qx...), qy...)...)
+
+	t.Run("matching key succeeds", func(t *testing.T) {
+		if err := checkVegaIssuerKeyMatches(sec1, qx, qy); err != nil {
+			t.Fatalf("expected match, got error: %v", err)
+		}
+	})
+
+	t.Run("mismatched qx is rejected", func(t *testing.T) {
+		wrongQx := make([]byte, 32)
+		wrongQx[31] = 0xff
+		if err := checkVegaIssuerKeyMatches(sec1, wrongQx, qy); err == nil {
+			t.Fatal("expected mismatch to be rejected")
+		}
+	})
+
+	t.Run("wrong-length SEC1 key is rejected", func(t *testing.T) {
+		if err := checkVegaIssuerKeyMatches(sec1[:64], qx, qy); err == nil {
+			t.Fatal("expected short SEC1 key to be rejected")
+		}
+	})
+
+	t.Run("non-0x04-prefixed SEC1 key is rejected", func(t *testing.T) {
+		compressed := append([]byte{0x02}, sec1[1:]...)
+		if err := checkVegaIssuerKeyMatches(compressed, qx, qy); err == nil {
+			t.Fatal("expected non-uncompressed SEC1 key to be rejected")
+		}
+	})
+}
+
+// buildVegaPlaintext CBOR-encodes a vegaIssuerSignedItemPlaintext - the
+// shape zk-cred-vega's verify returns as a disclosed claim's plaintext
+// bytes (the full original IssuerSignedItem, not just elementValue).
+func buildVegaPlaintext(t *testing.T, digestID uint32, identifier string, value any) []byte {
+	t.Helper()
+	encoder, err := NewCBOREncoder()
+	if err != nil {
+		t.Fatalf("NewCBOREncoder: %v", err)
+	}
+	b, err := encoder.Marshal(vegaIssuerSignedItemPlaintext{
+		DigestID:          digestID,
+		Random:            []byte{0x01, 0x02, 0x03},
+		ElementIdentifier: identifier,
+		ElementValue:      value,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return b
+}
+
+func TestCheckVegaDisclosedClaimsMatchWire(t *testing.T) {
+	t.Run("matching disclosed claim succeeds", func(t *testing.T) {
+		dd := &ZkDocumentDataMdoc{
+			IssuerSigned: map[string][]ZkSignedItemMdoc{
+				Namespace: {
+					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(26)},
+				},
+			},
+		}
+		claims := []zkvegaworker.DisclosedClaim{
+			{Disclosed: true, DigestID: 26, Plaintext: buildVegaPlaintext(t, 26, "given_name", "Jane")},
+		}
+		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err != nil {
+			t.Fatalf("expected match, got error: %v", err)
+		}
+	})
+
+	t.Run("wire value not matching proof-disclosed value is rejected", func(t *testing.T) {
+		dd := &ZkDocumentDataMdoc{
+			IssuerSigned: map[string][]ZkSignedItemMdoc{
+				Namespace: {
+					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(26)},
+				},
+			},
+		}
+		claims := []zkvegaworker.DisclosedClaim{
+			// Proof actually attests a DIFFERENT value than what the wire
+			// declares for the same digestId - the exact attack this check
+			// exists to catch.
+			{Disclosed: true, DigestID: 26, Plaintext: buildVegaPlaintext(t, 26, "given_name", "NotJane")},
+		}
+		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err == nil {
+			t.Fatal("expected value mismatch to be rejected")
+		}
+	})
+
+	t.Run("wire claim with no matching disclosed proof slot is rejected", func(t *testing.T) {
+		dd := &ZkDocumentDataMdoc{
+			IssuerSigned: map[string][]ZkSignedItemMdoc{
+				Namespace: {
+					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(26)},
+				},
+			},
+		}
+		claims := []zkvegaworker.DisclosedClaim{
+			// The proof never disclosed digestId 26 at all.
+			{Disclosed: false, DigestID: 26, Plaintext: nil},
+		}
+		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err == nil {
+			t.Fatal("expected undisclosed-on-proof claim to be rejected")
+		}
+	})
+
+	t.Run("wire item missing digestId is rejected", func(t *testing.T) {
+		dd := &ZkDocumentDataMdoc{
+			IssuerSigned: map[string][]ZkSignedItemMdoc{
+				Namespace: {
+					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: nil},
+				},
+			},
+		}
+		claims := []zkvegaworker.DisclosedClaim{
+			{Disclosed: true, DigestID: 26, Plaintext: buildVegaPlaintext(t, 26, "given_name", "Jane")},
+		}
+		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err == nil {
+			t.Fatal("expected missing-digestId wire item to be rejected")
+		}
+	})
+
+	t.Run("undisclosed proof claims not on the wire are ignored", func(t *testing.T) {
+		dd := &ZkDocumentDataMdoc{
+			IssuerSigned: map[string][]ZkSignedItemMdoc{
+				Namespace: {
+					{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(26)},
+				},
+			},
+		}
+		claims := []zkvegaworker.DisclosedClaim{
+			{Disclosed: true, DigestID: 26, Plaintext: buildVegaPlaintext(t, 26, "given_name", "Jane")},
+			// A second, undisclosed slot the wallet chose not to reveal -
+			// harmless, must not cause a rejection.
+			{Disclosed: false, DigestID: 300, Plaintext: nil},
+		}
+		if err := checkVegaDisclosedClaimsMatchWire(dd, claims); err != nil {
+			t.Fatalf("expected undisclosed unrelated claim to be ignored, got error: %v", err)
+		}
+	})
+}
+
+func TestCheckVegaValidityWindow(t *testing.T) {
+	validFrom := []byte("2026-01-01T00:00:00Z")
+	validUntil := []byte("2027-01-01T00:00:00Z")
+
+	t.Run("within window succeeds", func(t *testing.T) {
+		now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+		if err := checkVegaValidityWindow(validFrom, validUntil, now); err != nil {
+			t.Fatalf("expected valid window, got error: %v", err)
+		}
+	})
+
+	t.Run("before validFrom is rejected", func(t *testing.T) {
+		now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		if err := checkVegaValidityWindow(validFrom, validUntil, now); err == nil {
+			t.Fatal("expected not-yet-valid credential to be rejected")
+		}
+	})
+
+	t.Run("after validUntil is rejected", func(t *testing.T) {
+		now := time.Date(2028, 1, 1, 0, 0, 0, 0, time.UTC)
+		if err := checkVegaValidityWindow(validFrom, validUntil, now); err == nil {
+			t.Fatal("expected expired credential to be rejected")
+		}
+	})
+
+	t.Run("malformed timestamp is rejected", func(t *testing.T) {
+		now := time.Now()
+		if err := checkVegaValidityWindow([]byte("not-a-timestamp"), validUntil, now); err == nil {
+			t.Fatal("expected malformed valid_from_ts to be rejected")
+		}
+	})
+}

--- a/pkg/mdoc/zk_verifier_vega_test.go
+++ b/pkg/mdoc/zk_verifier_vega_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/SUNET/vc/pkg/openid4vp"
 )
 
 func digestIDPtr(v uint32) *uint32 { return &v }
@@ -353,5 +355,56 @@ func TestBuildVegaDisclosedBytesRejectsDuplicateSlots(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "both slot 1 and slot 2") {
 		t.Fatalf("error should name both slots, got: %v", err)
+	}
+}
+
+func TestIsVegaSystem(t *testing.T) {
+	// The point of the change: routing follows the request's "system", so a
+	// circuit id that does not look like a Vega id still routes correctly.
+	t.Run("system decides, not the id", func(t *testing.T) {
+		spec := &openid4vp.ZKSystemTypeSpec{ID: "custom-build-2026-09", System: "vega-mc-p256-v1"}
+		if !isVegaSystem(spec, spec.ID) {
+			t.Fatal("a vega-mc system must route to Vega regardless of how its id is spelled")
+		}
+	})
+
+	t.Run("a Longfellow system does not route to Vega", func(t *testing.T) {
+		spec := &openid4vp.ZKSystemTypeSpec{ID: "vega-mc-lookalike", System: "longfellow-libzk-v1"}
+		if isVegaSystem(spec, spec.ID) {
+			t.Fatal("system must win over an id that merely looks like a Vega id")
+		}
+	})
+
+	t.Run("falls back to the id when the spec carries no system", func(t *testing.T) {
+		if !isVegaSystem(&openid4vp.ZKSystemTypeSpec{ID: "vega-mc-p256-v1-r12"}, "vega-mc-p256-v1-r12") {
+			t.Fatal("expected the id fallback for a spec with no system")
+		}
+		if !isVegaSystem(nil, "vega-mc-p256-v1-r12") {
+			t.Fatal("expected the id fallback for a nil spec")
+		}
+		if isVegaSystem(nil, "longfellow-libzk-v1_8_1") {
+			t.Fatal("a Longfellow id must not route to Vega")
+		}
+	})
+}
+
+// TestIssuerSignedItemsByDigestIDNamespaceCollision: digestIDs are
+// namespace-scoped in ISO 18013-5 and this package's MSOBuilder counts from
+// zero per namespace, so a collision across namespaces is well-formed mdoc.
+// claimSlotDigestIds cannot express it, so it is refused - but the error has
+// to say that, or it reads as a wallet bug.
+func TestIssuerSignedItemsByDigestIDNamespaceCollision(t *testing.T) {
+	dd := &ZkDocumentDataMdoc{
+		IssuerSigned: map[string][]ZkSignedItemMdoc{
+			"org.iso.18013.5.1":    {{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(0)}},
+			"org.iso.18013.5.1.SE": {{ElementIdentifier: "personal_number", ElementValue: "1", DigestID: digestIDPtr(0)}},
+		},
+	}
+	_, err := dd.IssuerSignedItemsByDigestID()
+	if err == nil {
+		t.Fatal("a cross-namespace digestId collision must be rejected")
+	}
+	if !strings.Contains(err.Error(), "namespace-scoped") {
+		t.Fatalf("the error must explain the wire-format constraint, got: %v", err)
 	}
 }

--- a/pkg/mdoc/zk_verifier_vega_test.go
+++ b/pkg/mdoc/zk_verifier_vega_test.go
@@ -8,6 +8,7 @@ package mdoc
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 )
@@ -172,6 +173,162 @@ func TestCheckVegaValidityWindow(t *testing.T) {
 		now := time.Now()
 		if err := checkVegaValidityWindow([]byte("not-a-timestamp"), validUntil, now); err == nil {
 			t.Fatal("expected malformed valid_from_ts to be rejected")
+		}
+	})
+}
+
+// buildVegaItemBytes builds a real #6.24(bstr .cbor IssuerSignedItem), the
+// framing ISO 18013-5 specifies. Built through EncodedCBORBytes rather than
+// hand-assembled so the test actually exercises the tag-24 unwrap path -
+// a bare CBOR map here would silently take the fallback branch instead.
+func buildVegaItemBytes(t *testing.T, digestID uint32, identifier string, value any) []byte {
+	t.Helper()
+	enc, err := NewCBOREncoder()
+	if err != nil {
+		t.Fatalf("NewCBOREncoder: %v", err)
+	}
+	inner, err := enc.Marshal(vegaIssuerSignedItem{
+		DigestID:          digestID,
+		Random:            []byte("0123456789abcdef"),
+		ElementIdentifier: identifier,
+		ElementValue:      value,
+	})
+	if err != nil {
+		t.Fatalf("marshal inner item: %v", err)
+	}
+	wrapped, err := enc.Marshal(EncodedCBORBytes(inner))
+	if err != nil {
+		t.Fatalf("wrap in tag 24: %v", err)
+	}
+	if len(wrapped) < 2 || wrapped[0] != 0xd8 || wrapped[1] != 0x18 {
+		t.Fatalf("expected a tag-24 prefix, got % x", wrapped[:min(4, len(wrapped))])
+	}
+	return wrapped
+}
+
+func vegaWireDoc(items ...ZkSignedItemMdoc) *ZkDocumentDataMdoc {
+	return &ZkDocumentDataMdoc{
+		IssuerSigned: map[string][]ZkSignedItemMdoc{Namespace: items},
+	}
+}
+
+// TestCheckVegaWireMatchesProofBoundItems covers the property that a
+// successful verify() does NOT provide on its own: verify() authenticates
+// the issuerSignedItemBytes, while the claims handed downstream come from
+// the separate wire-declared elementIdentifier/elementValue fields.
+func TestCheckVegaWireMatchesProofBoundItems(t *testing.T) {
+	t.Run("agreeing wire and proof-bound item is accepted", func(t *testing.T) {
+		dd := vegaWireDoc(ZkSignedItemMdoc{
+			ElementIdentifier:     "given_name",
+			ElementValue:          "Jane",
+			DigestID:              digestIDPtr(300),
+			IssuerSignedItemBytes: buildVegaItemBytes(t, 300, "given_name", "Jane"),
+		})
+		if err := checkVegaWireMatchesProofBoundItems(dd); err != nil {
+			t.Fatalf("expected agreement to be accepted, got: %v", err)
+		}
+	})
+
+	// The attack: bind the genuine bytes so verify() passes, then declare
+	// something else on the wire.
+	t.Run("lying elementValue is rejected", func(t *testing.T) {
+		dd := vegaWireDoc(ZkSignedItemMdoc{
+			ElementIdentifier:     "given_name",
+			ElementValue:          "Mallory",
+			DigestID:              digestIDPtr(300),
+			IssuerSignedItemBytes: buildVegaItemBytes(t, 300, "given_name", "Jane"),
+		})
+		err := checkVegaWireMatchesProofBoundItems(dd)
+		if err == nil {
+			t.Fatal("a wire value that disagrees with the proof-bound value must be rejected")
+		}
+		if !strings.Contains(err.Error(), "elementValue") {
+			t.Fatalf("error should name the mismatching field, got: %v", err)
+		}
+	})
+
+	t.Run("lying elementIdentifier is rejected", func(t *testing.T) {
+		// Relabelling is as damaging as changing the value: the identifier
+		// becomes the claim key downstream, so age_over_21's bytes could be
+		// presented as age_over_18.
+		dd := vegaWireDoc(ZkSignedItemMdoc{
+			ElementIdentifier:     "age_over_18",
+			ElementValue:          true,
+			DigestID:              digestIDPtr(300),
+			IssuerSignedItemBytes: buildVegaItemBytes(t, 300, "age_over_21", true),
+		})
+		if err := checkVegaWireMatchesProofBoundItems(dd); err == nil {
+			t.Fatal("a wire identifier that disagrees with the proof-bound one must be rejected")
+		}
+	})
+
+	t.Run("lying digestId is rejected", func(t *testing.T) {
+		dd := vegaWireDoc(ZkSignedItemMdoc{
+			ElementIdentifier:     "given_name",
+			ElementValue:          "Jane",
+			DigestID:              digestIDPtr(301),
+			IssuerSignedItemBytes: buildVegaItemBytes(t, 300, "given_name", "Jane"),
+		})
+		if err := checkVegaWireMatchesProofBoundItems(dd); err == nil {
+			t.Fatal("a wire digestId that disagrees with the proof-bound one must be rejected")
+		}
+	})
+
+	t.Run("absent wire digestId is rejected", func(t *testing.T) {
+		dd := vegaWireDoc(ZkSignedItemMdoc{
+			ElementIdentifier:     "given_name",
+			ElementValue:          "Jane",
+			DigestID:              nil,
+			IssuerSignedItemBytes: buildVegaItemBytes(t, 300, "given_name", "Jane"),
+		})
+		if err := checkVegaWireMatchesProofBoundItems(dd); err == nil {
+			t.Fatal("a missing wire digestId must be rejected, not treated as agreement")
+		}
+	})
+
+	t.Run("undecodable issuerSignedItemBytes is rejected", func(t *testing.T) {
+		dd := vegaWireDoc(ZkSignedItemMdoc{
+			ElementIdentifier:     "given_name",
+			ElementValue:          "Jane",
+			DigestID:              digestIDPtr(300),
+			IssuerSignedItemBytes: []byte{0xff, 0xff, 0xff},
+		})
+		if err := checkVegaWireMatchesProofBoundItems(dd); err == nil {
+			t.Fatal("bytes that decode as neither framing must be rejected")
+		}
+	})
+
+	// The bare-map framing is accepted deliberately - see
+	// decodeVegaIssuerSignedItem's doc comment - and must compare identically.
+	t.Run("bare-map framing is compared the same way", func(t *testing.T) {
+		enc, err := NewCBOREncoder()
+		if err != nil {
+			t.Fatal(err)
+		}
+		bare, err := enc.Marshal(vegaIssuerSignedItem{
+			DigestID:          300,
+			Random:            []byte("0123456789abcdef"),
+			ElementIdentifier: "given_name",
+			ElementValue:      "Jane",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ok := vegaWireDoc(ZkSignedItemMdoc{
+			ElementIdentifier: "given_name", ElementValue: "Jane",
+			DigestID: digestIDPtr(300), IssuerSignedItemBytes: bare,
+		})
+		if err := checkVegaWireMatchesProofBoundItems(ok); err != nil {
+			t.Fatalf("bare map that agrees should be accepted, got: %v", err)
+		}
+
+		lying := vegaWireDoc(ZkSignedItemMdoc{
+			ElementIdentifier: "given_name", ElementValue: "Mallory",
+			DigestID: digestIDPtr(300), IssuerSignedItemBytes: bare,
+		})
+		if err := checkVegaWireMatchesProofBoundItems(lying); err == nil {
+			t.Fatal("bare map that disagrees must still be rejected")
 		}
 	})
 }

--- a/pkg/mdoc/zk_verifier_vega_test.go
+++ b/pkg/mdoc/zk_verifier_vega_test.go
@@ -332,3 +332,26 @@ func TestCheckVegaWireMatchesProofBoundItems(t *testing.T) {
 		}
 	})
 }
+
+// TestBuildVegaDisclosedBytesRejectsDuplicateSlots: a digestId in two slots
+// would put one item's bytes in both, building a differently-shaped input
+// than the credential the proof was made over - and the existing
+// "every disclosed item is bound" check would not notice, since it only
+// asks whether each item was used at all.
+func TestBuildVegaDisclosedBytesRejectsDuplicateSlots(t *testing.T) {
+	dd := &ZkDocumentDataMdoc{
+		ClaimSlotDigestIds: []uint32{26, 300, 300, 55555},
+		IssuerSigned: map[string][]ZkSignedItemMdoc{
+			Namespace: {
+				{ElementIdentifier: "given_name", ElementValue: "Jane", DigestID: digestIDPtr(300), IssuerSignedItemBytes: []byte{0x01}},
+			},
+		},
+	}
+	_, err := BuildVegaDisclosedBytes(dd)
+	if err == nil {
+		t.Fatal("a duplicated digestId in claimSlotDigestIds must be rejected")
+	}
+	if !strings.Contains(err.Error(), "both slot 1 and slot 2") {
+		t.Fatalf("error should name both slots, got: %v", err)
+	}
+}

--- a/pkg/mdoc/zknative_vega/verifier.go
+++ b/pkg/mdoc/zknative_vega/verifier.go
@@ -137,15 +137,25 @@ type VerifyResult struct {
 // call via zk-cred-vega's real zk_cred_vega_verify - a thin cgo marshaling
 // wrapper, not a separate/weaker check.
 //
+// disclosedBytes is the r12 circuit revision's required input: exactly
+// MaxClaims entries, in claim-slot order - a disclosed slot's real
+// IssuerSignedItem bytes, or an empty/nil slice for an undisclosed one.
+// These bytes are no longer part of the proof itself (see this package's
+// own doc comment on CDisclosedInput's rationale); a mismatch between what
+// is supplied here and what the proof committed to fails the WHOLE call,
+// not just that slot. See pkg/mdoc/zk_verifier.go's BuildVegaDisclosedBytes
+// for how the caller builds this slice from the presentation's wire data.
+//
 // A REAL SHAPE DIFFERENCE from zknative.Verifier.VerifyWithPPID: that
 // function takes the *expected* attribute values as input and returns only
 // an error (pass/fail) - the caller already knows what should be true and
-// just asks Rust to confirm it. This function takes ONLY the proof and
-// *returns* the recomputed public values (issuer pubkey, disclosed claims,
-// MSO-body fields) - the caller must independently check them against
-// whatever it already knows. See pkg/mdoc/zk_verifier.go's Vega dispatch
-// branch for exactly that comparison logic.
-func (k *VerifierKey) Verify(proof []byte) (VerifyResult, error) {
+// just asks Rust to confirm it. This function takes the proof PLUS
+// disclosedBytes and *returns* the recomputed public values (issuer
+// pubkey, disclosed claims, MSO-body fields) - the caller must
+// independently check them against whatever it already knows. See
+// pkg/mdoc/zk_verifier.go's Vega dispatch branch for exactly that
+// comparison logic.
+func (k *VerifierKey) Verify(proof []byte, disclosedBytes [][]byte) (VerifyResult, error) {
 	if k == nil || k.handle == nil {
 		return VerifyResult{}, errors.New("zknative_vega: verifier key is closed or nil")
 	}
@@ -153,10 +163,15 @@ func (k *VerifierKey) Verify(proof []byte) (VerifyResult, error) {
 		return VerifyResult{}, errors.New("zknative_vega: proof must not be empty")
 	}
 
+	cDisclosed, err := cDisclosedInputs(disclosedBytes)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+
 	proofPtr, proofLen := bytesPtr(proof)
 	var cResult C.CVerifyResult
 	var errOut *C.char
-	status := C.zk_cred_vega_verify(k.handle, proofPtr, proofLen, &cResult, &errOut)
+	status := C.zk_cred_vega_verify(k.handle, proofPtr, proofLen, &cDisclosed[0], C.size_t(MaxClaims), &cResult, &errOut)
 	// proofPtr points into proof's backing array - KeepAlive guarantees proof
 	// can't be GC'd before the (synchronous) C call above returns.
 	runtime.KeepAlive(proof)
@@ -167,6 +182,32 @@ func (k *VerifierKey) Verify(proof []byte) (VerifyResult, error) {
 		_ = takeErrorString(errOut)
 	}
 	return fromCResult(&cResult), nil
+}
+
+// cDisclosedInputs builds the fixed-size CDisclosedInput array
+// zk_cred_vega_verify requires, copying each slot's bytes directly into
+// the C struct's embedded (not pointer) byte array - no separate C
+// allocation needed, since CDisclosedInput.bytes is a fixed-size field the
+// struct owns by value.
+func cDisclosedInputs(disclosedBytes [][]byte) ([MaxClaims]C.CDisclosedInput, error) {
+	var out [MaxClaims]C.CDisclosedInput
+	if len(disclosedBytes) != MaxClaims {
+		return out, fmt.Errorf("zknative_vega: expected exactly %d disclosed-bytes entries (one per claim slot), got %d", MaxClaims, len(disclosedBytes))
+	}
+	for i, b := range disclosedBytes {
+		if len(b) == 0 {
+			continue // present stays 0 (Go zero value) - undisclosed slot.
+		}
+		if len(b) > MaxClaimBytes {
+			return out, fmt.Errorf("zknative_vega: disclosed-bytes slot %d is %d bytes, exceeds MaxClaimBytes (%d)", i, len(b), MaxClaimBytes)
+		}
+		out[i].present = 1
+		out[i].len = C.size_t(len(b))
+		for j, bb := range b {
+			out[i].bytes[j] = C.uint8_t(bb)
+		}
+	}
+	return out, nil
 }
 
 // fromCResult copies a C.CVerifyResult (backed by C memory that becomes

--- a/pkg/mdoc/zknative_vega/verifier.go
+++ b/pkg/mdoc/zknative_vega/verifier.go
@@ -1,0 +1,245 @@
+//go:build zknative
+
+// Package zknative_vega is a cgo wrapper around zk-cred-vega's plain
+// C-ABI Go verifier binding (src/go_ffi.rs / include/zk_cred_vega_go.h in
+// that crate) - the Vega counterpart of pkg/mdoc/zknative (which wraps
+// zk-cred-longfellow instead). The two are separate packages, not one,
+// because they wrap genuinely different C headers/shared libraries with
+// different verify shapes (see VerifierKey.Verify's own doc comment).
+//
+// This package is linked ONLY into the standalone cmd/zkvegaverifyworker
+// binary, never into the main vc-verifier process - see that command's
+// package doc for why (an isolated-subprocess mitigation for the cgo
+// marshaling shim processing attacker-controlled proof bytes). It is built
+// only when the "zknative" Go build tag is set, same convention as
+// pkg/mdoc/zknative.
+//
+// Setup: run `make zk-native-lib-vega` at the repo root (fetches/builds
+// zk-cred-vega's `go-cabi` target and stages the shared library + header
+// under third_party/zk-cred-vega/), then build/test with `-tags zknative`
+// and CGO_CFLAGS/CGO_LDFLAGS pointing at that directory - see the
+// Makefile's `build-zkvegaverifyworker` target and README.md's "Native
+// ZK/PPID proof verification" section.
+package zknative_vega
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../../third_party/zk-cred-vega/include
+#cgo LDFLAGS: -L${SRCDIR}/../../../third_party/zk-cred-vega/lib -lzk_cred_vega
+#include <stdlib.h>
+#include "zk_cred_vega_go.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"unsafe"
+)
+
+// MaxClaims/MaxClaimBytes/TimestampLen mirror the crate's own
+// MAX_CLAIMS_V1/MAX_CLAIM_BYTES_V1/mso::TIMESTAMP_LEN constants (see
+// zk_cred_vega_go.h's ZK_CRED_VEGA_MAX_CLAIMS/_MAX_CLAIM_BYTES/_TIMESTAMP_LEN
+// macros, and go_ffi.rs's own compile-time assertions tying those to the
+// real crate constants) - fixed at compile time on the Rust side, so fixed
+// here too rather than read from anywhere at runtime.
+const (
+	MaxClaims      = int(C.ZK_CRED_VEGA_MAX_CLAIMS)
+	MaxClaimBytes  = int(C.ZK_CRED_VEGA_MAX_CLAIM_BYTES)
+	TimestampLen   = int(C.ZK_CRED_VEGA_TIMESTAMP_LEN)
+	P256CoordBytes = 32
+)
+
+// VerifierKey wraps an opaque, deserialized zk-cred-vega verifier-key
+// handle (C.GoVegaVerifierKey). Deserializing a key is comparatively cheap
+// (no circuit compilation happens here, unlike zknative.NewVerifier), but a
+// long-lived process should still construct one VerifierKey per distinct
+// circuit (via NewVerifierKey) and reuse it across many Verify calls,
+// mirroring zknative.Verifier's own caching guidance.
+type VerifierKey struct {
+	handle *C.GoVegaVerifierKey
+	// closeOnce guards zk_cred_vega_free_verifier_key against a
+	// check-then-act double-free race - see zknative.Verifier.closeOnce's
+	// identical rationale.
+	closeOnce sync.Once
+}
+
+// NewVerifierKey deserializes a published verifier-key artifact (the same
+// bytes go-zk-circuits serves for a vega-mc-p256-v1-*-verifier-key-* entry)
+// into a reusable VerifierKey.
+func NewVerifierKey(bytes []byte) (*VerifierKey, error) {
+	if len(bytes) == 0 {
+		return nil, errors.New("zknative_vega: verifier key bytes must not be empty")
+	}
+
+	ptr, length := bytesPtr(bytes)
+	var errOut *C.char
+	handle := C.zk_cred_vega_deserialize_verifier_key(ptr, length, &errOut)
+	// ptr points into bytes' backing array - KeepAlive guarantees bytes (and
+	// so its backing array) can't be GC'd before the (synchronous) C call
+	// above returns. See zknative.NewVerifier's identical rationale.
+	runtime.KeepAlive(bytes)
+	if handle == nil {
+		return nil, fmt.Errorf("zknative_vega: zk_cred_vega_deserialize_verifier_key: %s", takeErrorString(errOut))
+	}
+	if errOut != nil {
+		_ = takeErrorString(errOut)
+	}
+	return &VerifierKey{handle: handle}, nil
+}
+
+// Close releases the underlying verifier-key handle. Safe to call more than
+// once (and concurrently) - only the first call frees the handle. Not safe
+// to call concurrently with an in-flight Verify call using the same
+// VerifierKey.
+func (k *VerifierKey) Close() error {
+	if k == nil {
+		return nil
+	}
+	k.closeOnce.Do(func() {
+		if k.handle != nil {
+			C.zk_cred_vega_free_verifier_key(k.handle)
+			k.handle = nil
+		}
+	})
+	return nil
+}
+
+// DisclosedClaim is one claim slot's verified disclosure outcome, mirroring
+// zk-cred-vega's CDisclosedClaim (and, one level up, its Rust
+// DisclosedClaim). Plaintext is exactly RealLen bytes (already trimmed of
+// the C ABI's fixed MaxClaimBytes padding) - meaningful only when Disclosed
+// is true (all-zero otherwise, per the crate's own masking).
+type DisclosedClaim struct {
+	Disclosed bool
+	Digest    [32]byte
+	RealLen   uint32
+	Plaintext []byte
+	DigestID  uint32
+}
+
+// VerifyResult is the verified, bound public output of a presentation,
+// mirroring zk-cred-vega's CVerifyResult.
+//
+// IMPORTANT (see Verify's own doc comment): this is everything the proof
+// itself proved, NOT a pass/fail against caller-supplied expected values -
+// the caller must independently compare these fields against whatever it
+// already knows before treating the presentation as accepted.
+type VerifyResult struct {
+	Qx, Qy                              [P256CoordBytes]byte
+	Claims                              [MaxClaims]DisclosedClaim
+	DeviceX, DeviceY                    [32]byte
+	SignedTs, ValidFromTs, ValidUntilTs [TimestampLen]byte
+}
+
+// Verify verifies proofBytes and checks the step<->core binding in one
+// call via zk-cred-vega's real zk_cred_vega_verify - a thin cgo marshaling
+// wrapper, not a separate/weaker check.
+//
+// A REAL SHAPE DIFFERENCE from zknative.Verifier.VerifyWithPPID: that
+// function takes the *expected* attribute values as input and returns only
+// an error (pass/fail) - the caller already knows what should be true and
+// just asks Rust to confirm it. This function takes ONLY the proof and
+// *returns* the recomputed public values (issuer pubkey, disclosed claims,
+// MSO-body fields) - the caller must independently check them against
+// whatever it already knows. See pkg/mdoc/zk_verifier.go's Vega dispatch
+// branch for exactly that comparison logic.
+func (k *VerifierKey) Verify(proof []byte) (VerifyResult, error) {
+	if k == nil || k.handle == nil {
+		return VerifyResult{}, errors.New("zknative_vega: verifier key is closed or nil")
+	}
+	if len(proof) == 0 {
+		return VerifyResult{}, errors.New("zknative_vega: proof must not be empty")
+	}
+
+	proofPtr, proofLen := bytesPtr(proof)
+	var cResult C.CVerifyResult
+	var errOut *C.char
+	status := C.zk_cred_vega_verify(k.handle, proofPtr, proofLen, &cResult, &errOut)
+	// proofPtr points into proof's backing array - KeepAlive guarantees proof
+	// can't be GC'd before the (synchronous) C call above returns.
+	runtime.KeepAlive(proof)
+	if status != 0 {
+		return VerifyResult{}, fmt.Errorf("zknative_vega: zk_cred_vega_verify failed (status=%d): %s", int32(status), takeErrorString(errOut))
+	}
+	if errOut != nil {
+		_ = takeErrorString(errOut)
+	}
+	return fromCResult(&cResult), nil
+}
+
+// fromCResult copies a C.CVerifyResult (backed by C memory that becomes
+// invalid the instant the calling function returns) into a plain Go
+// VerifyResult - no pointers into C memory escape this function.
+func fromCResult(r *C.CVerifyResult) VerifyResult {
+	var out VerifyResult
+	copyBytes(out.Qx[:], unsafe.Pointer(&r.qx[0]), len(out.Qx))
+	copyBytes(out.Qy[:], unsafe.Pointer(&r.qy[0]), len(out.Qy))
+	copyBytes(out.DeviceX[:], unsafe.Pointer(&r.device_x[0]), len(out.DeviceX))
+	copyBytes(out.DeviceY[:], unsafe.Pointer(&r.device_y[0]), len(out.DeviceY))
+	copyBytes(out.SignedTs[:], unsafe.Pointer(&r.signed_ts[0]), len(out.SignedTs))
+	copyBytes(out.ValidFromTs[:], unsafe.Pointer(&r.valid_from_ts[0]), len(out.ValidFromTs))
+	copyBytes(out.ValidUntilTs[:], unsafe.Pointer(&r.valid_until_ts[0]), len(out.ValidUntilTs))
+
+	for i := 0; i < MaxClaims; i++ {
+		c := r.claims[i]
+		var claim DisclosedClaim
+		claim.Disclosed = c.disclosed != 0
+		copyBytes(claim.Digest[:], unsafe.Pointer(&c.digest[0]), len(claim.Digest))
+		claim.RealLen = uint32(c.real_len)
+		claim.DigestID = uint32(c.digest_id)
+		realLen := int(claim.RealLen)
+		if realLen > MaxClaimBytes {
+			// Defensive: a value this large from the native library would
+			// indicate a real bug in the crate's own verify_and_check_binding
+			// (see go_ffi.rs's identical validation), not caller-controlled
+			// input - clamp rather than read out of the fixed C array.
+			realLen = MaxClaimBytes
+		}
+		if claim.Disclosed && realLen > 0 {
+			claim.Plaintext = make([]byte, realLen)
+			copyBytes(claim.Plaintext, unsafe.Pointer(&c.plaintext[0]), realLen)
+		}
+		out.Claims[i] = claim
+	}
+	return out
+}
+
+// copyBytes copies n bytes from a C-owned array (src) into dst, which must
+// have length >= n. Used only for fixed-size fields read out of a
+// C.CVerifyResult passed by value into fromCResult (i.e. src always points
+// into memory owned by the calling Go stack frame's C struct copy, not
+// separately heap-allocated C memory needing a free).
+func copyBytes(dst []byte, src unsafe.Pointer, n int) {
+	srcSlice := unsafe.Slice((*byte)(src), n)
+	copy(dst, srcSlice)
+}
+
+// bytesPtr returns a pointer to the first byte of b and its length, or
+// (nil, 0) for an empty slice. Only safe for pointers passed directly as
+// top-level cgo call arguments - see pkg/mdoc/zknative's identical
+// bytesPtr for the same rule (this package never needs cBytesCopy's
+// struct-field variant, since it never builds an array of C structs to
+// pass by pointer the way zknative.VerifyWithPPID's CAttribute array does).
+func bytesPtr(b []byte) (*C.uint8_t, C.size_t) {
+	if len(b) == 0 {
+		return nil, 0
+	}
+	return (*C.uint8_t)(unsafe.Pointer(&b[0])), C.size_t(len(b))
+}
+
+// takeErrorString converts and frees an owned error string written into an
+// error_out out-parameter by zk-cred-vega's C ABI, returning "(no message)"
+// if ptr is nil. Mirrors pkg/mdoc/zknative's identical helper - MUST use
+// zk_cred_vega_free_error_string (not the generic C.free) since the string
+// was allocated Rust-side via CString::into_raw, not malloc; freeing it any
+// other way is undefined behavior even if it happens to work today.
+func takeErrorString(ptr *C.char) string {
+	if ptr == nil {
+		return "(no message)"
+	}
+	msg := C.GoString(ptr)
+	C.zk_cred_vega_free_error_string(ptr)
+	return msg
+}

--- a/pkg/mdoc/zknative_vega/verifier.go
+++ b/pkg/mdoc/zknative_vega/verifier.go
@@ -36,6 +36,8 @@ import (
 	"runtime"
 	"sync"
 	"unsafe"
+
+	"github.com/SUNET/vc/pkg/mdoc/zkvegaworker"
 )
 
 // MaxClaims/MaxClaimBytes/TimestampLen mirror the crate's own
@@ -49,6 +51,18 @@ const (
 	MaxClaimBytes  = int(C.ZK_CRED_VEGA_MAX_CLAIM_BYTES)
 	TimestampLen   = int(C.ZK_CRED_VEGA_TIMESTAMP_LEN)
 	P256CoordBytes = 32
+)
+
+// The verifier-side builder cannot see the header - it must compile without
+// this tag - so it takes the slot count from zkvegaworker instead. These two
+// declarations fail to compile if that value and the crate's ever diverge:
+// a constant conversion to uint rejects a negative, so one of the pair
+// underflows unless they are equal. A circuit revision that changes
+// MAX_CLAIMS then breaks the tagged build here, rather than silently
+// producing a disclosedBytes slice the worker rejects at runtime.
+const (
+	_ = uint(MaxClaims - zkvegaworker.MaxClaims)
+	_ = uint(zkvegaworker.MaxClaims - MaxClaims)
 )
 
 // VerifierKey wraps an opaque, deserialized zk-cred-vega verifier-key

--- a/pkg/mdoc/zknative_vega/verifier.go
+++ b/pkg/mdoc/zknative_vega/verifier.go
@@ -82,18 +82,18 @@ type VerifierKey struct {
 // NewVerifierKey deserializes a published verifier-key artifact (the same
 // bytes go-zk-circuits serves for a vega-mc-p256-v1-*-verifier-key-* entry)
 // into a reusable VerifierKey.
-func NewVerifierKey(bytes []byte) (*VerifierKey, error) {
-	if len(bytes) == 0 {
+func NewVerifierKey(keyBytes []byte) (*VerifierKey, error) {
+	if len(keyBytes) == 0 {
 		return nil, errors.New("zknative_vega: verifier key bytes must not be empty")
 	}
 
-	ptr, length := bytesPtr(bytes)
+	ptr, length := bytesPtr(keyBytes)
 	var errOut *C.char
 	handle := C.zk_cred_vega_deserialize_verifier_key(ptr, length, &errOut)
-	// ptr points into bytes' backing array - KeepAlive guarantees bytes (and
+	// ptr points into keyBytes' backing array - KeepAlive guarantees it (and
 	// so its backing array) can't be GC'd before the (synchronous) C call
 	// above returns. See zknative.NewVerifier's identical rationale.
-	runtime.KeepAlive(bytes)
+	runtime.KeepAlive(keyBytes)
 	if handle == nil {
 		return nil, fmt.Errorf("zknative_vega: zk_cred_vega_deserialize_verifier_key: %s", takeErrorString(errOut))
 	}

--- a/pkg/mdoc/zknative_vega/verifier_test.go
+++ b/pkg/mdoc/zknative_vega/verifier_test.go
@@ -1,0 +1,126 @@
+//go:build zknative
+
+package zknative_vega
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// This test is a REAL end-to-end exercise of the cgo boundary: it loads a
+// real, published-shaped verifier key and a real proof over it, both
+// produced by zk-cred-vega's own already-tested safe Rust API, and
+// verifies the proof through the actual C ABI, from actual Go.
+//
+// Fixtures live in testdata/ (git-ignored - the verifier key is ~105MB
+// decompressed, too large to commit, unlike pkg/mdoc/testdata/zk_native's
+// small Longfellow fixtures). Regenerate via, in a zk-cred-vega checkout:
+//
+//	cargo test --release go_ffi::tests::dump_golden_fixture_for_go_smoke_test -- --ignored
+//
+// then copy target/go-cabi/testdata/{verifier_key,proof,claim0}.bin here.
+// Skipped automatically if the fixtures aren't present, rather than
+// failing the whole suite - mirrors pkg/mdoc/zknative's own
+// network-unreachable skip, just for a different "not set up" reason
+// (this crate has no live-published circuit to fetch from yet - see
+// go-zk-circuits' r7 entries' unpublished state).
+func TestVerify_RealGoldenProof(t *testing.T) {
+	vkBytes, proofBytes, claim0 := loadFixtures(t)
+
+	vk, err := NewVerifierKey(vkBytes)
+	if err != nil {
+		t.Fatalf("NewVerifierKey: %v", err)
+	}
+	defer vk.Close()
+
+	result, err := vk.Verify(proofBytes)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	if !result.Claims[0].Disclosed {
+		t.Error("claims[0] should be disclosed")
+	}
+	if int(result.Claims[0].RealLen) != len(claim0) {
+		t.Errorf("claims[0].RealLen = %d, want %d", result.Claims[0].RealLen, len(claim0))
+	}
+	if !bytes.Equal(result.Claims[0].Plaintext, claim0) {
+		t.Errorf("claims[0].Plaintext = %x, want %x", result.Claims[0].Plaintext, claim0)
+	}
+	if result.Claims[1].Disclosed {
+		t.Error("claims[1] should NOT be disclosed")
+	}
+	if len(result.Claims[1].Plaintext) != 0 {
+		t.Errorf("undisclosed claims[1].Plaintext should be empty, got %d bytes", len(result.Claims[1].Plaintext))
+	}
+
+	var zero [32]byte
+	if result.Qx == zero {
+		t.Error("Qx should not be all-zero")
+	}
+	if result.Qy == zero {
+		t.Error("Qy should not be all-zero")
+	}
+}
+
+// A tampered proof must be rejected with a real, non-empty error message.
+func TestVerify_RejectsTamperedProof(t *testing.T) {
+	vkBytes, proofBytes, _ := loadFixtures(t)
+
+	vk, err := NewVerifierKey(vkBytes)
+	if err != nil {
+		t.Fatalf("NewVerifierKey: %v", err)
+	}
+	defer vk.Close()
+
+	tampered := append([]byte(nil), proofBytes...)
+	tampered[len(tampered)-1] ^= 0xff
+
+	if _, err := vk.Verify(tampered); err == nil {
+		t.Fatal("expected tampered proof to fail verification")
+	}
+}
+
+func TestNewVerifierKey_RejectsEmptyBytes(t *testing.T) {
+	if _, err := NewVerifierKey(nil); err == nil {
+		t.Fatal("expected empty verifier key bytes to be rejected")
+	}
+}
+
+func TestVerify_RejectsClosedKey(t *testing.T) {
+	vkBytes, proofBytes, _ := loadFixtures(t)
+
+	vk, err := NewVerifierKey(vkBytes)
+	if err != nil {
+		t.Fatalf("NewVerifierKey: %v", err)
+	}
+	vk.Close()
+	vk.Close() // Close must be idempotent.
+
+	if _, err := vk.Verify(proofBytes); err == nil {
+		t.Fatal("expected Verify on a closed key to fail")
+	}
+}
+
+func loadFixtures(t *testing.T) (vkBytes, proofBytes, claim0 []byte) {
+	t.Helper()
+	dir := "testdata"
+	vkBytes = readFixtureOrSkip(t, filepath.Join(dir, "verifier_key.bin"))
+	proofBytes = readFixtureOrSkip(t, filepath.Join(dir, "proof.bin"))
+	claim0 = readFixtureOrSkip(t, filepath.Join(dir, "claim0.bin"))
+	return vkBytes, proofBytes, claim0
+}
+
+func readFixtureOrSkip(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("fixture %s not present - see this file's package doc for how to regenerate it", path)
+		}
+		t.Fatalf("reading fixture %s: %v", path, err)
+	}
+	return data
+}

--- a/pkg/mdoc/zknative_vega/verifier_test.go
+++ b/pkg/mdoc/zknative_vega/verifier_test.go
@@ -35,7 +35,7 @@ func TestVerify_RealGoldenProof(t *testing.T) {
 	}
 	defer vk.Close()
 
-	result, err := vk.Verify(proofBytes)
+	result, err := vk.Verify(proofBytes, disclosedBytesForFixture(claim0))
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestVerify_RealGoldenProof(t *testing.T) {
 
 // A tampered proof must be rejected with a real, non-empty error message.
 func TestVerify_RejectsTamperedProof(t *testing.T) {
-	vkBytes, proofBytes, _ := loadFixtures(t)
+	vkBytes, proofBytes, claim0 := loadFixtures(t)
 
 	vk, err := NewVerifierKey(vkBytes)
 	if err != nil {
@@ -78,7 +78,7 @@ func TestVerify_RejectsTamperedProof(t *testing.T) {
 	tampered := append([]byte(nil), proofBytes...)
 	tampered[len(tampered)-1] ^= 0xff
 
-	if _, err := vk.Verify(tampered); err == nil {
+	if _, err := vk.Verify(tampered, disclosedBytesForFixture(claim0)); err == nil {
 		t.Fatal("expected tampered proof to fail verification")
 	}
 }
@@ -90,7 +90,7 @@ func TestNewVerifierKey_RejectsEmptyBytes(t *testing.T) {
 }
 
 func TestVerify_RejectsClosedKey(t *testing.T) {
-	vkBytes, proofBytes, _ := loadFixtures(t)
+	vkBytes, proofBytes, claim0 := loadFixtures(t)
 
 	vk, err := NewVerifierKey(vkBytes)
 	if err != nil {
@@ -99,9 +99,21 @@ func TestVerify_RejectsClosedKey(t *testing.T) {
 	vk.Close()
 	vk.Close() // Close must be idempotent.
 
-	if _, err := vk.Verify(proofBytes); err == nil {
+	if _, err := vk.Verify(proofBytes, disclosedBytesForFixture(claim0)); err == nil {
 		t.Fatal("expected Verify on a closed key to fail")
 	}
+}
+
+// disclosedBytesForFixture builds the MaxClaims-length disclosedBytes
+// Verify now requires, for this package's golden-fixture tests: slot 0
+// gets claim0 (the fixture's own disclosed claim, matching the assertions
+// below), every other slot is left empty (undisclosed) - this fixture
+// predates r12 and was never regenerated to dump every slot's bytes, only
+// claim0's; see this file's own package doc for the regeneration command.
+func disclosedBytesForFixture(claim0 []byte) [][]byte {
+	out := make([][]byte, MaxClaims)
+	out[0] = claim0
+	return out
 }
 
 func loadFixtures(t *testing.T) (vkBytes, proofBytes, claim0 []byte) {

--- a/pkg/mdoc/zkvegaworker/protocol.go
+++ b/pkg/mdoc/zkvegaworker/protocol.go
@@ -41,6 +41,19 @@ type Request struct {
 
 	// ProofBytes is the presented ZK proof to verify.
 	ProofBytes []byte `json:"proof_bytes"`
+
+	// DisclosedBytes is the r12 circuit revision's required verify()
+	// input: exactly MAX_CLAIMS_V1 entries, one per circuit claim slot, in
+	// slot order - a disclosed slot's real IssuerSignedItemBytes, or an
+	// empty slice for an undisclosed one. zk_cred_vega no longer returns a
+	// disclosed claim's plaintext from the proof itself; the caller
+	// supplies it here and verify() re-derives + checks its blinded
+	// digest against the proof's own binding (a hard failure of the WHOLE
+	// call if any slot's bytes don't match). See
+	// BuildVegaDisclosedBytes's doc comment (in zk_verifier.go) for how
+	// the main process builds this slice from the wire's
+	// claimSlotDigestIds + per-item issuerSignedItemBytes fields.
+	DisclosedBytes [][]byte `json:"disclosed_bytes"`
 }
 
 // DisclosedClaim mirrors zknative_vega.DisclosedClaim over the wire.

--- a/pkg/mdoc/zkvegaworker/protocol.go
+++ b/pkg/mdoc/zkvegaworker/protocol.go
@@ -1,0 +1,71 @@
+// Package zkvegaworker defines the stdin/stdout JSON wire protocol between
+// the main vc-verifier process and the standalone cmd/zkvegaverifyworker
+// subprocess.
+//
+// This package is intentionally NOT cgo-tagged (no "zknative" build
+// constraint, no import of pkg/mdoc/zknative_vega): it's imported by both
+// sides of the pipe - the main process (which must keep building with
+// CGO_ENABLED=0) and the worker binary (which links zk-cred-vega via cgo) -
+// so the wire types themselves can't carry a cgo dependency either.
+//
+// Protocol: the main process writes one Request as a single JSON object to
+// the worker's stdin, then closes stdin (or the worker reads until EOF -
+// either way, exactly one request per process invocation - see this
+// package's own doc on why the worker isn't a long-lived pooled process
+// yet). The worker writes exactly one Response as a single JSON object to
+// stdout, then exits 0 (a struct Response.Result was produced, possibly
+// nil for a rejected-but-not-erroring... no: Result is always set on
+// success) or non-zero (Response.Error is set; process also exits
+// non-zero so a caller that fails to parse stdout at all still sees
+// something went wrong via the exit code).
+//
+// See docs/ZK_PPID_VERIFICATION_PLAN.md and
+// ~/.claude/plans/dreamy-frolicking-chipmunk.md's Phase 2/3 for the
+// subprocess-isolation rationale: the cgo call touching attacker-supplied
+// proof bytes runs in this isolated worker, not the main verifier process,
+// so a memory-safety fault in the native library only takes down one
+// worker, not the process serving other in-flight requests.
+package zkvegaworker
+
+// Request is the single JSON object the main process writes to the
+// worker's stdin.
+type Request struct {
+	// VerifierKeyBytes is the raw (decompressed) verifier-key artifact
+	// bytes - the same bytes zkcircuit.Client.DownloadAndDecompress
+	// returns for a vega-mc-p256-v1-*-verifier-key-* catalog entry. The
+	// main process is expected to cache these across calls (see
+	// getOrLoadVegaVerifierKey in zk_native_cgo.go); the worker
+	// re-deserializes them on every invocation since it holds no state
+	// across calls itself.
+	VerifierKeyBytes []byte `json:"verifier_key_bytes"`
+
+	// ProofBytes is the presented ZK proof to verify.
+	ProofBytes []byte `json:"proof_bytes"`
+}
+
+// DisclosedClaim mirrors zknative_vega.DisclosedClaim over the wire.
+type DisclosedClaim struct {
+	Disclosed bool   `json:"disclosed"`
+	Digest    []byte `json:"digest"`
+	RealLen   uint32 `json:"real_len"`
+	Plaintext []byte `json:"plaintext"`
+	DigestID  uint32 `json:"digest_id"`
+}
+
+// VerifyResult mirrors zknative_vega.VerifyResult over the wire - the
+// verified, bound public output of a presentation. See that type's own doc
+// comment: this is everything the proof itself proved, NOT a pass/fail
+// against caller-supplied expected values.
+type VerifyResult struct {
+	Qx, Qy                              []byte
+	Claims                              []DisclosedClaim
+	DeviceX, DeviceY                    []byte
+	SignedTs, ValidFromTs, ValidUntilTs []byte
+}
+
+// Response is the single JSON object the worker writes to stdout before
+// exiting. Exactly one of Result/Error is set.
+type Response struct {
+	Result *VerifyResult `json:"result,omitempty"`
+	Error  string        `json:"error,omitempty"`
+}

--- a/pkg/mdoc/zkvegaworker/protocol.go
+++ b/pkg/mdoc/zkvegaworker/protocol.go
@@ -26,6 +26,18 @@
 // worker, not the process serving other in-flight requests.
 package zkvegaworker
 
+// MaxClaims is zk-cred-vega's MAX_CLAIMS_V1: the fixed number of claim
+// slots a v1 circuit has, and so the exact length of Request.DisclosedBytes.
+//
+// It lives here because this package is the one both sides can import - the
+// authoritative value is C.ZK_CRED_VEGA_MAX_CLAIMS in the crate's header,
+// but that is only reachable under the cgo build tag, and the verifier-side
+// builder has to know the slot count without it. zknative_vega asserts at
+// compile time that this matches the header, so a circuit revision that
+// changes the count fails the tagged build instead of producing wire data
+// the worker then rejects at runtime.
+const MaxClaims = 4
+
 // Request is the single JSON object the main process writes to the
 // worker's stdin.
 type Request struct {

--- a/pkg/mdoc/zkvegaworker/protocol.go
+++ b/pkg/mdoc/zkvegaworker/protocol.go
@@ -68,11 +68,19 @@ type DisclosedClaim struct {
 // verified, bound public output of a presentation. See that type's own doc
 // comment: this is everything the proof itself proved, NOT a pass/fail
 // against caller-supplied expected values.
+// Tagged explicitly, like every other type here: these names are a wire
+// protocol between two separately-built binaries, so leaving them to
+// default Go field names would let a rename in one silently stop matching
+// the other.
 type VerifyResult struct {
-	Qx, Qy                              []byte
-	Claims                              []DisclosedClaim
-	DeviceX, DeviceY                    []byte
-	SignedTs, ValidFromTs, ValidUntilTs []byte
+	Qx           []byte           `json:"qx"`
+	Qy           []byte           `json:"qy"`
+	Claims       []DisclosedClaim `json:"claims"`
+	DeviceX      []byte           `json:"device_x"`
+	DeviceY      []byte           `json:"device_y"`
+	SignedTs     []byte           `json:"signed_ts"`
+	ValidFromTs  []byte           `json:"valid_from_ts"`
+	ValidUntilTs []byte           `json:"valid_until_ts"`
 }
 
 // Response is the single JSON object the worker writes to stdout before

--- a/pkg/mdoc/zkvegaworker/protocol.go
+++ b/pkg/mdoc/zkvegaworker/protocol.go
@@ -19,9 +19,8 @@
 // non-zero so a caller that fails to parse stdout at all still sees
 // something went wrong via the exit code).
 //
-// See docs/ZK_PPID_VERIFICATION_PLAN.md and
-// ~/.claude/plans/dreamy-frolicking-chipmunk.md's Phase 2/3 for the
-// subprocess-isolation rationale: the cgo call touching attacker-supplied
+// See docs/ZK_PPID_VERIFICATION_PLAN.md for the subprocess-isolation
+// rationale: the cgo call touching attacker-supplied
 // proof bytes runs in this isolated worker, not the main verifier process,
 // so a memory-safety fault in the native library only takes down one
 // worker, not the process serving other in-flight requests.

--- a/pkg/mdoc/zkvegaworker/protocol.go
+++ b/pkg/mdoc/zkvegaworker/protocol.go
@@ -13,11 +13,17 @@
 // either way, exactly one request per process invocation - see this
 // package's own doc on why the worker isn't a long-lived pooled process
 // yet). The worker writes exactly one Response as a single JSON object to
-// stdout, then exits 0 (a struct Response.Result was produced, possibly
-// nil for a rejected-but-not-erroring... no: Result is always set on
-// success) or non-zero (Response.Error is set; process also exits
-// non-zero so a caller that fails to parse stdout at all still sees
-// something went wrong via the exit code).
+// stdout, then exits. Two invariants, and a caller may rely on both:
+//
+//   - exit 0 means Response.Result is set and Response.Error is empty.
+//   - a non-zero exit means Response.Error is set and Response.Result is
+//     nil. The exit code carries the failure as well as the body, so a
+//     caller that cannot parse stdout at all still learns something went
+//     wrong.
+//
+// There is no third case: the worker never exits 0 with a nil Result to
+// mean "rejected but not errored". A proof that fails verification is an
+// error.
 //
 // See docs/ZK_PPID_VERIFICATION_PLAN.md for the subprocess-isolation
 // rationale: the cgo call touching attacker-supplied

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -634,6 +634,16 @@ type VerificationPresetScope struct {
 	ExcludeClaims []VerificationPresetClaim `yaml:"exclude_claims,omitempty" validate:"omitempty,dive"`
 	// Validations are optional rules applied server-side after claims extraction
 	Validations []openid4vp.ClaimValidation `yaml:"validations,omitempty" validate:"omitempty,dive"`
+	// Format overrides the scope's own credential_metadata format (e.g.
+	// requesting "mso_mdoc_zk" - a zero-knowledge proof - over a scope whose
+	// credential_metadata format is the plain "mso_mdoc" it's actually
+	// issued as). Empty means use the scope's own format unchanged.
+	Format string `yaml:"format,omitempty" validate:"omitempty"`
+	// ZKSystemType overrides meta.zk_system_type - required whenever Format
+	// is set to "mso_mdoc_zk" (openid4vp.FormatMsoMdocZk), since a ZK-mdoc
+	// DCQL query has no other way to say which proof system/circuit a
+	// verifier accepts. See openid4vp.ZKSystemTypeSpec's own doc comment.
+	ZKSystemType []openid4vp.ZKSystemTypeSpec `yaml:"zk_system_type,omitempty" validate:"omitempty,dive"`
 }
 
 // VerificationPresetClaim defines a claim path to request within a credential.

--- a/pkg/openid4vp/claims_extractor.go
+++ b/pkg/openid4vp/claims_extractor.go
@@ -169,6 +169,19 @@ func extractMDocClaimsFromToken(vpToken string) (map[string]any, error) {
 				NameSpaces map[string][]any `cbor:"nameSpaces"`
 			} `cbor:"issuerSigned"`
 		} `cbor:"documents"`
+		// A "mso_mdoc_zk" presentation (multipaz's zkDocuments extension,
+		// see pkg/mdoc/zk.go) carries its documents here instead of
+		// "documents" - checked only to distinguish "genuinely empty
+		// DeviceResponse" from "a ZK-proof response this best-effort,
+		// pre-verification preview extractor doesn't understand yet".
+		// Real claim extraction+verification for these happens in the
+		// dedicated pkg/mdoc/zk_verifier.go path elsewhere in the pipeline
+		// (can't import it directly here - it already imports this
+		// package). Confirmed live: without this check, every ZK mdoc
+		// presentation failed the whole /verification/direct_post
+		// submission with "no documents in DeviceResponse", even though
+		// the proof itself was valid and never got a chance to verify.
+		ZkDocuments []cbor.RawMessage `cbor:"zkDocuments,omitempty"`
 	}
 
 	if err := cbor.Unmarshal(data, &deviceResponse); err != nil {
@@ -176,6 +189,9 @@ func extractMDocClaimsFromToken(vpToken string) (map[string]any, error) {
 	}
 
 	if len(deviceResponse.Documents) == 0 {
+		if len(deviceResponse.ZkDocuments) > 0 {
+			return make(map[string]any), nil
+		}
 		return nil, fmt.Errorf("no documents in DeviceResponse")
 	}
 


### PR DESCRIPTION
## Summary
Adds a second native ZK proof system (Microsoft's Vega, via
`sirosfoundation/zk-cred-vega`) alongside the existing Longfellow
native ZK/PPID verification path - both real, distinct cgo
integrations dispatched by the presentation's declared
`zk_system_type`, not a rename of the existing path.

- **`pkg/mdoc/zknative_vega`**: cgo wrapper mirroring `pkg/mdoc/zknative`'s
  existing patterns (`sync.Once`-guarded `Close()`, `runtime.KeepAlive`,
  owned-error-string cleanup), but the actual native call runs in an
  isolated subprocess (`cmd/zkvegaverifyworker`) rather than in-process -
  a memory-safety fault in an unreviewed native library touching
  attacker-controlled proof bytes then only takes down one worker, not
  the verifier serving other in-flight requests.
- **`pkg/mdoc/zk_verifier.go`**: dispatch + a real architectural
  difference from Longfellow's path - Vega's `verify()` takes only the
  proof and *returns* the plaintext/qx/qy/timestamps it recomputed,
  rather than taking expected values as input. So this adds real new
  comparison logic: issuer pubkey vs. the trust-evaluated cert, each
  disclosed claim's returned plaintext vs. the wire-declared
  `elementValue` (matched by `digest_id`, not position), and MSO
  validity timestamps vs. now - otherwise a malicious wallet could send
  a real proof for one claim value while wire-declaring a different one.
  Also fixes tag(24) unwrapping: the returned plaintext is the item's
  real wire bytes verbatim (a `#6.24(bstr <map>)`-wrapped CBOR item),
  confirmed against a real device presentation's captured claim bytes.
- **Makefile/README wiring** (`zk-native-lib-vega`,
  `dockerfiles/verifier-zknative`) for building/staging the native
  library and a Docker image with both native libs present. The
  Dockerfile documents an early-testing shortcut (expects
  `third_party/{zk-cred-longfellow,zk-cred-vega}` already staged in the
  build context) rather than building from source inside the image.
- Several verifier-side fixes discovered live-testing this end-to-end
  against a real wallet: a Mongo round-trip that dropped `DCQLQuery`
  before ZK matching (falls back to `RequestObjectCache`), a
  session-transcript `responseURI` mismatch and a missing ephemeral-key
  JWK thumbprint (both broke the ZK proof's Fiat-Shamir transcript,
  causing every real proof to reject with `InvalidSumcheckProof`
  regardless of claim correctness), plus DCQL/preset schema and
  `zk_system_type` declarations from earlier ZK/PPID work.

Vega's own circuit code is unreviewed (expert security review pending -
see `sirosfoundation/zk-cred-vega`'s README), so none of this should be
treated as vouched-for; it's shipped for early interop testing the same
way the existing Longfellow path was before its own review milestone.

## Test plan
- [x] `go build -tags zknative ./...` and `go vet -tags zknative
      ./pkg/mdoc/... ./internal/verifier/...` - clean
- [x] Live-tested end-to-end against a real Kotlin wallet presentation
      (Vega ZK mdoc proof, both accept and reject-tampered paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)