### PR TITLE
issuer: fail when a JWK member cannot survive the proto conversion

### DIFF
--- a/internal/issuer/apiv1/jwk.go
+++ b/internal/issuer/apiv1/jwk.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
+	"github.com/SUNET/vc/internal/gen/issuer/apiv1_issuer"
 	"github.com/go-jose/go-jose/v4"
 )
 
@@ -41,5 +44,58 @@ func (c *Client) createJWK(ctx context.Context) error {
 		return fmt.Errorf("failed to unmarshal JWK into proto: %w", err)
 	}
 
+	// The step above is lossy, and silently so - see checkNoJWKMembersDropped.
+	if err := checkNoJWKMembersDropped(jwkBytes, c.jwkProto); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// checkNoJWKMembersDropped fails when the proto could not carry every member
+// go-jose produced.
+//
+// The proto is a hand-maintained mirror of a JWK, and the conversion into it
+// is encoding/json, which discards members the target has no field for
+// without any error. So a key type whose members the proto does not model
+// serves a JWK that is well-formed JSON, correct as far as it goes, and
+// missing the parts that make it usable.
+//
+// That is not hypothetical: RSA keys were served as {"kid":..,"kty":"RSA"}
+// for months because the proto had no n or e (SUNET/vc#639, fixed by adding
+// the fields in #403). EC keys were unaffected and hid it, and nothing
+// failed - the endpoint kept answering 200 with a key nobody could verify
+// against. Publishing a signing key is exactly the wrong place to be
+// quietly approximate, so a drop is a startup error here rather than a
+// surprise for whoever consumes /jwks.
+func checkNoJWKMembersDropped(jwkBytes []byte, proto *apiv1_issuer.Jwk) error {
+	var produced map[string]json.RawMessage
+	if err := json.Unmarshal(jwkBytes, &produced); err != nil {
+		return fmt.Errorf("failed to inspect marshalled JWK: %w", err)
+	}
+
+	roundTripped, err := json.Marshal(proto)
+	if err != nil {
+		return fmt.Errorf("failed to re-marshal JWK proto: %w", err)
+	}
+	var carried map[string]json.RawMessage
+	if err := json.Unmarshal(roundTripped, &carried); err != nil {
+		return fmt.Errorf("failed to inspect JWK proto: %w", err)
+	}
+
+	dropped := make([]string, 0, len(produced))
+	for member := range produced {
+		if _, ok := carried[member]; !ok {
+			dropped = append(dropped, member)
+		}
+	}
+	if len(dropped) == 0 {
+		return nil
+	}
+	sort.Strings(dropped)
+
+	return fmt.Errorf(
+		"JWK member(s) %s cannot be represented by the jwk proto message and would be dropped from /jwks: add them to proto/v1-issuer.proto's jwk message (kty=%q)",
+		strings.Join(dropped, ", "), proto.GetKty(),
+	)
 }

