### PR TITLE
Update worker GOBUILD_IMAGE to version 1.27.1

### DIFF
--- a/dockerfiles/worker
+++ b/dockerfiles/worker
@@ -5,7 +5,7 @@
 # When overriding, the install-tools/clean-apt-cache steps are redundant but
 # harmless (make targets are idempotent). For a faster local build, use the
 # pre-built image directly as the builder stage via multi-stage FROM.
-ARG GOBUILD_IMAGE=golang:1.26.5
+ARG GOBUILD_IMAGE=golang:1.27.1
 FROM ${GOBUILD_IMAGE} AS gobuild
 WORKDIR /go/src/app
 COPY Makefile .


### PR DESCRIPTION
`make docker-build` fails with `go: go.mod requires go >= 1.27 (running go 1.26.5; GOTOOLCHAIN=local)` without this change.