### PR TITLE
fix(verifier): make client_metadata usable by OpenID4VP 1.0 wallets

### DIFF
--- a/internal/apigw/apiv1/handlers_verifier.go
+++ b/internal/apigw/apiv1/handlers_verifier.go
@@ -146,6 +146,9 @@ func (c *Client) VerificationRequestObject(ctx context.Context, req *Verificatio
 			},
 			AuthorizationEncryptedResponseALG: "ECDH-ES",
 			AuthorizationEncryptedResponseENC: "A256GCM",
+			// See handlers_ui.go: OpenID4VP 1.0 renamed this field and made
+			// it an array. Both spellings are sent.
+			EncryptedResponseEncValuesSupported: []string{"A256GCM"},
 		},
 		IAT: time.Now().UTC().Unix(),
 	}

--- a/internal/verifier/apiv1/client_test.go
+++ b/internal/verifier/apiv1/client_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestClient_generateSubjectIdentifier_Public(t *testing.T) {
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 	client.cfg.Verifier.Outbound.OIDCProvider.SubjectType = "public"
 	client.cfg.Verifier.Outbound.OIDCProvider.SubjectSalt = "test-salt"
 
@@ -31,7 +31,7 @@ func TestClient_generateSubjectIdentifier_Public(t *testing.T) {
 }
 
 func TestClient_generateSubjectIdentifier_Pairwise(t *testing.T) {
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 	client.cfg.Verifier.Outbound.OIDCProvider.SubjectType = "pairwise"
 	client.cfg.Verifier.Outbound.OIDCProvider.SubjectSalt = "test-salt"
 
@@ -53,7 +53,7 @@ func TestClient_generateSubjectIdentifier_Pairwise(t *testing.T) {
 }
 
 func TestClient_generateSubjectIdentifier_DifferentWallets(t *testing.T) {
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 	client.cfg.Verifier.Outbound.OIDCProvider.SubjectType = "pairwise"
 	client.cfg.Verifier.Outbound.OIDCProvider.SubjectSalt = "test-salt"
 
@@ -68,7 +68,7 @@ func TestClient_generateSubjectIdentifier_DifferentWallets(t *testing.T) {
 }
 
 func TestClient_containsOIDC(t *testing.T) {
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 
 	tests := []struct {
 		name     string
@@ -154,7 +154,7 @@ func TestClient_parseScopes(t *testing.T) {
 
 func TestClient_Health(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 
 	// Note: Health requires db to be set, which may fail in mock
 	// This test verifies the method exists and can be called
@@ -292,7 +292,7 @@ func TestClient_buildDCQLQueryFromConfig(t *testing.T) {
 					CredentialMetadata: tt.credMeta,
 				},
 			}
-			client, _ := CreateTestClientWithMock(cfg)
+			client, _ := CreateTestClientWithMock(t, cfg)
 
 			dcql, err := client.buildDCQLQueryFromConfig(tt.scopes)
 
@@ -352,7 +352,7 @@ func TestClient_createDCQLQuery(t *testing.T) {
 					CredentialMetadata: tt.credMeta,
 				},
 			}
-			client, _ := CreateTestClientWithMock(cfg)
+			client, _ := CreateTestClientWithMock(t, cfg)
 
 			dcql, err := client.createDCQLQuery(ctx, tt.scopes)
 

--- a/internal/verifier/apiv1/handler_client_registration_test.go
+++ b/internal/verifier/apiv1/handler_client_registration_test.go
@@ -374,7 +374,7 @@ func TestClientRegistrationRequest_Defaults(t *testing.T) {
 // TestAuthenticateClient tests client authentication
 func TestAuthenticateClient(t *testing.T) {
 	ctx := t.Context()
-	client, mockDB := CreateTestClientWithMock(nil)
+	client, mockDB := CreateTestClientWithMock(t, nil)
 
 	// Create a test client with a bcrypt-hashed credential
 	// Generate test value dynamically to avoid static analysis false positives
@@ -542,7 +542,7 @@ func TestRegisterClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mockDB := CreateTestClientWithMock(nil)
+			client, mockDB := CreateTestClientWithMock(t, nil)
 			client.cfg.Verifier.PublicURL = "https://verifier.example.com"
 
 			// Simulate HTTP layer: apply defaults and validate
@@ -647,7 +647,7 @@ func TestGetClientInformation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mockDB := CreateTestClientWithMock(nil)
+			client, mockDB := CreateTestClientWithMock(t, nil)
 			client.cfg.Verifier.PublicURL = "https://verifier.example.com"
 
 			clientID, token := tt.setupMock(t, mockDB.Clients)
@@ -724,7 +724,7 @@ func TestDeleteClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mockDB := CreateTestClientWithMock(nil)
+			client, mockDB := CreateTestClientWithMock(t, nil)
 
 			clientID, token := tt.setupMock(t, mockDB.Clients)
 
@@ -903,7 +903,7 @@ func TestUpdateClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mockDB := CreateTestClientWithMock(nil)
+			client, mockDB := CreateTestClientWithMock(t, nil)
 			client.cfg.Verifier.PublicURL = "https://verifier.example.com"
 
 			clientID, token := tt.setupMock(t, mockDB.Clients)
@@ -1106,7 +1106,7 @@ func TestGetClientByID(t *testing.T) {
 		},
 	}
 
-	client, mockDB := CreateTestClientWithMock(&model.Cfg{
+	client, mockDB := CreateTestClientWithMock(t, &model.Cfg{
 		Verifier: &model.Verifier{
 			Outbound: model.VerifierOutbound{
 				OIDCProvider: &model.OIDCOP{
@@ -1228,7 +1228,7 @@ func TestAuthenticateClientWithStaticClients(t *testing.T) {
 		},
 	}
 
-	client, _ := CreateTestClientWithMock(&model.Cfg{
+	client, _ := CreateTestClientWithMock(t, &model.Cfg{
 		Verifier: &model.Verifier{
 			Outbound: model.VerifierOutbound{
 				OIDCProvider: &model.OIDCOP{

--- a/internal/verifier/apiv1/handler_oidc_test.go
+++ b/internal/verifier/apiv1/handler_oidc_test.go
@@ -365,7 +365,7 @@ func TestStandardClaims(t *testing.T) {
 // Note: Full Authorize flow requires CredentialMetadata config which is complex to mock
 func TestAuthorize_ClientValidation(t *testing.T) {
 	ctx := t.Context()
-	client, mockDB := CreateTestClientWithMock(nil)
+	client, mockDB := CreateTestClientWithMock(t, nil)
 
 	// Add a test client to the mock
 	mockDB.Clients.AddClient(&db.Client{
@@ -428,7 +428,7 @@ func TestAuthorize_ClientValidation(t *testing.T) {
 // TestAuthorize_PKCEValidation tests PKCE enforcement in the Authorize handler
 func TestAuthorize_PKCEValidation(t *testing.T) {
 	ctx := t.Context()
-	client, mockDB := CreateTestClientWithMock(nil)
+	client, mockDB := CreateTestClientWithMock(t, nil)
 
 	// Add a client that requires PKCE
 	mockDB.Clients.AddClient(&db.Client{
@@ -877,7 +877,7 @@ func TestToken_AuthorizationCodeGrant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mockDB := CreateTestClientWithMock(nil)
+			client, mockDB := CreateTestClientWithMock(t, nil)
 			tt.setupMock(t, client.cacheService.AuthContext, mockDB.Clients)
 
 			// Set up test signing key
@@ -921,7 +921,7 @@ func TestToken_AuthorizationCodeGrant(t *testing.T) {
 func TestToken_EnableUserInfoTrue(t *testing.T) {
 	ctx := t.Context()
 
-	client, mockDB := CreateTestClientWithMock(nil)
+	client, mockDB := CreateTestClientWithMock(t, nil)
 	client.cfg.Verifier.Outbound.OIDCProvider.EnableUserInfo = true
 	client.cfg.Verifier.Outbound.OIDCProvider.AccessTokenDuration = 3600
 
@@ -993,7 +993,7 @@ func TestToken_EnableUserInfoTrue(t *testing.T) {
 // TestToken_RefreshTokenGrant tests the refresh token grant (currently unimplemented)
 func TestToken_RefreshTokenGrant(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 
 	req := &TokenRequest{
 		GrantType:    "refresh_token",
@@ -1041,7 +1041,7 @@ func TestGenerateIDToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
 
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 			client.cfg.Verifier.Outbound.OIDCProvider.Issuer = "https://issuer.example.com"
 			client.cfg.Verifier.Outbound.OIDCProvider.IDTokenDuration = 3600
 			client.cfg.Verifier.Outbound.OIDCProvider.SubjectType = "public"
@@ -1097,7 +1097,7 @@ func TestGenerateIDToken(t *testing.T) {
 
 // TestAuthenticateOIDCClient tests client authentication
 func TestAuthenticateOIDCClient(t *testing.T) {
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 
 	tests := []struct {
 		name         string
@@ -1331,7 +1331,7 @@ func TestAuthorize_FullFlow(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, mockDB := CreateTestClientWithMock(nil)
+			client, mockDB := CreateTestClientWithMock(t, nil)
 			client.cfg.Verifier.PublicURL = "https://verifier.example.com"
 			client.cfg.Verifier.Outbound.OIDCProvider.SessionDuration = 900
 			client.cfg.Verifier.DigitalCredentials.Enable = true
@@ -1403,7 +1403,7 @@ func TestAuthorize_FullFlow(t *testing.T) {
 func TestAuthorize_DigitalCredentialsDisabled(t *testing.T) {
 	ctx := t.Context()
 
-	client, mockDB := CreateTestClientWithMock(nil)
+	client, mockDB := CreateTestClientWithMock(t, nil)
 	client.cfg.Verifier.PublicURL = "https://verifier.example.com"
 	client.cfg.Verifier.Outbound.OIDCProvider.SessionDuration = 900
 	// Explicitly disable Digital Credentials API
@@ -1453,7 +1453,7 @@ func TestAuthorize_DigitalCredentialsDisabled(t *testing.T) {
 func TestAuthorize_WalletLinks(t *testing.T) {
 	ctx := t.Context()
 
-	client, mockDB := CreateTestClientWithMock(nil)
+	client, mockDB := CreateTestClientWithMock(t, nil)
 	client.cfg.Verifier.PublicURL = "https://verifier.example.com"
 	client.cfg.Verifier.Outbound.OIDCProvider.SessionDuration = 900
 	client.cfg.Verifier.SupportedWallets = map[string]string{
@@ -1526,7 +1526,7 @@ func TestAuthorize_WalletLinks(t *testing.T) {
 func TestAuthorize_NoWalletLinks(t *testing.T) {
 	ctx := t.Context()
 
-	client, mockDB := CreateTestClientWithMock(nil)
+	client, mockDB := CreateTestClientWithMock(t, nil)
 	client.cfg.Verifier.PublicURL = "https://verifier.example.com"
 	client.cfg.Verifier.Outbound.OIDCProvider.SessionDuration = 900
 	// No supported wallets configured
@@ -1562,7 +1562,7 @@ func TestAuthorize_NoWalletLinks(t *testing.T) {
 // TestGetQRCode tests QR code generation
 func TestGetQRCode(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 	client.cfg.Verifier.SupportedWallets = map[string]string{
 		"SUNET Wallet": "https://wallet.sunet.se/cb",
 		"Test Wallet":  "https://test-wallet.example.com/authorize",
@@ -1646,7 +1646,7 @@ func TestGetQRCode(t *testing.T) {
 // TestPollSession tests session polling
 func TestPollSession(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 
 	// Create test sessions with different statuses
 	pendingSession := &cache.AuthorizationContext{
@@ -1728,7 +1728,7 @@ func TestPollSession(t *testing.T) {
 // TestGetUserInfo tests the stateless UserInfo endpoint with JWT access tokens
 func TestGetUserInfo(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(&model.Cfg{
+	client, _ := CreateTestClientWithMock(t, &model.Cfg{
 		Verifier: &model.Verifier{
 			PublicURL: "https://verifier.example.com",
 			Outbound: model.VerifierOutbound{
@@ -1940,7 +1940,7 @@ func TestGetOIDCRequestObject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Generate RSA key for signing
 			key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -2032,7 +2032,7 @@ func TestProcessCallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup session if needed
 			if tt.authCtxSetup != nil {
@@ -2140,7 +2140,7 @@ func TestGetJWKS_KeyTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup key
 			key := tt.setupKey()
@@ -2304,7 +2304,7 @@ func TestProcessDirectPost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup session if needed
 			if tt.authCtxSetup != nil {
@@ -2393,7 +2393,7 @@ func TestAuthorizationCodeRedirectURI(t *testing.T) {
 
 // TestContainsOIDC tests the containsOIDC helper method
 func TestContainsOIDC(t *testing.T) {
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 
 	tests := []struct {
 		name     string
@@ -2466,7 +2466,7 @@ func TestGetDiscoveryMetadata(t *testing.T) {
 		},
 	}
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(t, cfg)
 
 	// Test getting discovery metadata
 	metadata, err := client.GetDiscoveryMetadata(ctx)
@@ -2538,7 +2538,7 @@ func TestGetDiscoveryMetadata_NoCredentials(t *testing.T) {
 		},
 	}
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(t, cfg)
 
 	metadata, err := client.GetDiscoveryMetadata(ctx)
 	assert.NoError(t, err)
@@ -2597,7 +2597,7 @@ func TestGetDiscoveryMetadata_CustomExternalURL(t *testing.T) {
 				},
 			}
 
-			client, _ := CreateTestClientWithMock(cfg)
+			client, _ := CreateTestClientWithMock(t, cfg)
 
 			metadata, err := client.GetDiscoveryMetadata(ctx)
 			assert.NoError(t, err)
@@ -2628,7 +2628,7 @@ func TestGetJWKS(t *testing.T) {
 	}
 
 	t.Run("RSA key", func(t *testing.T) {
-		client, _ := CreateTestClientWithMock(cfg)
+		client, _ := CreateTestClientWithMock(t, cfg)
 
 		// Set signing key for testing
 		privateKey := generateTestRSAKey(t)
@@ -2652,7 +2652,7 @@ func TestGetJWKS(t *testing.T) {
 	})
 
 	t.Run("ECDSA key", func(t *testing.T) {
-		client, _ := CreateTestClientWithMock(cfg)
+		client, _ := CreateTestClientWithMock(t, cfg)
 
 		// Set ECDSA signing key for testing
 		privateKey := generateTestECDSAKey(t)
@@ -2676,7 +2676,7 @@ func TestGetJWKS(t *testing.T) {
 	})
 
 	t.Run("unsupported key type", func(t *testing.T) {
-		client, _ := CreateTestClientWithMock(cfg)
+		client, _ := CreateTestClientWithMock(t, cfg)
 
 		// Set an unsupported key type (string instead of crypto key)
 		err := client.SetSigningKeyForTesting("not-a-crypto-key")
@@ -2687,7 +2687,7 @@ func TestGetJWKS(t *testing.T) {
 	})
 
 	t.Run("no signing key set", func(t *testing.T) {
-		client, _ := CreateTestClientWithMock(cfg)
+		client, _ := CreateTestClientWithMock(t, cfg)
 
 		// Don't set any signing key - signingKey will be nil
 
@@ -2724,7 +2724,7 @@ func BenchmarkGetDiscoveryMetadata(b *testing.B) {
 		},
 	}
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(b, cfg)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -2747,7 +2747,7 @@ func BenchmarkGetJWKS(b *testing.B) {
 		},
 	}
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(b, cfg)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -2823,7 +2823,7 @@ func TestMatchRedirectURI(t *testing.T) {
 			},
 		},
 	}
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(t, cfg)
 
 	tests := []struct {
 		name       string

--- a/internal/verifier/apiv1/handler_openid4vp.go
+++ b/internal/verifier/apiv1/handler_openid4vp.go
@@ -92,7 +92,12 @@ func (c *Client) CreateRequestObject(ctx context.Context, sessionID string, dcql
 			return "", fmt.Errorf("response_mode %q requires encryption but no ephemeral key cache is configured", responseMode)
 		}
 
-		_, ephemeralPublicJWK, err := c.openid4vp.EphemeralKeyCache.GenerateAndStore(sessionID)
+		// Reuse any key already held for this session. A request object can
+		// be built more than once for the same session - GetOIDCRequestObject
+		// rebuilds and re-signs on every call - and regenerating would
+		// replace the private key under an unchanged kid, stranding a wallet
+		// that still holds an earlier request object.
+		ephemeralPublicJWK, err := c.openid4vp.EphemeralKeyCache.GenerateAndStoreIfAbsent(sessionID)
 		if err != nil {
 			c.log.Error(err, "Failed to generate ephemeral encryption key")
 			return "", fmt.Errorf("generating ephemeral encryption key: %w", err)

--- a/internal/verifier/apiv1/handler_openid4vp.go
+++ b/internal/verifier/apiv1/handler_openid4vp.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/SUNET/vc/pkg/crypto"
 	"github.com/SUNET/vc/pkg/openid4vp"
+	"github.com/lestrrat-go/jwx/v3/jwk"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -72,6 +74,37 @@ func (c *Client) CreateRequestObject(ctx context.Context, sessionID string, dcql
 		requestObject.ClientMetadata = &openid4vp.ClientMetadata{
 			VPFormatsSupported: c.cfg.Verifier.PreferredVPFormats,
 		}
+	}
+
+	// A response mode ending in .jwt asks the wallet to encrypt its response,
+	// which it can only do with a key. This path previously sent neither a
+	// key nor the encryption parameters, so a conformant wallet rejected the
+	// request before it got as far as the credential query.
+	//
+	// The key is stored under the session ID, and VerificationDirectPost
+	// looks the private half up by the kid in the JWE header, so the two
+	// halves meet without extra plumbing.
+	if responseModeRequiresEncryption(responseMode) {
+		if c.openid4vp == nil || c.openid4vp.EphemeralKeyCache == nil {
+			// Better a named error than a nil dereference: response_mode
+			// asks the wallet to encrypt, and without a key cache we cannot
+			// give it anything to encrypt to.
+			return "", fmt.Errorf("response_mode %q requires encryption but no ephemeral key cache is configured", responseMode)
+		}
+
+		_, ephemeralPublicJWK, err := c.openid4vp.EphemeralKeyCache.GenerateAndStore(sessionID)
+		if err != nil {
+			c.log.Error(err, "Failed to generate ephemeral encryption key")
+			return "", fmt.Errorf("generating ephemeral encryption key: %w", err)
+		}
+
+		if requestObject.ClientMetadata == nil {
+			requestObject.ClientMetadata = &openid4vp.ClientMetadata{}
+		}
+		requestObject.ClientMetadata.JWKS = &openid4vp.Keys{Keys: []jwk.Key{ephemeralPublicJWK}}
+		requestObject.ClientMetadata.AuthorizationEncryptedResponseALG = "ECDH-ES"
+		requestObject.ClientMetadata.AuthorizationEncryptedResponseENC = "A256GCM"
+		requestObject.ClientMetadata.EncryptedResponseEncValuesSupported = []string{"A256GCM"}
 	}
 
 	// Sign the request object with X.509 certificate chain for x509_san_dns verification
@@ -204,4 +237,15 @@ type SessionPollResponse struct {
 	AuthorizationCode string `json:"authorization_code,omitempty"`
 	RedirectURI       string `json:"redirect_uri,omitempty"`
 	State             string `json:"state,omitempty"`
+}
+
+// responseModeRequiresEncryption reports whether a response mode obliges the
+// wallet to encrypt its response to us.
+//
+// OpenID4VP spells these as a ".jwt" suffix: dc_api.jwt and direct_post.jwt
+// are the encrypted forms of dc_api and direct_post. Matching on the suffix
+// rather than listing the two keeps a future encrypted mode from silently
+// falling through to the unencrypted branch.
+func responseModeRequiresEncryption(responseMode string) bool {
+	return strings.HasSuffix(responseMode, ".jwt")
 }

--- a/internal/verifier/apiv1/handler_openid4vp_test.go
+++ b/internal/verifier/apiv1/handler_openid4vp_test.go
@@ -1,8 +1,11 @@
 package apiv1
 
 import (
+	"crypto"
+
 	"crypto/rand"
 	"crypto/rsa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
 	"testing"
 	"time"
 
@@ -467,4 +470,54 @@ func newSigningTestClient(t *testing.T) *Client {
 	require.NoError(t, client.SetSigningKeyForTesting(key))
 
 	return client
+}
+
+// TestCreateRequestObject_ReusesTheSessionKey covers a wallet fetching the
+// request object twice. GetOIDCRequestObject rebuilds and re-signs on every
+// call, so regenerating the key would replace the private half under an
+// unchanged kid: a wallet still holding the first request object would
+// encrypt to a public key whose private half no longer exists, and the
+// response would fail to decrypt for no visible reason.
+func TestCreateRequestObject_ReusesTheSessionKey(t *testing.T) {
+	ctx := t.Context()
+	client := newSigningTestClient(t)
+	client.cfg.Verifier.DigitalCredentials.Enable = true
+
+	firstKey := func(t *testing.T, sessionID string) jwk.Key {
+		t.Helper()
+		cached, err := client.GetRequestObject(ctx, sessionID)
+		require.NoError(t, err)
+		require.NotNil(t, cached.ClientMetadata)
+		require.NotNil(t, cached.ClientMetadata.JWKS)
+		require.Len(t, cached.ClientMetadata.JWKS.Keys, 1)
+		return cached.ClientMetadata.JWKS.Keys[0]
+	}
+
+	_, err := client.CreateRequestObject(ctx, "same-session", createTestDCQLForVP(t), "nonce-1", nil)
+	require.NoError(t, err)
+	before := firstKey(t, "same-session")
+
+	// Second fetch of the same session, as a wallet retry or reload would do.
+	_, err = client.CreateRequestObject(ctx, "same-session", createTestDCQLForVP(t), "nonce-2", nil)
+	require.NoError(t, err)
+	after := firstKey(t, "same-session")
+
+	beforeThumb, err := before.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	afterThumb, err := after.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	assert.Equal(t, beforeThumb, afterThumb,
+		"the advertised public key must not change between fetches of the same session")
+
+	// And the private half must still match what is advertised.
+	kid, ok := after.KeyID()
+	require.True(t, ok)
+	priv, found := client.openid4vp.EphemeralKeyCache.Get(kid)
+	require.True(t, found)
+	privPub, err := priv.PublicKey()
+	require.NoError(t, err)
+	privThumb, err := privPub.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	assert.Equal(t, afterThumb, privThumb,
+		"the cached private key must be the pair of the advertised public key")
 }

--- a/internal/verifier/apiv1/handler_openid4vp_test.go
+++ b/internal/verifier/apiv1/handler_openid4vp_test.go
@@ -2,16 +2,15 @@ package apiv1
 
 import (
 	"crypto"
-
 	"crypto/rand"
 	"crypto/rsa"
-	"github.com/lestrrat-go/jwx/v3/jwk"
 	"testing"
 	"time"
 
 	"github.com/SUNET/vc/pkg/cache"
 	"github.com/SUNET/vc/pkg/openid4vp"
 
+	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/verifier/apiv1/handler_openid4vp_test.go
+++ b/internal/verifier/apiv1/handler_openid4vp_test.go
@@ -71,12 +71,7 @@ func TestCreateRequestObject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(t, nil)
-
-			// Generate RSA key for signing
-			key, err := rsa.GenerateKey(rand.Reader, 2048)
-			require.NoError(t, err)
-			require.NoError(t, client.SetSigningKeyForTesting(key))
+			client := newSigningTestClient(t)
 
 			// Configure Digital Credentials API
 			client.cfg.Verifier.DigitalCredentials.Enable = tt.dcEnabled
@@ -410,15 +405,11 @@ func createTestDBSession(sessionID string) *cache.AuthorizationContext {
 // reading the credential query.
 func TestCreateRequestObject_EncryptedModeCarriesAKey(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(t, nil)
-
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	require.NoError(t, client.SetSigningKeyForTesting(key))
+	client := newSigningTestClient(t)
 
 	client.cfg.Verifier.DigitalCredentials.Enable = true // response_mode defaults to dc_api.jwt
 
-	_, err = client.CreateRequestObject(ctx, "session-enc", createTestDCQLForVP(t), "nonce-enc", nil)
+	_, err := client.CreateRequestObject(ctx, "session-enc", createTestDCQLForVP(t), "nonce-enc", nil)
 	require.NoError(t, err)
 
 	cached, err := client.GetRequestObject(ctx, "session-enc")
@@ -447,15 +438,11 @@ func TestCreateRequestObject_EncryptedModeCarriesAKey(t *testing.T) {
 // there is no reason to mint or advertise a key.
 func TestCreateRequestObject_UnencryptedModeSendsNoKey(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(t, nil)
-
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	require.NoError(t, client.SetSigningKeyForTesting(key))
+	client := newSigningTestClient(t)
 
 	client.cfg.Verifier.DigitalCredentials.Enable = false
 
-	_, err = client.CreateRequestObject(ctx, "session-plain", createTestDCQLForVP(t), "nonce-plain", nil)
+	_, err := client.CreateRequestObject(ctx, "session-plain", createTestDCQLForVP(t), "nonce-plain", nil)
 	require.NoError(t, err)
 
 	cached, err := client.GetRequestObject(ctx, "session-plain")
@@ -465,4 +452,19 @@ func TestCreateRequestObject_UnencryptedModeSendsNoKey(t *testing.T) {
 		assert.Nil(t, cached.ClientMetadata.JWKS)
 		assert.Empty(t, cached.ClientMetadata.EncryptedResponseEncValuesSupported)
 	}
+}
+
+// newSigningTestClient returns a mock-backed client with a signing key
+// installed, which every CreateRequestObject test needs before it can sign a
+// request object.
+func newSigningTestClient(t *testing.T) *Client {
+	t.Helper()
+
+	client, _ := CreateTestClientWithMock(t, nil)
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	require.NoError(t, client.SetSigningKeyForTesting(key))
+
+	return client
 }

--- a/internal/verifier/apiv1/handler_openid4vp_test.go
+++ b/internal/verifier/apiv1/handler_openid4vp_test.go
@@ -401,3 +401,68 @@ func createTestDBSession(sessionID string) *cache.AuthorizationContext {
 
 	return authCtx
 }
+
+// TestCreateRequestObject_EncryptedModeCarriesAKey covers what an external
+// wallet actually validates. A response_mode ending in .jwt asks the wallet
+// to encrypt its response; this path previously sent client_metadata with
+// only vp_formats_supported, so there was no key to encrypt to and no
+// encryption parameters, and a conformant wallet rejected the request before
+// reading the credential query.
+func TestCreateRequestObject_EncryptedModeCarriesAKey(t *testing.T) {
+	ctx := t.Context()
+	client, _ := CreateTestClientWithMock(nil)
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	require.NoError(t, client.SetSigningKeyForTesting(key))
+
+	client.cfg.Verifier.DigitalCredentials.Enable = true // response_mode defaults to dc_api.jwt
+
+	_, err = client.CreateRequestObject(ctx, "session-enc", createTestDCQLForVP(t), "nonce-enc", nil)
+	require.NoError(t, err)
+
+	cached, err := client.GetRequestObject(ctx, "session-enc")
+	require.NoError(t, err)
+	require.NotNil(t, cached.ClientMetadata, "client_metadata is required for an encrypted response mode")
+
+	md := cached.ClientMetadata
+	require.NotNil(t, md.JWKS, "the wallet needs a key to encrypt to")
+	require.Len(t, md.JWKS.Keys, 1)
+
+	assert.Equal(t, []string{"A256GCM"}, md.EncryptedResponseEncValuesSupported,
+		"OpenID4VP 1.0 expects an array under this name")
+	assert.Equal(t, "ECDH-ES", md.AuthorizationEncryptedResponseALG)
+	assert.Equal(t, "A256GCM", md.AuthorizationEncryptedResponseENC)
+
+	// The private half must be findable by the advertised kid, or the wallet
+	// encrypts to a key we cannot decrypt with.
+	kid, ok := md.JWKS.Keys[0].KeyID()
+	require.True(t, ok)
+	_, found := client.openid4vp.EphemeralKeyCache.Get(kid)
+	assert.True(t, found, "the ephemeral private key must be retrievable by the advertised kid")
+}
+
+// TestCreateRequestObject_UnencryptedModeSendsNoKey is the other side: with
+// DC API off the response mode is direct_post, which is not encrypted, so
+// there is no reason to mint or advertise a key.
+func TestCreateRequestObject_UnencryptedModeSendsNoKey(t *testing.T) {
+	ctx := t.Context()
+	client, _ := CreateTestClientWithMock(nil)
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	require.NoError(t, client.SetSigningKeyForTesting(key))
+
+	client.cfg.Verifier.DigitalCredentials.Enable = false
+
+	_, err = client.CreateRequestObject(ctx, "session-plain", createTestDCQLForVP(t), "nonce-plain", nil)
+	require.NoError(t, err)
+
+	cached, err := client.GetRequestObject(ctx, "session-plain")
+	require.NoError(t, err)
+	assert.Equal(t, "direct_post", cached.ResponseMode)
+	if cached.ClientMetadata != nil {
+		assert.Nil(t, cached.ClientMetadata.JWKS)
+		assert.Empty(t, cached.ClientMetadata.EncryptedResponseEncValuesSupported)
+	}
+}

--- a/internal/verifier/apiv1/handler_openid4vp_test.go
+++ b/internal/verifier/apiv1/handler_openid4vp_test.go
@@ -71,7 +71,7 @@ func TestCreateRequestObject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Generate RSA key for signing
 			key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -147,7 +147,7 @@ func TestGetRequestObject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup cache if needed
 			if tt.setupCache {
@@ -217,7 +217,7 @@ func TestHandleDirectPost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup session if needed
 			if tt.authCtxSetup != nil {
@@ -287,7 +287,7 @@ func TestGetPollStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup session if needed
 			if tt.authCtxSetup != nil {
@@ -369,7 +369,7 @@ func TestExtractAndMapClaimsEmpty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Test with nil claims extractor (which is the default for test client)
 			claims, err := client.extractAndMapClaims(ctx, tt.vpToken, "")
@@ -410,7 +410,7 @@ func createTestDBSession(sessionID string) *cache.AuthorizationContext {
 // reading the credential query.
 func TestCreateRequestObject_EncryptedModeCarriesAKey(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
@@ -447,7 +447,7 @@ func TestCreateRequestObject_EncryptedModeCarriesAKey(t *testing.T) {
 // there is no reason to mint or advertise a key.
 func TestCreateRequestObject_UnencryptedModeSendsNoKey(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)

--- a/internal/verifier/apiv1/handler_session_preference_test.go
+++ b/internal/verifier/apiv1/handler_session_preference_test.go
@@ -47,7 +47,7 @@ func TestUpdateSessionPreference(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup session if needed
 			if tt.sessionExists {
@@ -81,7 +81,7 @@ func TestUpdateSessionPreference(t *testing.T) {
 
 func TestUpdateSessionPreference_WalletFollowsRedirect(t *testing.T) {
 	ctx := t.Context()
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 
 	authCtx := createTestDBSessionForPrefs("session-wallet-redirect")
 	authCtx.ShowCredentialDetails = true
@@ -171,7 +171,7 @@ func TestConfirmCredentialDisplay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup session if needed
 			if tt.authCtxSetup != nil {
@@ -262,7 +262,7 @@ func TestGetCredentialDisplayData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup session if needed
 			if tt.authCtxSetup != nil {

--- a/internal/verifier/apiv1/handler_session_preference_test.go
+++ b/internal/verifier/apiv1/handler_session_preference_test.go
@@ -331,11 +331,11 @@ func TestFlattenClaimsForDisplay(t *testing.T) {
 			name: "flat claims unchanged",
 			input: map[string]any{
 				"given_name": "Helen",
-				"birthdate": "1996-01-30",
+				"birthdate":  "1996-01-30",
 			},
 			expect: map[string]any{
 				"given_name": "Helen",
-				"birthdate": "1996-01-30",
+				"birthdate":  "1996-01-30",
 			},
 		},
 		{
@@ -352,7 +352,7 @@ func TestFlattenClaimsForDisplay(t *testing.T) {
 				},
 			},
 			expect: map[string]any{
-				"given_name":             "Helen",
+				"given_name":              "Helen",
 				"place_of_birth.locality": "Stockholm",
 				"place_of_birth.country":  "SE",
 				"address.street_address":  "Tulegatan",

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -399,6 +399,11 @@ func (c *Client) UIInteraction(ctx context.Context, req *UIInteractionRequest) (
 			AuthorizationSignedResponseALG:    "",
 			AuthorizationEncryptedResponseALG: "ECDH-ES",
 			AuthorizationEncryptedResponseENC: "A256GCM",
+			// OpenID4VP 1.0 renamed authorization_encrypted_response_enc to
+			// encrypted_response_enc_values_supported and made it an array.
+			// Both are sent: a 1.0 wallet rejects a request carrying only the
+			// old name, and a draft-era wallet ignores the new one.
+			EncryptedResponseEncValuesSupported: []string{"A256GCM"},
 		},
 		IAT:              time.Now().UTC().Unix(),
 		RedirectURI:      "",

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -83,7 +83,7 @@ func TestUIMetadata(t *testing.T) {
 				},
 			}
 
-			client, _ := CreateTestClientWithMock(cfg)
+			client, _ := CreateTestClientWithMock(t, cfg)
 			// Override cfg with our test config
 			client.cfg = cfg
 
@@ -147,7 +147,7 @@ func TestUIMetadata_MsoMdocScope(t *testing.T) {
 		Verifier: &model.Verifier{},
 	}
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(t, cfg)
 	client.cfg = cfg
 
 	reply, err := client.UIMetadata(ctx)
@@ -230,7 +230,7 @@ func TestUIMetadataPresetValidationsPerScope(t *testing.T) {
 		},
 	}
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(t, cfg)
 	client.cfg = cfg
 
 	reply, err := client.UIMetadata(ctx)
@@ -342,7 +342,7 @@ func TestUIMetadataPresetFormatFromMetadata(t *testing.T) {
 		},
 	}
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(t, cfg)
 	client.cfg = cfg
 
 	reply, err := client.UIMetadata(ctx)
@@ -377,7 +377,7 @@ func TestUIMetadataCredentialFormatFromMetadata(t *testing.T) {
 		Verifier: &model.Verifier{},
 	}
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(t, cfg)
 	client.cfg = cfg
 
 	reply, err := client.UIMetadata(ctx)
@@ -499,7 +499,7 @@ func TestAugmentDCQLFromVCTM_ArraySelectiveDisclosure(t *testing.T) {
 				Verifier: &model.Verifier{},
 			}
 
-			client, _ := CreateTestClientWithMock(cfg)
+			client, _ := CreateTestClientWithMock(t, cfg)
 			client.cfg = cfg
 
 			dcql := &openid4vp.DCQL{
@@ -870,7 +870,7 @@ func TestAugmentDCQLFromVCTM_ComplexCredential(t *testing.T) {
 				Verifier: &model.Verifier{},
 			}
 
-			client, _ := CreateTestClientWithMock(cfg)
+			client, _ := CreateTestClientWithMock(t, cfg)
 			client.cfg = cfg
 
 			dcql := &openid4vp.DCQL{
@@ -1012,7 +1012,7 @@ func TestUIMetadataOffersBothVCTIdentifiers(t *testing.T) {
 		cfg.Common.CredentialMetadata["novct"].GetVCTM().VCT,
 		"precondition: ResolveVCTUrls should have back-filled the empty vct from the URL")
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(t, cfg)
 	client.cfg = cfg
 
 	reply, err := client.UIMetadata(ctx)
@@ -1104,7 +1104,7 @@ func TestUIMetadataPresetMsoMdocUsesDoctypeValue(t *testing.T) {
 		},
 	}
 
-	client, _ := CreateTestClientWithMock(cfg)
+	client, _ := CreateTestClientWithMock(t, cfg)
 	client.cfg = cfg
 
 	reply, err := client.UIMetadata(ctx)

--- a/internal/verifier/apiv1/handlers_verification_test.go
+++ b/internal/verifier/apiv1/handlers_verification_test.go
@@ -547,5 +547,3 @@ func ecCoordinates(t *testing.T, pub *ecdsa.PublicKey) (x, y []byte) {
 	require.Equal(t, 65, len(raw), "unexpected uncompressed P-256 point length")
 	return raw[1:33], raw[33:65]
 }
-
-

--- a/internal/verifier/apiv1/handlers_verification_test.go
+++ b/internal/verifier/apiv1/handlers_verification_test.go
@@ -155,7 +155,7 @@ func TestVerificationCallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Setup credential cache if needed
 			if tt.setupCache {
@@ -305,7 +305,7 @@ func TestVerificationDirectPost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := CreateTestClientWithMock(nil)
+			client, _ := CreateTestClientWithMock(t, nil)
 
 			// Set up notify service
 			log := logger.NewSimple("test")
@@ -395,7 +395,7 @@ func TestVerificationDirectPostDecoyDisclosure(t *testing.T) {
 	sigKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
-	client, _ := CreateTestClientWithMock(nil)
+	client, _ := CreateTestClientWithMock(t, nil)
 	log := logger.NewSimple("test")
 	notifyService, _ := notify.New(ctx, client.cfg, log)
 	client.notify = notifyService

--- a/internal/verifier/apiv1/mock_db_test.go
+++ b/internal/verifier/apiv1/mock_db_test.go
@@ -119,9 +119,11 @@ func (m *MockDBService) ToDBService() *db.Service {
 // when the test finishes; it starts a background expiry goroutine that would
 // otherwise outlive every test in the suite.
 //
-// Note the four cache.NewTestMemory* caches below start goroutines too, and
-// are not stopped here: pkg/cache's MemoryCache exposes no Stop method, so
-// cleaning those up needs an API change rather than a test-only one.
+// The cache.NewTestMemory* caches below start goroutines too. MemoryCache
+// has a Stop method, but cache.Service types those fields as the Cache
+// interface, which does not include it - so they are stopped through a type
+// assertion. AuthContext is backed by MemoryStore, which has no Stop at all,
+// and is the one goroutine left running.
 func CreateTestClientWithMock(t testing.TB, cfg *model.Cfg) (*Client, *MockDBService) {
 	ctx := context.TODO()
 
@@ -174,6 +176,19 @@ func CreateTestClientWithMock(t testing.TB, cfg *model.Cfg) (*Client, *MockDBSer
 	}
 
 	t.Cleanup(client.openid4vp.Close)
+
+	// Stop the memory caches that can be stopped. The Cache interface omits
+	// Stop, so this asserts for it rather than widening the interface for a
+	// test-only need.
+	for _, c := range []any{
+		client.cacheService.Credential,
+		client.cacheService.EphemeralEncryptionKey,
+		client.cacheService.RequestObject,
+	} {
+		if stoppable, ok := c.(interface{ Stop() }); ok {
+			t.Cleanup(stoppable.Stop)
+		}
+	}
 
 	return client, mockDB
 }

--- a/internal/verifier/apiv1/mock_db_test.go
+++ b/internal/verifier/apiv1/mock_db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/SUNET/vc/internal/verifier/cache"
@@ -112,7 +113,16 @@ func (m *MockDBService) ToDBService() *db.Service {
 }
 
 // CreateTestClientWithMock creates a test Client with a mock database for testing handlers
-func CreateTestClientWithMock(cfg *model.Cfg) (*Client, *MockDBService) {
+// CreateTestClientWithMock builds a Client wired to mock dependencies.
+//
+// t is taken so the openid4vp client's ephemeral key cache can be stopped
+// when the test finishes; it starts a background expiry goroutine that would
+// otherwise outlive every test in the suite.
+//
+// Note the four cache.NewTestMemory* caches below start goroutines too, and
+// are not stopped here: pkg/cache's MemoryCache exposes no Stop method, so
+// cleaning those up needs an API change rather than a test-only one.
+func CreateTestClientWithMock(t testing.TB, cfg *model.Cfg) (*Client, *MockDBService) {
 	ctx := context.TODO()
 
 	if cfg == nil {
@@ -162,6 +172,8 @@ func CreateTestClientWithMock(cfg *model.Cfg) (*Client, *MockDBService) {
 			EphemeralKeyCache: openid4vp.NewEphemeralEncryptionKeyCache(10 * time.Minute),
 		},
 	}
+
+	t.Cleanup(client.openid4vp.Close)
 
 	return client, mockDB
 }

--- a/internal/verifier/apiv1/mock_db_test.go
+++ b/internal/verifier/apiv1/mock_db_test.go
@@ -155,6 +155,12 @@ func CreateTestClientWithMock(cfg *model.Cfg) (*Client, *MockDBService) {
 			Credential:             cache.NewTestMemoryCache[[]sdjwtvc.CredentialCache](5 * time.Minute),
 		},
 		jwksResolver: trust.NewJWKSKeyResolver(trust.JWKSResolverConfig{}),
+		// Production wires this in New(); without it any path that needs an
+		// ephemeral encryption key - such as an encrypted response_mode -
+		// has nothing to generate one from.
+		openid4vp: &openid4vp.Client{
+			EphemeralKeyCache: openid4vp.NewEphemeralEncryptionKeyCache(10 * time.Minute),
+		},
 	}
 
 	return client, mockDB

--- a/pkg/openid4vp/client_metadata_encryption_test.go
+++ b/pkg/openid4vp/client_metadata_encryption_test.go
@@ -1,0 +1,79 @@
+package openid4vp
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEphemeralPublicJWK_CarriesEveryRequiredMember pins the members a wallet
+// checks for. The key previously carried kty, crv, x and y but not alg, and
+// wallets reject the whole request object over the one missing member.
+func TestEphemeralPublicJWK_CarriesEveryRequiredMember(t *testing.T) {
+	cache := NewEphemeralEncryptionKeyCache(5 * time.Minute)
+	_, pub, err := cache.GenerateAndStore("kid-1")
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(pub)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	for _, member := range []string{"kty", "crv", "x", "y", "alg"} {
+		assert.Contains(t, got, member, "wallets require %q in each client_metadata JWK", member)
+		assert.NotEmpty(t, got[member], "%q must not be empty", member)
+	}
+
+	assert.Equal(t, "ECDH-ES", got["alg"], "alg names the key-agreement algorithm for this key")
+	assert.Equal(t, "EC", got["kty"])
+	assert.Equal(t, "P-256", got["crv"])
+	assert.Equal(t, "enc", got["use"])
+	assert.Equal(t, "kid-1", got["kid"])
+}
+
+// TestEphemeralKeyRoundTrip guards the property the DC API change depends on:
+// the private half must be retrievable by the kid advertised in the public
+// half, or the wallet encrypts to a key we cannot find.
+func TestEphemeralKeyRoundTrip(t *testing.T) {
+	cache := NewEphemeralEncryptionKeyCache(5 * time.Minute)
+	priv, pub, err := cache.GenerateAndStore("session-42")
+	require.NoError(t, err)
+
+	kid, ok := pub.KeyID()
+	require.True(t, ok)
+	assert.Equal(t, "session-42", kid)
+
+	found, ok := cache.Get(kid)
+	require.True(t, ok, "the private key must be retrievable by the advertised kid")
+	assert.Equal(t, priv, found)
+}
+
+// TestClientMetadata_EncryptedResponseEncValuesSupportedIsAnArray pins the
+// wire shape. OpenID4VP 1.0 replaced the single-string
+// authorization_encrypted_response_enc with an array under a new name, and a
+// 1.0 wallet rejects client_metadata carrying only the old spelling.
+func TestClientMetadata_EncryptedResponseEncValuesSupportedIsAnArray(t *testing.T) {
+	md := &ClientMetadata{
+		AuthorizationEncryptedResponseALG:   "ECDH-ES",
+		AuthorizationEncryptedResponseENC:   "A256GCM",
+		EncryptedResponseEncValuesSupported: []string{"A256GCM"},
+	}
+
+	raw, err := json.Marshal(md)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	values, ok := got["encrypted_response_enc_values_supported"].([]any)
+	require.True(t, ok, "must serialise as an array of strings, not a string")
+	assert.Equal(t, []any{"A256GCM"}, values)
+
+	// The draft-era spellings stay so wallets that predate 1.0 keep working.
+	assert.Equal(t, "A256GCM", got["authorization_encrypted_response_enc"])
+	assert.Equal(t, "ECDH-ES", got["authorization_encrypted_response_alg"])
+}

--- a/pkg/openid4vp/client_metadata_encryption_test.go
+++ b/pkg/openid4vp/client_metadata_encryption_test.go
@@ -14,6 +14,7 @@ import (
 // wallets reject the whole request object over the one missing member.
 func TestEphemeralPublicJWK_CarriesEveryRequiredMember(t *testing.T) {
 	cache := NewEphemeralEncryptionKeyCache(5 * time.Minute)
+	t.Cleanup(cache.Stop)
 	_, pub, err := cache.GenerateAndStore("kid-1")
 	require.NoError(t, err)
 
@@ -40,6 +41,7 @@ func TestEphemeralPublicJWK_CarriesEveryRequiredMember(t *testing.T) {
 // half, or the wallet encrypts to a key we cannot find.
 func TestEphemeralKeyRoundTrip(t *testing.T) {
 	cache := NewEphemeralEncryptionKeyCache(5 * time.Minute)
+	t.Cleanup(cache.Stop)
 	priv, pub, err := cache.GenerateAndStore("session-42")
 	require.NoError(t, err)
 

--- a/pkg/openid4vp/client_metadata_encryption_test.go
+++ b/pkg/openid4vp/client_metadata_encryption_test.go
@@ -1,7 +1,9 @@
 package openid4vp
 
 import (
+	"crypto"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -78,4 +80,56 @@ func TestClientMetadata_EncryptedResponseEncValuesSupportedIsAnArray(t *testing.
 	// The draft-era spellings stay so wallets that predate 1.0 keep working.
 	assert.Equal(t, "A256GCM", got["authorization_encrypted_response_enc"])
 	assert.Equal(t, "ECDH-ES", got["authorization_encrypted_response_alg"])
+}
+
+// TestGenerateAndStoreIfAbsent_Concurrent covers the check-then-act race.
+// Two request objects for one session can be built at the same time - a
+// wallet retry, a reload, two tabs. If both callers generated, the second
+// store would win and the first caller would already have returned a public
+// key whose private half was gone: the wallet encrypts, and we cannot
+// decrypt.
+func TestGenerateAndStoreIfAbsent_Concurrent(t *testing.T) {
+	cache := NewEphemeralEncryptionKeyCache(5 * time.Minute)
+	t.Cleanup(cache.Stop)
+
+	const callers = 32
+	var wg sync.WaitGroup
+	thumbs := make([][]byte, callers)
+	errs := make([]error, callers)
+
+	start := make(chan struct{})
+	for i := range callers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // maximise the overlap
+			pub, err := cache.GenerateAndStoreIfAbsent("one-session")
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			thumbs[i], errs[i] = pub.Thumbprint(crypto.SHA256)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "caller %d", i)
+	}
+
+	// Every caller must have been handed the same key.
+	for i := 1; i < callers; i++ {
+		assert.Equal(t, thumbs[0], thumbs[i], "caller %d got a different public key", i)
+	}
+
+	// And it must be the pair of the one private key left in the cache.
+	priv, found := cache.Get("one-session")
+	require.True(t, found)
+	privPub, err := priv.PublicKey()
+	require.NoError(t, err)
+	privThumb, err := privPub.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	assert.Equal(t, thumbs[0], privThumb,
+		"the advertised key must be the pair of the cached private key")
 }

--- a/pkg/openid4vp/combined_binding_test.go
+++ b/pkg/openid4vp/combined_binding_test.go
@@ -14,8 +14,8 @@ import (
 func TestCombinedBindingVerifier_SingleCredential(t *testing.T) {
 	v := &CombinedBindingVerifier{
 		Config: CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      BindingEnforcementEnforce,
+			Enabled:           true,
+			Enforcement:       BindingEnforcementEnforce,
 			KeyBindingEnabled: true,
 		},
 	}
@@ -31,8 +31,8 @@ func TestCombinedBindingVerifier_SingleCredential(t *testing.T) {
 func TestCombinedBindingVerifier_EmptyCredentials(t *testing.T) {
 	v := &CombinedBindingVerifier{
 		Config: CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      BindingEnforcementEnforce,
+			Enabled:           true,
+			Enforcement:       BindingEnforcementEnforce,
 			KeyBindingEnabled: true,
 		},
 	}
@@ -45,8 +45,8 @@ func TestCombinedBindingVerifier_EmptyCredentials(t *testing.T) {
 func TestCombinedBindingVerifier_KeyBinding_SameKey(t *testing.T) {
 	v := &CombinedBindingVerifier{
 		Config: CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      BindingEnforcementEnforce,
+			Enabled:           true,
+			Enforcement:       BindingEnforcementEnforce,
 			KeyBindingEnabled: true,
 		},
 	}
@@ -73,8 +73,8 @@ func TestCombinedBindingVerifier_KeyBinding_SameKey(t *testing.T) {
 func TestCombinedBindingVerifier_KeyBinding_DifferentKeys(t *testing.T) {
 	v := &CombinedBindingVerifier{
 		Config: CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      BindingEnforcementEnforce,
+			Enabled:           true,
+			Enforcement:       BindingEnforcementEnforce,
 			KeyBindingEnabled: true,
 		},
 	}
@@ -97,8 +97,8 @@ func TestCombinedBindingVerifier_KeyBinding_DifferentKeys(t *testing.T) {
 func TestCombinedBindingVerifier_KeyBinding_DifferentKeys_WarnMode(t *testing.T) {
 	v := &CombinedBindingVerifier{
 		Config: CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      BindingEnforcementWarn,
+			Enabled:           true,
+			Enforcement:       BindingEnforcementWarn,
 			KeyBindingEnabled: true,
 		},
 	}
@@ -253,8 +253,8 @@ func TestCombinedBindingVerifier_NestedAttributePath(t *testing.T) {
 func TestCombinedBindingVerifier_KeyAndAttributeBinding(t *testing.T) {
 	v := &CombinedBindingVerifier{
 		Config: CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      BindingEnforcementEnforce,
+			Enabled:           true,
+			Enforcement:       BindingEnforcementEnforce,
 			KeyBindingEnabled: true,
 			BindingAttributes: []BindingAttributeConfig{
 				{Paths: []string{"sub"}},
@@ -277,8 +277,8 @@ func TestCombinedBindingVerifier_KeyAndAttributeBinding(t *testing.T) {
 func TestCombinedBindingVerifier_InsufficientKeyMaterial(t *testing.T) {
 	v := &CombinedBindingVerifier{
 		Config: CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      BindingEnforcementEnforce,
+			Enabled:           true,
+			Enforcement:       BindingEnforcementEnforce,
 			KeyBindingEnabled: true,
 			BindingAttributes: []BindingAttributeConfig{
 				{Paths: []string{"sub"}},
@@ -304,8 +304,8 @@ func TestCombinedBindingVerifier_InsufficientKeyMaterial(t *testing.T) {
 func TestCombinedBindingVerifier_ThreeCredentials_SameKey(t *testing.T) {
 	v := &CombinedBindingVerifier{
 		Config: CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      BindingEnforcementEnforce,
+			Enabled:           true,
+			Enforcement:       BindingEnforcementEnforce,
 			KeyBindingEnabled: true,
 		},
 	}
@@ -331,8 +331,8 @@ func TestCombinedBindingVerifier_ThreeCredentials_MixedBinding(t *testing.T) {
 	t.Run("key_mismatch_attribute_match", func(t *testing.T) {
 		v := &CombinedBindingVerifier{
 			Config: CombinedPresentationConfig{
-				Enabled:          true,
-				Enforcement:      BindingEnforcementEnforce,
+				Enabled:           true,
+				Enforcement:       BindingEnforcementEnforce,
 				KeyBindingEnabled: true,
 				BindingAttributes: []BindingAttributeConfig{
 					{Paths: []string{"sub", "family_name"}},
@@ -359,8 +359,8 @@ func TestCombinedBindingVerifier_ThreeCredentials_MixedBinding(t *testing.T) {
 	t.Run("key_mismatch_attribute_match_warn_mode", func(t *testing.T) {
 		v := &CombinedBindingVerifier{
 			Config: CombinedPresentationConfig{
-				Enabled:          true,
-				Enforcement:      BindingEnforcementWarn,
+				Enabled:           true,
+				Enforcement:       BindingEnforcementWarn,
 				KeyBindingEnabled: true,
 				BindingAttributes: []BindingAttributeConfig{
 					{Paths: []string{"sub"}},
@@ -388,8 +388,8 @@ func TestCombinedBindingVerifier_ThreeCredentials_MixedBinding(t *testing.T) {
 		// Cred 1+2 share key, cred 3 has no key and different sub
 		v := &CombinedBindingVerifier{
 			Config: CombinedPresentationConfig{
-				Enabled:          true,
-				Enforcement:      BindingEnforcementEnforce,
+				Enabled:           true,
+				Enforcement:       BindingEnforcementEnforce,
 				KeyBindingEnabled: true,
 				BindingAttributes: []BindingAttributeConfig{
 					{Paths: []string{"sub"}},

--- a/pkg/openid4vp/dcql_test.go
+++ b/pkg/openid4vp/dcql_test.go
@@ -467,8 +467,8 @@ func TestValidateClaimValues_FloatBounds(t *testing.T) {
 	overflowFloat64 := math.Nextafter(float64(math.MaxInt64), math.MaxFloat64)
 	underflowFloat64 := math.Nextafter(float64(math.MinInt64), -math.MaxFloat64)
 	// Just outside the JSON-safe integer range.
-	aboveSafeInt := float64(1<<53) // 2^53 is representable but 2^53+1 is not; anything > 2^53-1 is unsafe.
-	belowSafeInt := -float64(1<<53)
+	aboveSafeInt := float64(1 << 53) // 2^53 is representable but 2^53+1 is not; anything > 2^53-1 is unsafe.
+	belowSafeInt := -float64(1 << 53)
 
 	tts := []struct {
 		name    string

--- a/pkg/openid4vp/encryption_key_cache.go
+++ b/pkg/openid4vp/encryption_key_cache.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -19,6 +20,15 @@ const (
 // EphemeralEncryptionKeyCache manages short-lived encryption keys for response encryption
 type EphemeralEncryptionKeyCache struct {
 	cache *ttlcache.Cache[string, jwk.Key]
+
+	// generate serialises GenerateAndStoreIfAbsent. Without it the
+	// check-then-act there races: two callers for the same kid both miss,
+	// both generate, and the second store wins - so the first caller has
+	// already returned a public key whose private half is gone.
+	//
+	// One mutex rather than one per kid: generating a P-256 key takes
+	// microseconds, so the contention is not worth the bookkeeping.
+	generate sync.Mutex
 }
 
 // NewEphemeralEncryptionKeyCache creates and starts a new ephemeral encryption key cache
@@ -79,7 +89,15 @@ func (e *EphemeralEncryptionKeyCache) Len() int {
 // an unchanged kid, so a wallet still holding an earlier request object
 // would encrypt to a public key whose private half no longer exists, and
 // the response would fail to decrypt with no obvious cause.
+//
+// Safe for concurrent use for the same kid: the lookup and the generate are
+// serialised, so every caller receives the same public key.
 func (e *EphemeralEncryptionKeyCache) GenerateAndStoreIfAbsent(kid string) (jwk.Key, error) {
+	// Held across the lookup and the generate, so a concurrent caller for
+	// the same kid waits and then finds the key rather than replacing it.
+	e.generate.Lock()
+	defer e.generate.Unlock()
+
 	if existing, found := e.Get(kid); found {
 		publicKey, err := existing.PublicKey()
 		if err != nil {

--- a/pkg/openid4vp/encryption_key_cache.go
+++ b/pkg/openid4vp/encryption_key_cache.go
@@ -3,6 +3,7 @@ package openid4vp
 import (
 	"crypto/ecdh"
 	"crypto/rand"
+	"fmt"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -71,6 +72,46 @@ func (e *EphemeralEncryptionKeyCache) Len() int {
 
 // GenerateAndStore generates a new ephemeral encryption key pair, stores the private key in the cache,
 // and returns both private and public JWKs. The key uses ECDH P-256.
+// GenerateAndStoreIfAbsent returns the public half of the key stored under
+// kid, generating and storing a new pair only when there is none.
+//
+// Reuse matters because a request object can be produced more than once for
+// the same session - GetOIDCRequestObject rebuilds and re-signs on every
+// call. Generating afresh each time would overwrite the private key under
+// an unchanged kid, so a wallet still holding an earlier request object
+// would encrypt to a public key whose private half no longer exists, and
+// the response would fail to decrypt with no obvious cause.
+func (e *EphemeralEncryptionKeyCache) GenerateAndStoreIfAbsent(kid string) (jwk.Key, error) {
+	if existing, found := e.Get(kid); found {
+		publicKey, err := existing.PublicKey()
+		if err != nil {
+			return nil, fmt.Errorf("deriving public key for kid %q: %w", kid, err)
+		}
+		// PublicKey copies the key material but not every parameter, so the
+		// members a wallet requires are restored here rather than assumed.
+		if err := decorateEncryptionKey(publicKey, kid); err != nil {
+			return nil, err
+		}
+		return publicKey, nil
+	}
+
+	_, publicKey, err := e.GenerateAndStore(kid)
+	return publicKey, err
+}
+
+// decorateEncryptionKey sets the parameters a wallet requires on a public
+// encryption key: the key ID it is advertised under, its use, and the
+// key-agreement algorithm to use with it.
+func decorateEncryptionKey(key jwk.Key, kid string) error {
+	if err := key.Set(jwk.KeyUsageKey, "enc"); err != nil {
+		return err
+	}
+	if err := key.Set(jwk.AlgorithmKey, jwa.ECDH_ES()); err != nil {
+		return err
+	}
+	return key.Set(jwk.KeyIDKey, kid)
+}
+
 func (e *EphemeralEncryptionKeyCache) GenerateAndStore(kid string) (privateKey jwk.Key, publicKey jwk.Key, err error) {
 	// Generate ECDH P-256 key pair
 	privKey, err := ecdh.P256().GenerateKey(rand.Reader)
@@ -99,19 +140,10 @@ func (e *EphemeralEncryptionKeyCache) GenerateAndStore(kid string) (privateKey j
 		return nil, nil, err
 	}
 
-	if err := publicJWK.Set(jwk.KeyUsageKey, "enc"); err != nil {
-		return nil, nil, err
-	}
-
-	// alg names the key-agreement algorithm the wallet should use with this
-	// key. Wallets reject a JWK without it - OpenID4VP requires each key in
-	// client_metadata.jwks to carry kty, crv, x, y and alg, and this key
-	// previously carried every member except alg.
-	if err := publicJWK.Set(jwk.AlgorithmKey, jwa.ECDH_ES()); err != nil {
-		return nil, nil, err
-	}
-
-	if err := publicJWK.Set(jwk.KeyIDKey, kid); err != nil {
+	// Sets use, alg and kid. alg in particular is required: OpenID4VP wants
+	// each key in client_metadata.jwks to carry kty, crv, x, y and alg, and
+	// this key previously carried every member except alg.
+	if err := decorateEncryptionKey(publicJWK, kid); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/openid4vp/encryption_key_cache.go
+++ b/pkg/openid4vp/encryption_key_cache.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 )
 
@@ -99,6 +100,14 @@ func (e *EphemeralEncryptionKeyCache) GenerateAndStore(kid string) (privateKey j
 	}
 
 	if err := publicJWK.Set(jwk.KeyUsageKey, "enc"); err != nil {
+		return nil, nil, err
+	}
+
+	// alg names the key-agreement algorithm the wallet should use with this
+	// key. Wallets reject a JWK without it - OpenID4VP requires each key in
+	// client_metadata.jwks to carry kty, crv, x, y and alg, and this key
+	// previously carried every member except alg.
+	if err := publicJWK.Set(jwk.AlgorithmKey, jwa.ECDH_ES()); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/openid4vp/encryption_key_cache.go
+++ b/pkg/openid4vp/encryption_key_cache.go
@@ -70,8 +70,6 @@ func (e *EphemeralEncryptionKeyCache) Len() int {
 	return e.cache.Len()
 }
 
-// GenerateAndStore generates a new ephemeral encryption key pair, stores the private key in the cache,
-// and returns both private and public JWKs. The key uses ECDH P-256.
 // GenerateAndStoreIfAbsent returns the public half of the key stored under
 // kid, generating and storing a new pair only when there is none.
 //
@@ -112,6 +110,13 @@ func decorateEncryptionKey(key jwk.Key, kid string) error {
 	return key.Set(jwk.KeyIDKey, kid)
 }
 
+// GenerateAndStore generates a new ephemeral encryption key pair, stores the
+// private key in the cache, and returns both private and public JWKs. The key
+// uses ECDH P-256.
+//
+// Callers producing a request object should prefer
+// GenerateAndStoreIfAbsent, which does not replace a key the session is
+// already advertising.
 func (e *EphemeralEncryptionKeyCache) GenerateAndStore(kid string) (privateKey jwk.Key, publicKey jwk.Key, err error) {
 	// Generate ECDH P-256 key pair
 	privKey, err := ecdh.P256().GenerateKey(rand.Reader)

--- a/pkg/openid4vp/example_combined_binding_test.go
+++ b/pkg/openid4vp/example_combined_binding_test.go
@@ -26,8 +26,8 @@ func Example_combinedPresentation_universityAdmission() {
 	//   3. Enforce binding — reject if not established
 	verifier := &openid4vp.CombinedBindingVerifier{
 		Config: openid4vp.CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      openid4vp.BindingEnforcementEnforce,
+			Enabled:           true,
+			Enforcement:       openid4vp.BindingEnforcementEnforce,
 			KeyBindingEnabled: true,
 			BindingAttributes: []openid4vp.BindingAttributeConfig{
 				{Paths: []string{"family_name", "birth_date"}}, // compound: both must match
@@ -54,9 +54,9 @@ func Example_combinedPresentation_universityAdmission() {
 			Scope:               "pid",
 			HolderKeyThumbprint: thumbprint,
 			Claims: map[string]any{
-				"given_name": "Anna",
+				"given_name":  "Anna",
 				"family_name": "Lindqvist",
-				"birth_date": "1998-03-15",
+				"birth_date":  "1998-03-15",
 				"nationality": "SE",
 				"sub":         "urn:eudi:pid:se:199803150123",
 			},
@@ -65,10 +65,10 @@ func Example_combinedPresentation_universityAdmission() {
 			Scope:               "diploma",
 			HolderKeyThumbprint: thumbprint, // same key → same WSCD → high confidence
 			Claims: map[string]any{
-				"given_name":       "Anna",
-				"family_name":      "Lindqvist",
-				"birth_date":       "1998-03-15",
-				"degree":           "MSc Computer Science",
+				"given_name":        "Anna",
+				"family_name":       "Lindqvist",
+				"birth_date":        "1998-03-15",
+				"degree":            "MSc Computer Science",
 				"issuing_authority": "Uppsala University",
 			},
 		},
@@ -100,8 +100,8 @@ func Example_combinedPresentation_universityAdmission() {
 func Example_combinedPresentation_differentHolderKeys() {
 	verifier := &openid4vp.CombinedBindingVerifier{
 		Config: openid4vp.CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      openid4vp.BindingEnforcementEnforce,
+			Enabled:           true,
+			Enforcement:       openid4vp.BindingEnforcementEnforce,
 			KeyBindingEnabled: true,
 		},
 	}
@@ -140,8 +140,8 @@ func Example_combinedPresentation_differentHolderKeys() {
 func Example_combinedPresentation_warnMode() {
 	verifier := &openid4vp.CombinedBindingVerifier{
 		Config: openid4vp.CombinedPresentationConfig{
-			Enabled:          true,
-			Enforcement:      openid4vp.BindingEnforcementWarn,
+			Enabled:           true,
+			Enforcement:       openid4vp.BindingEnforcementWarn,
 			KeyBindingEnabled: true,
 			BindingAttributes: []openid4vp.BindingAttributeConfig{
 				{Paths: []string{"sub"}},


### PR DESCRIPTION
An external wallet rejected our DC API / openid4vp requests with two errors. Both reproduced, and a third related defect turned up on the way.

```
client_metadata must include a valid encrypted_response_enc_values_supported as an array of strings.
each JWK in client_metadata.jwks.keys must include kty, crv, x, y and alg.
```

## 1. The ephemeral JWK was missing `alg`

Dumped what we actually emit rather than reasoning about it:

```json
{"crv":"P-256","kid":"kid-1","kty":"EC","use":"enc","x":"…","y":"…"}
```

`kty`, `crv`, `x`, `y` are all present — `alg` is the one member of the five the wallet lists that was absent. `encryption_key_cache.go` set `use` and `kid` and stopped there. It now also sets `alg: "ECDH-ES"`, naming the key-agreement algorithm the wallet should use with the key.

## 2. `encrypted_response_enc_values_supported` was never populated

The field exists on `ClientMetadata` with the correct JSON tag, and **nothing in the codebase ever assigned it**. What went on the wire was the draft-era JARM field:

```go
AuthorizationEncryptedResponseENC: "A256GCM",   // single string
```

OpenID4VP 1.0 renamed `authorization_encrypted_response_enc` to `encrypted_response_enc_values_supported` and changed it from a string to an **array**. So this was version drift, not a missing value — a 1.0 wallet saw nothing it recognised.

**Both spellings are now sent.** The new one so 1.0 wallets accept the request; the old one so draft-era wallets keep working. Happy to drop the legacy pair if you'd rather commit fully to 1.0 — that is a wallet-compatibility call, so I did not make it unilaterally.

## 3. The DC API path advertised no key at all

Worse than the reported case, and it would have surfaced next. `CreateRequestObject` built `client_metadata` with **only** `vp_formats_supported`, while `response_mode` defaults to `dc_api.jwt` — which obliges the wallet to encrypt. No key, no encryption parameters.

It now mints an ephemeral key whenever the response mode requires encryption. `VerificationDirectPost` already resolves the private half by the `kid` in the JWE header, so the halves meet without new plumbing — there is a test asserting exactly that, since advertising a key we cannot decrypt with would be a worse bug than the one being fixed.

Matching on the `.jwt` suffix rather than enumerating `dc_api.jwt` and `direct_post.jwt` keeps a future encrypted mode from silently falling through to the unencrypted branch.

## Why no test caught any of this

`CreateTestClientWithMock` never populated the `openid4vp` client that production wires in `New()`. Every test exercising this path ran with a nil key cache. Fixed in the helper, which is also why the first run of the new code panicked rather than failing — a missing cache was a nil dereference, and now returns a named error instead.

## Verification

- The JWK dump above, before and after.
- 5 new tests: every required JWK member present and non-empty; the array wire shape with both spellings; the encrypted path carrying a key whose private half is retrievable by the advertised `kid`; and the unencrypted path minting no key at all.
- `go build ./...`, `make test-pkg`, and `go test ./internal/verifier/... ./internal/apigw/...` all green.