### PR TITLE
fix(apigw): filter assertion claims against the credential type

### DIFF
--- a/internal/apigw/apiv1/handlers_oauth.go
+++ b/internal/apigw/apiv1/handlers_oauth.go
@@ -612,7 +612,7 @@ func (c *Client) OAuthToken(ctx context.Context, req *openid4vci.TokenRequest) (
 		reply.CNonce = childNonce
 
 		childSession := &cache.AuthorizationContext{
-			SessionID:             childSessionID,
+			SessionID:            childSessionID,
 			SourceSessionID:      authorizationContext.SessionID,
 			Status:               cache.SessionStatusTokenIssued,
 			CreatedAt:            time.Now(),
@@ -1003,5 +1003,3 @@ func (c *Client) handleRefreshTokenGrant(ctx context.Context, start time.Time, r
 	c.log.Debug("refresh token grant complete", "session_id", authContext.SessionID)
 	return reply, nil
 }
-
-

--- a/internal/apigw/apiv1/handlers_oidcrp.go
+++ b/internal/apigw/apiv1/handlers_oidcrp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"sort"
 	"time"
 
 	"github.com/SUNET/vc/internal/apigw/auth_providers/oidcrp"
@@ -166,8 +167,13 @@ func (c *Client) OIDCRPCallback(ctx context.Context, req *OIDCRPCallbackRequest,
 			return nil, err
 		}
 	} else {
-		// No mapping configured — pass through raw claims
-		claims = authResp.Claims
+		// No mapping configured. Raw OIDC claims used to pass through
+		// verbatim, which put every ID-token claim into the credential -
+		// including ones the credential type never declares. Those can
+		// never be selectively disclosed, so a wallet has to present them
+		// every time, and the standard ones (iss, aud, exp, iat, nonce)
+		// collide with the envelope the issuer fills in at signing.
+		claims = c.filterClaimsByCredentialType(session.CredentialType, authResp.Claims)
 	}
 
 	// Log the resulting document data for diagnostics.
@@ -416,4 +422,55 @@ func (c *Client) createCredentialViaOIDCRP(ctx context.Context, credentialType s
 	}
 
 	return reply.Credentials[0].Credential, nil
+}
+
+// filterClaimsByCredentialType drops claims the credential type does not
+// declare, so an assertion-sourced credential carries only what its VCTM or
+// MDDL describes.
+//
+// It is deliberately conservative about not having metadata: when no VCTM or
+// MDDL is loaded for the scope there is nothing to filter against, and
+// silently emptying the credential would be worse than the over-sharing this
+// exists to prevent, so the claims pass through unchanged and the reason is
+// logged.
+func (c *Client) filterClaimsByCredentialType(credentialType string, claims map[string]any) map[string]any {
+	if len(claims) == 0 {
+		return claims
+	}
+
+	metadata := c.cfg.Common.CredentialMetadata[credentialType]
+	if metadata == nil {
+		c.log.Warn("assertion claims not filtered: no credential metadata configured for scope",
+			"credential_type", credentialType, "claim_count", len(claims))
+		return claims
+	}
+
+	allowed, loaded := metadata.DeclaredClaimNames()
+	if !loaded {
+		c.log.Warn("assertion claims not filtered: neither VCTM nor MDDL loaded for scope",
+			"credential_type", credentialType, "claim_count", len(claims))
+		return claims
+	}
+
+	filtered := make(map[string]any, len(claims))
+	dropped := make([]string, 0)
+	for name, value := range claims {
+		if allowed[name] {
+			filtered[name] = value
+			continue
+		}
+		dropped = append(dropped, name)
+	}
+
+	if len(dropped) > 0 {
+		// Named rather than counted: this changes what a credential
+		// contains, and an operator upgrading into it should be able to see
+		// exactly which claims stopped being issued rather than infer it
+		// from missing data.
+		sort.Strings(dropped)
+		c.log.Info("assertion claims dropped: not declared by the credential type",
+			"credential_type", credentialType, "dropped", dropped, "kept", len(filtered))
+	}
+
+	return filtered
 }

