### PR TITLE
ci: run the pkg/ tests without -v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ test-env: ## Set up test environment
 
 test-pkg: ## Test the shared packages under pkg/
 	$(info Testing pkg)
-	go test -v ./pkg/...
+	go test ./pkg/...
 
 test-js: ## Run JS unit tests for staticembed helpers
 	$(info Running JS unit tests)


### PR DESCRIPTION
Small follow-up to #619, reverting one line.

`test-pkg` picked up `-v` during review, for consistency with `test-verifier` and the other service targets. On reflection the consistency is not worth what it costs here.

**`go test` prints the full output of a failing test either way** — the failure, the assertion diff, and that test's `t.Log`. `-v` adds the `=== RUN` / `--- PASS` lines for tests that *passed*. So it does not improve failure diagnosis; it only changes volume.

And the volume is the issue: `pkg/` is **223 test files** against roughly a dozen per service. Verbose output there means a CI log where the passing case dominates and the interesting output is thousands of lines up. For a target whose whole purpose is to be quiet until something breaks, that is the wrong default.

The service targets keep `-v` — a dozen files each is a different proposition, and this does not touch them.

Verified `make test-pkg` still green and `make -n test` still resolves to `go test ./pkg/...` exactly once.