--- a/internal/issuer/apiv1/jwk_test.go
+++ b/internal/issuer/apiv1/jwk_test.go
@@ -1,11 +1,14 @@
 package apiv1
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/SUNET/vc/internal/gen/issuer/apiv1_issuer"
 	"github.com/SUNET/vc/pkg/logger"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateJWK(t *testing.T) {
@@ -63,4 +66,85 @@ func TestCreateJWK_KidMatchesSigner(t *testing.T) {
 	// The JWK kid must match signer.KeyID(), not the config value
 	expectedKid := client.signer.KeyID()
 	assert.Equal(t, expectedKid, client.jwkProto.Kid)
+}
+
+// TestCheckNoJWKMembersDropped covers the guard directly, including the
+// shape SUNET/vc#639 reported: an RSA key served as kid+kty only, because
+// the proto had no n or e to unmarshal them into.
+func TestCheckNoJWKMembersDropped(t *testing.T) {
+	t.Run("a fully modelled EC key passes", func(t *testing.T) {
+		src := []byte(`{"kty":"EC","kid":"k","crv":"P-256","x":"AA","y":"BB","alg":"ES256","use":"sig"}`)
+		proto := &apiv1_issuer.Jwk{}
+		require.NoError(t, json.Unmarshal(src, proto))
+		assert.NoError(t, checkNoJWKMembersDropped(src, proto))
+	})
+
+	t.Run("a fully modelled RSA key passes", func(t *testing.T) {
+		src := []byte(`{"kty":"RSA","kid":"k","n":"AQAB","e":"AQAB","alg":"RS256","use":"sig"}`)
+		proto := &apiv1_issuer.Jwk{}
+		require.NoError(t, json.Unmarshal(src, proto))
+		assert.NoError(t, checkNoJWKMembersDropped(src, proto))
+	})
+
+	// The regression itself: n and e have nowhere to go, so the served key
+	// is kid+kty and verifies nothing. Simulated by unmarshalling into a
+	// proto that never sees them.
+	t.Run("dropped RSA members are reported", func(t *testing.T) {
+		src := []byte(`{"kty":"RSA","kid":"k","n":"AQAB","e":"AQAB"}`)
+		proto := &apiv1_issuer.Jwk{Kty: "RSA", Kid: "k"} // as if n/e were unmodelled
+
+		err := checkNoJWKMembersDropped(src, proto)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "e, n", "both dropped members should be named, sorted")
+		assert.Contains(t, err.Error(), "proto/v1-issuer.proto", "the error should say where to fix it")
+		assert.Contains(t, err.Error(), `kty="RSA"`, "the key type makes the report actionable")
+	})
+
+	t.Run("an unmodelled member of any kind is reported", func(t *testing.T) {
+		// x5c is a legitimate JWK member the proto does not model; the point
+		// is that the guard is not RSA-specific.
+		src := []byte(`{"kty":"EC","kid":"k","crv":"P-256","x":"AA","y":"BB","x5c":["MII"]}`)
+		proto := &apiv1_issuer.Jwk{}
+		require.NoError(t, json.Unmarshal(src, proto))
+
+		err := checkNoJWKMembersDropped(src, proto)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "x5c")
+	})
+}
+
+// TestCreateJWKServesCompleteKey is the end-to-end assertion the issue was
+// really about: whatever the key type, /jwks must carry every member needed
+// to verify a signature with it. The apigw endpoint is a pass-through of
+// this exact proto (JWKSResponse is an alias for it), so asserting here
+// covers what a caller of /jwks receives.
+func TestCreateJWKServesCompleteKey(t *testing.T) {
+	for _, tc := range []struct {
+		keyType  string
+		wantKty  string
+		required []string
+	}{
+		{keyType: "ecdsa", wantKty: "EC", required: []string{"crv", "x", "y"}},
+		{keyType: "rsa", wantKty: "RSA", required: []string{"n", "e"}},
+	} {
+		t.Run(tc.keyType, func(t *testing.T) {
+			ctx := t.Context()
+			client := mockNewClient(ctx, t, tc.keyType, logger.NewSimple("testing_apiv1"))
+			require.NoError(t, client.createJWK(ctx))
+
+			served, err := json.Marshal(client.jwkProto)
+			require.NoError(t, err)
+			var members map[string]any
+			require.NoError(t, json.Unmarshal(served, &members))
+
+			assert.Equal(t, tc.wantKty, members["kty"])
+			assert.NotEmpty(t, members["kid"])
+			assert.Equal(t, "sig", members["use"])
+			assert.NotEmpty(t, members["alg"], "alg is needed to pick a verification algorithm")
+			for _, m := range tc.required {
+				assert.NotEmpty(t, members[m], "%s key must carry %q", tc.wantKty, m)
+			}
+			assert.NotContains(t, members, "d", "no private key material on /jwks")
+		})
+	}
 }


### PR DESCRIPTION
Analysis of #639, plus a guard so the same class of bug cannot recur silently.

## #639 is already fixed

The reported output — `{"keys":[{"kid":"issuer.example.com","kty":"RSA"}]}` — is what you get when the `jwk` proto message has no `n`/`e`/`alg`/`use` fields: `json.Unmarshal` drops them and the two fields that *are* modelled (`kid`, `kty`) survive.

**#403 added exactly those four fields** on 2026-05-21 (`d4370f3a`). Bisecting the tags:

| | |
|---|---|
| affected | up to and including **v0.5.8** |
| first release with the fix | **v0.5.9** |

So this is a version issue, not a live defect — the reporter's RSA deployment predates v0.5.9. Corroborated by their own two samples: the EC one shows `alg` and `use`, which also only exist post-#403, so that deployment is newer than the RSA one.

Verified on current `main` that both key types serve complete keys, and that the apigw path is a straight pass-through (`JWKSResponse` is a type alias for the same proto, so no second place to lose fields).

## Why this PR exists anyway

The bug was invisible for months, and the reason is structural rather than a typo. `createJWK` builds the JWK with go-jose — correct for every key type — and then pours it into a **hand-maintained proto mirror** using `encoding/json`, which silently discards any member the target has no field for. There was no error, no log line, and a `200` response the whole time. EC keys happened to be fully modelled, so nothing local ever failed; it took a report from another organisation.

`checkNoJWKMembersDropped` compares what go-jose produced against what the proto round-trips back, and fails startup on any difference — naming the dropped members and the file to add them to. Publishing a signing key is the wrong place to be quietly approximate.

**No behaviour change for a current build.** Every key type in use today is fully modelled, so the guard is inert until someone adds a key type, or go-jose adds a member, that the proto does not cover.

## Tests

- `checkNoJWKMembersDropped` directly, including the exact #639 shape (`n`/`e` unmodelled → both named in the error, sorted)
- a non-RSA case (`x5c`) so it is clear the guard is not RSA-specific
- `TestCreateJWKServesCompleteKey`: end-to-end, both key types, asserting a served key carries `kty`/`kid`/`use`/`alg` plus its type-specific members and no `d`

`go build ./...`, `go vet`, and `go test ./internal/issuer/... ./pkg/...` all clean.

Closes #639