--- a/internal/apigw/apiv1/handlers_oidcrp_filter_test.go
+++ b/internal/apigw/apiv1/handlers_oidcrp_filter_test.go
@@ -1,0 +1,92 @@
+package apiv1
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/logger"
+	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/sdjwtvc"
+	"github.com/stretchr/testify/assert"
+)
+
+func claimPath(s string) *string { return &s }
+
+func filterTestClient(t *testing.T, scope string, metadata *model.CredentialMetadata) *Client {
+	t.Helper()
+	md := map[string]*model.CredentialMetadata{}
+	if metadata != nil {
+		md[scope] = metadata
+	}
+	return &Client{
+		log: logger.NewSimple("test"),
+		cfg: &model.Cfg{Common: &model.Common{CredentialMetadata: md}},
+	}
+}
+
+// idTokenClaims is what an OIDC provider actually hands back: a few claims the
+// credential wants, wrapped in envelope claims it does not.
+func idTokenClaims() map[string]any {
+	return map[string]any{
+		"given_name":  "Helen",
+		"family_name": "Nilsson",
+		"iss":         "https://idp.example",
+		"aud":         "vc-apigw",
+		"exp":         1893456000,
+		"iat":         1893452400,
+		"nonce":       "n-0S6_WzA2Mj",
+		"at_hash":     "abc",
+		"sid":         "session-1",
+		"email":       "helen@example.org",
+	}
+}
+
+// TestFilterClaims_DropsUndeclared is issue #623: claims the credential type
+// does not declare can never be selectively disclosed, so a wallet has to
+// present them every time.
+func TestFilterClaims_DropsUndeclared(t *testing.T) {
+	c := filterTestClient(t, "pid", &model.CredentialMetadata{VCTM: &sdjwtvc.VCTM{Claims: []sdjwtvc.Claim{
+		{Path: []*string{claimPath("given_name")}},
+		{Path: []*string{claimPath("family_name")}},
+	}}})
+
+	got := c.filterClaimsByCredentialType("pid", idTokenClaims())
+
+	assert.Equal(t, map[string]any{"given_name": "Helen", "family_name": "Nilsson"}, got)
+
+	// Called out individually: these collide with the envelope the issuer
+	// fills in at signing time (see sdjwtvc.isIssuerSuppliedClaim), so
+	// letting them through is a correctness problem as well as a privacy one.
+	for _, envelope := range []string{"iss", "aud", "exp", "iat"} {
+		assert.NotContains(t, got, envelope, "envelope claim must not survive")
+	}
+	assert.NotContains(t, got, "email", "an undeclared claim must not survive")
+}
+
+// TestFilterClaims_NoMetadataPassesThrough pins the deliberate conservatism:
+// with nothing to filter against, emptying the credential would be worse than
+// the over-sharing this exists to prevent.
+func TestFilterClaims_NoMetadataPassesThrough(t *testing.T) {
+	t.Run("scope not configured", func(t *testing.T) {
+		c := filterTestClient(t, "pid", nil)
+		assert.Equal(t, idTokenClaims(), c.filterClaimsByCredentialType("pid", idTokenClaims()))
+	})
+
+	t.Run("configured but neither VCTM nor MDDL loaded", func(t *testing.T) {
+		c := filterTestClient(t, "pid", &model.CredentialMetadata{})
+		assert.Equal(t, idTokenClaims(), c.filterClaimsByCredentialType("pid", idTokenClaims()))
+	})
+}
+
+// TestFilterClaims_LoadedButEmptyDropsEverything is the other side of that
+// distinction: a credential type that genuinely declares no claims is not the
+// same as one whose metadata never loaded.
+func TestFilterClaims_LoadedButEmptyDropsEverything(t *testing.T) {
+	c := filterTestClient(t, "pid", &model.CredentialMetadata{VCTM: &sdjwtvc.VCTM{}})
+	assert.Empty(t, c.filterClaimsByCredentialType("pid", idTokenClaims()))
+}
+
+func TestFilterClaims_NoClaims(t *testing.T) {
+	c := filterTestClient(t, "pid", &model.CredentialMetadata{VCTM: &sdjwtvc.VCTM{}})
+	assert.Empty(t, c.filterClaimsByCredentialType("pid", map[string]any{}))
+	assert.Nil(t, c.filterClaimsByCredentialType("pid", nil))
+}

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -2112,3 +2112,44 @@ func (cfg *OAuthServer) GenerateMetadata(ctx context.Context, issuerURL string) 
 
 	return metadata
 }
+
+// DeclaredClaimNames returns the top-level claim names this credential type
+// declares, across both VCTM and MDDL. The boolean reports whether any
+// metadata was available to derive them from - an empty set from a loaded
+// document means "declares nothing", which is different from "nothing
+// loaded", and callers must not treat the two alike.
+//
+// Names are top-level because the claim maps produced by external identity
+// providers are flat. For a VCTM the name is the first path segment, so a
+// nested claim like ["address","street_address"] admits an "address" object
+// and lets the existing pipeline handle its interior. For an MDDL it is the
+// element ID, since document data is keyed by element directly rather than
+// nested under the mdoc namespace - see MDDLSchema.Presentation.
+func (c *CredentialMetadata) DeclaredClaimNames() (map[string]bool, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	names := map[string]bool{}
+	loaded := false
+
+	if c.VCTM != nil {
+		loaded = true
+		for _, claim := range c.VCTM.Claims {
+			if len(claim.Path) == 0 || claim.Path[0] == nil {
+				continue
+			}
+			names[*claim.Path[0]] = true
+		}
+	}
+
+	if c.MDDL != nil {
+		loaded = true
+		for _, elements := range c.MDDL.Claims {
+			for elementID := range elements {
+				names[elementID] = true
+			}
+		}
+	}
+
+	return names, loaded
+}

--- a/pkg/model/declared_claims_test.go
+++ b/pkg/model/declared_claims_test.go
@@ -1,0 +1,54 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SUNET/vc/pkg/mdoc"
+	"github.com/SUNET/vc/pkg/sdjwtvc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestDeclaredClaimNames_VCTM(t *testing.T) {
+	m := &CredentialMetadata{VCTM: &sdjwtvc.VCTM{Claims: []sdjwtvc.Claim{
+		{Path: []*string{ptr("given_name")}},
+		{Path: []*string{ptr("family_name")}},
+		// A nested claim contributes its top-level object, so an address
+		// object from the provider is admitted and handled downstream.
+		{Path: []*string{ptr("address"), ptr("street_address")}},
+		{Path: []*string{ptr("address"), ptr("country")}},
+		{Path: nil},            // malformed entries must not panic
+		{Path: []*string{nil}}, //
+	}}}
+
+	names, loaded := m.DeclaredClaimNames()
+	require.True(t, loaded)
+	assert.Equal(t, map[string]bool{"given_name": true, "family_name": true, "address": true}, names)
+}
+
+func TestDeclaredClaimNames_MDDL(t *testing.T) {
+	m := &CredentialMetadata{MDDL: &mdoc.MDDLSchema{Claims: map[string]mdoc.NamespaceClaims{
+		"org.iso.18013.5.1": {"given_name": {}, "birth_date": {}},
+	}}}
+
+	names, loaded := m.DeclaredClaimNames()
+	require.True(t, loaded)
+	assert.Equal(t, map[string]bool{"given_name": true, "birth_date": true}, names,
+		"MDDL document data is keyed by element ID, not namespaced")
+}
+
+// TestDeclaredClaimNames_NothingLoaded pins the distinction the second return
+// value exists for: a credential type with no metadata loaded declares
+// nothing, and that must not be mistaken for declaring an empty set.
+func TestDeclaredClaimNames_NothingLoaded(t *testing.T) {
+	names, loaded := (&CredentialMetadata{}).DeclaredClaimNames()
+	assert.False(t, loaded)
+	assert.Empty(t, names)
+
+	// A loaded VCTM that happens to declare nothing is a different answer.
+	names, loaded = (&CredentialMetadata{VCTM: &sdjwtvc.VCTM{}}).DeclaredClaimNames()
+	assert.True(t, loaded)
+	assert.Empty(t, names)
+}


### PR DESCRIPTION
Fixes #623.

## Confirmed

`oidcrp.BuildTransformer()` returns `nil` when no `attribute_mapping` is configured, and the callback then did:

```go
} else {
    // No mapping configured — pass through raw claims
    claims = authResp.Claims
}
```

Every claim in the OIDC ID token became a credential claim. Nothing filtered against the VCTM/MDDL on this path — `ValidateDocumentData` is only called from the datastore handlers.

## Two problems, not one

**The one reported:** claims the credential type does not declare are never selectively disclosable, so the wallet must present them on every use.

**One the issue does not mention:** an ID token carries `iss`, `aud`, `exp`, `iat`, `nonce`, `at_hash`, `sid`, `azp`. Of those, `iss`, `exp` and `iat` are *envelope claims the issuer fills in at signing* — `pkg/sdjwtvc/validation.go` lists them in `isIssuerSuppliedClaim`. So passthrough also fed the identity provider's envelope values into the credential's own envelope namespace. That is a correctness risk, and it is why filtering is the right fix rather than documenting the behaviour.

## Fix

Claims are filtered to those the scope's VCTM or MDDL declares.

**Top-level names**, because provider claim maps are flat. For a VCTM that is the first path segment — so a nested `["address","street_address"]` claim still admits an `address` object and lets the existing pipeline handle its interior. For an MDDL it is the **element ID**, not the namespaced path, since document data is keyed by element directly (as `MDDLSchema.Presentation` already notes).

## Two deliberate choices worth reviewing

**Dropped claims are logged by name, not counted.** This changes what a credential contains. An operator upgrading into it should be able to see exactly which claims stopped being issued, rather than infer it from data going missing.

**No metadata means no filtering.** When neither a VCTM nor an MDDL is loaded for the scope there is nothing to filter against, so claims pass through with a warning — quietly emptying the credential would be a worse failure than the over-sharing this fixes. `DeclaredClaimNames` returns a separate `loaded` boolean for exactly this: *a type that declares nothing* and *a type whose metadata never loaded* are different answers, and collapsing them would turn a config problem into silent data loss.

## Scope

**Only the OIDC RP path.** SAML's `BuildTransformer` already returns an error when `attribute_mapping` is empty, so it never had a passthrough to fix.

## Verification

- 10 subtests: the ID-token case end to end, each envelope claim asserted absent individually, both no-metadata fallbacks, the loaded-but-empty case, and empty/nil input.
- `make test-pkg` and `go test ./internal/apigw/...` green.
- No new lint (the two hits in `handlers_oidcrp.go` are pre-existing on `main`).